### PR TITLE
docs: address analytics PR review feedback

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -5,8 +5,8 @@ template:
   bootswatch: flatly
   includes:
     in_header: |
-      <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orestbida/cookieconsent@3.1.0/dist/cookieconsent.css">
-      <script defer src="https://cdn.jsdelivr.net/gh/orestbida/cookieconsent@3.1.0/dist/cookieconsent.umd.js"></script>
+      <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orestbida/cookieconsent@3.1.0/dist/cookieconsent.css" integrity="sha384-9KcNFt4axT+TNOVPHpwGHOm4Kv0UcMjdVya1kl+EPBQG+Vmqtz28cnx0f5PZYcnF" crossorigin="anonymous">
+      <script defer src="https://cdn.jsdelivr.net/gh/orestbida/cookieconsent@3.1.0/dist/cookieconsent.umd.js" integrity="sha384-xOY5eqzqHsjfa8YYAomICWjVJ3g9q1C1tWgRF09ut5PzRJjLFSpKH7gCsIN3hKcA" crossorigin="anonymous"></script>
       <script type="text/plain" data-category="analytics">
         (function(){
           var s=document.createElement('script');
@@ -15,6 +15,7 @@ template:
           document.head.appendChild(s);
           window.dataLayer=window.dataLayer||[];
           function gtag(){dataLayer.push(arguments);}
+          window.gtag=gtag;
           gtag('js',new Date());
           gtag('config','G-0Q5XSD4Q3P');
         })();

--- a/pkgdown/extra.js
+++ b/pkgdown/extra.js
@@ -25,13 +25,13 @@ window.addEventListener('DOMContentLoaded', function () {
               description:
                 'This site uses cookies to help us understand how it is used. You can choose to accept or decline analytics cookies.',
               acceptAllBtn: 'Accept all',
-              acceptNecessaryBtn: 'Reject all',
+              acceptNecessaryBtn: 'Accept necessary only',
               showPreferencesBtn: 'Manage preferences',
             },
             preferencesModal: {
               title: 'Cookie preferences',
               acceptAllBtn: 'Accept all',
-              acceptNecessaryBtn: 'Reject all',
+              acceptNecessaryBtn: 'Accept necessary only',
               savePreferencesBtn: 'Save preferences',
               sections: [
                 {


### PR DESCRIPTION
## Summary
Follow-up to #36 addressing bot review feedback:

- **Add SRI hashes** — cookieconsent CDN resources now have `integrity` and `crossorigin` attributes to mitigate supply-chain risk
- **Expose `window.gtag`** — GA4 `gtag` function is now attached to `window` so future event tracking calls (e.g., `gtag('event', ...)`) work after consent
- **Clearer button label** — "Reject all" renamed to "Accept necessary only" for accurate GDPR compliance language (necessary cookies are still kept)

## Test plan
- [ ] Build pkgdown site with `pkgdown::build_site()`
- [ ] Verify cookie consent banner shows updated button text
- [ ] Verify `window.gtag` is accessible after accepting cookies
- [ ] Verify SRI doesn't break CDN loading (CSS/JS still load correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)