### PR TITLE
ci: add devcontainer and copilot-setup-steps configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,41 @@
+{
+  "name": "r-maidr",
+  "image": "ghcr.io/rocker-org/devcontainer/r-ver:4",
+
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/rocker-org/devcontainer-features/r-packages:1": {
+      "packages": "devtools,testthat,lintr,styler,roxygen2,covr,rcmdcheck,knitr,rmarkdown,pkgdown,goodpractice,cyclocomp,patchwork,remotes",
+      "installSystemRequirements": true
+    },
+    "ghcr.io/rocker-org/devcontainer-features/r-dependent-packages:latest": {},
+    "ghcr.io/rocker-org/devcontainer-features/r-history:1": {},
+    "ghcr.io/rocker-org/devcontainer-features/pandoc:latest": {}
+  },
+
+  "containerEnv": {
+    "R_KEEP_PKG_SOURCE": "yes",
+    "NOT_CRAN": "true"
+  },
+
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "r.rterm.linux": "/usr/local/bin/radian",
+        "r.bracketedPaste": true,
+        "r.plot.useHttpgd": true
+      },
+      "extensions": [
+        "REditorSupport.r",
+        "RDebugger.r-debugger",
+        "github.copilot",
+        "github.copilot-chat",
+        "github.vscode-github-actions",
+        "eamodio.gitlens",
+        "quarto.quarto"
+      ]
+    }
+  },
+
+  "postCreateCommand": "R -e 'devtools::install_deps(dependencies = TRUE)'"
+}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,33 @@
+name: "Copilot Setup Steps"
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Pandoc
+        uses: r-lib/actions/setup-pandoc@v2
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - name: Install R dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck, any::lintr, any::styler, any::devtools, any::testthat, any::covr
+          needs: check


### PR DESCRIPTION
## Summary

- Add `.devcontainer/devcontainer.json` to provide a reproducible R development environment using the Rocker R 4 devcontainer image, with pre-installed packages (devtools, testthat, lintr, styler, roxygen2, covr, rcmdcheck, knitr, rmarkdown, pkgdown, etc.), VS Code extensions (R support, Copilot, GitLens, Quarto), and automatic dependency installation on container creation.
- Add `.github/workflows/copilot-setup-steps.yml` to configure GitHub Copilot coding agent with the correct R toolchain (R, Pandoc, and all package dependencies including rcmdcheck, lintr, styler, devtools, testthat, and covr), so Copilot can build, test, and lint the package when working on issues.

## Why

These configurations enable:
1. **Devcontainer**: Contributors can spin up a fully-configured R development environment in GitHub Codespaces or VS Code Dev Containers with zero manual setup.
2. **Copilot Setup Steps**: GitHub Copilot coding agent gets the R environment it needs to understand, build, and test the package when autonomously working on assigned issues.

## Test plan

- [ ] Verify the devcontainer builds successfully in GitHub Codespaces or locally via VS Code Dev Containers
- [ ] Verify `copilot-setup-steps` workflow runs successfully (triggered on push/PR to its own path, or via workflow_dispatch)
- [ ] Confirm Copilot coding agent can be assigned an issue and successfully sets up the environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)