### PR TITLE
docs: add Google Analytics, MS Clarity, and cookie consent

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -3,6 +3,29 @@ url: https://r.maidr.ai/
 template:
   bootstrap: 5
   bootswatch: flatly
+  includes:
+    in_header: |
+      <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orestbida/cookieconsent@3.1.0/dist/cookieconsent.css">
+      <script defer src="https://cdn.jsdelivr.net/gh/orestbida/cookieconsent@3.1.0/dist/cookieconsent.umd.js"></script>
+      <script type="text/plain" data-category="analytics">
+        (function(){
+          var s=document.createElement('script');
+          s.async=true;
+          s.src='https://www.googletagmanager.com/gtag/js?id=G-0Q5XSD4Q3P';
+          document.head.appendChild(s);
+          window.dataLayer=window.dataLayer||[];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js',new Date());
+          gtag('config','G-0Q5XSD4Q3P');
+        })();
+      </script>
+      <script type="text/plain" data-category="analytics">
+        (function(c,l,a,r,i,t,y){
+          c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+          t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+          y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+        })(window, document, "clarity", "script", "vwqzk7wq0c");
+      </script>
 
 navbar:
   structure:

--- a/pkgdown/extra.js
+++ b/pkgdown/extra.js
@@ -1,3 +1,60 @@
+// Cookie consent configuration (orestbida/cookieconsent v3)
+// Gates GA4 and MS Clarity under the "analytics" category.
+window.addEventListener('DOMContentLoaded', function () {
+  if (typeof CookieConsent !== 'undefined') {
+    CookieConsent.run({
+      guiOptions: {
+        consentModal: {
+          layout: 'box inline',
+          position: 'bottom right',
+        },
+      },
+      categories: {
+        necessary: {
+          enabled: true,
+          readOnly: true,
+        },
+        analytics: {},
+      },
+      language: {
+        default: 'en',
+        translations: {
+          en: {
+            consentModal: {
+              title: 'We use cookies',
+              description:
+                'This site uses cookies to help us understand how it is used. You can choose to accept or decline analytics cookies.',
+              acceptAllBtn: 'Accept all',
+              acceptNecessaryBtn: 'Reject all',
+              showPreferencesBtn: 'Manage preferences',
+            },
+            preferencesModal: {
+              title: 'Cookie preferences',
+              acceptAllBtn: 'Accept all',
+              acceptNecessaryBtn: 'Reject all',
+              savePreferencesBtn: 'Save preferences',
+              sections: [
+                {
+                  title: 'Necessary cookies',
+                  description:
+                    'These cookies are essential for the site to function properly.',
+                  linkedCategory: 'necessary',
+                },
+                {
+                  title: 'Analytics cookies',
+                  description:
+                    'These cookies help us understand how visitors interact with the site via Google Analytics and Microsoft Clarity.',
+                  linkedCategory: 'analytics',
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+  }
+});
+
 // Accessibility fix: improve keyboard navigation per WCAG 2.4.3 (Focus Order)
 // - Remove auto-linked function names from Tab order inside code blocks
 // - Ensure all MAIDR plot iframes are keyboard-focusable


### PR DESCRIPTION
## Summary
- Add GA4 tracking (G-0Q5XSD4Q3P) and MS Clarity (vwqzk7wq0c) to the pkgdown site
- Both tracking scripts are gated behind cookie consent using [orestbida/cookieconsent v3](https://github.com/orestbida/cookieconsent)
- Scripts only execute after the user explicitly accepts analytics cookies (GDPR-compliant)
- GA4 and Clarity are already linked in the Clarity dashboard for unified analytics

## Implementation
- **`_pkgdown.yml`**: Added cookieconsent CSS/JS from CDN + GA4 and Clarity scripts with `type="text/plain" data-category="analytics"`
- **`pkgdown/extra.js`**: Added CookieConsent.run() configuration with necessary + analytics categories

## Test plan
- [ ] Build pkgdown site locally with `pkgdown::build_site()`
- [ ] Verify cookie consent banner appears on page load
- [ ] Verify GA4/Clarity scripts are NOT loaded before accepting cookies
- [ ] Accept cookies and verify GA4/Clarity scripts load
- [ ] Reject cookies and verify no tracking scripts execute
- [ ] Confirm data appears in GA4 and Clarity dashboards after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)