### PR TITLE
ci: switch from deprecated macos-13 to macos-15-intel

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macos-13,       r: 'release'}  # Intel, better binary availability
+          - {os: macos-15-intel, r: 'release'}  # Intel, better binary availability
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,  r: 'release'}
           - {os: ubuntu-latest,  r: 'oldrel-1'}


### PR DESCRIPTION
macos-13 is being deprecated per actions/runner-images#13046

🤖 Generated with [Claude Code](https://claude.com/claude-code)