### PR TITLE
ci: disable RSPM for macOS to fix arm64 binary availability

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -36,7 +36,7 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
-          use-public-rspm: true
+          use-public-rspm: ${{ runner.os != 'macOS' }}
 
       # cache-version: increment to invalidate stale package caches when
       # CRAN binary URLs change (rare, ~1-2x per year)


### PR DESCRIPTION
RSPM doesn't provide macOS binaries. This allows macOS to use CRAN directly and compile from source when binaries aren't available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)