### PR TITLE
docs: add SEO and GEO improvements

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,10 +1,40 @@
 url: https://r.maidr.ai/
 
+home:
+  title: "maidr - Accessible Data Visualizations for R"
+  description: >
+    Make ggplot2 and Base R plots accessible with keyboard navigation,
+    screen reader support, and sonification. The maidr R package converts
+    data visualizations into interactive, multimodal formats for blind
+    and low-vision users.
+
 template:
   bootstrap: 5
   bootswatch: flatly
+  opengraph:
+    twitter:
+      creator: "@jooyoungseo"
+      card: summary_large_image
   includes:
     in_header: |
+      <script>document.documentElement.setAttribute('lang', 'en');</script>
+      <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareSourceCode",
+        "name": "maidr",
+        "description": "R package for multimodal accessible data visualization with keyboard navigation, screen reader support, and sonification",
+        "url": "https://r.maidr.ai/",
+        "codeRepository": "https://github.com/xability/r-maidr",
+        "programmingLanguage": "R",
+        "license": "https://www.gnu.org/licenses/gpl-3.0.html",
+        "author": {
+          "@type": "Organization",
+          "name": "(x)Ability Design Lab",
+          "url": "https://xability.github.io/"
+        }
+      }
+      </script>
       <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orestbida/cookieconsent@3.1.0/dist/cookieconsent.css" integrity="sha384-9KcNFt4axT+TNOVPHpwGHOm4Kv0UcMjdVya1kl+EPBQG+Vmqtz28cnx0f5PZYcnF" crossorigin="anonymous">
       <script defer src="https://cdn.jsdelivr.net/gh/orestbida/cookieconsent@3.1.0/dist/cookieconsent.umd.js" integrity="sha384-xOY5eqzqHsjfa8YYAomICWjVJ3g9q1C1tWgRF09ut5PzRJjLFSpKH7gCsIN3hKcA" crossorigin="anonymous"></script>
       <script type="text/plain" data-category="analytics">

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,19 +1,20 @@
 url: https://r.maidr.ai/
 
 home:
-  title: "maidr - Accessible Data Visualizations for R"
-  description: >
-    Make ggplot2 and Base R plots accessible with keyboard navigation,
-    screen reader support, and sonification. The maidr R package converts
-    data visualizations into interactive, multimodal formats for blind
-    and low-vision users.
+  title: "maidr - Accessible ggplot2 & R Plots with Sonification"
+  description: >-
+    maidr makes ggplot2 and Base R plots accessible with keyboard navigation,
+    screen reader support, and sonification for blind and low-vision users.
 
 template:
   bootstrap: 5
   bootswatch: flatly
   opengraph:
+    image:
+      src: man/figures/logo.svg
+      alt: "maidr hex sticker logo - accessible data visualization for R"
     twitter:
-      creator: "@jooyoungseo"
+      creator: "@seo_jooyoung"
       card: summary_large_image
   includes:
     in_header: |
@@ -21,17 +22,74 @@ template:
       <script type="application/ld+json">
       {
         "@context": "https://schema.org",
-        "@type": "SoftwareSourceCode",
+        "@type": "SoftwareApplication",
         "name": "maidr",
-        "description": "R package for multimodal accessible data visualization with keyboard navigation, screen reader support, and sonification",
+        "alternateName": "Multimodal Access and Interactive Data Representation",
+        "description": "R package that makes ggplot2 and Base R plots accessible through keyboard navigation, screen reader support, and sonification for blind and low-vision users.",
         "url": "https://r.maidr.ai/",
         "codeRepository": "https://github.com/xability/r-maidr",
+        "downloadUrl": "https://cran.r-project.org/package=maidr",
+        "applicationCategory": "DeveloperApplication",
+        "operatingSystem": "Windows, macOS, Linux",
         "programmingLanguage": "R",
         "license": "https://www.gnu.org/licenses/gpl-3.0.html",
-        "author": {
+        "isAccessibleForFree": true,
+        "keywords": ["accessibility", "data visualization", "ggplot2", "R package", "screen reader", "sonification", "keyboard navigation", "blind", "low-vision"],
+        "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+        "sameAs": [
+          "https://github.com/xability/r-maidr",
+          "https://cran.r-project.org/package=maidr",
+          "https://maidr.ai/"
+        ],
+        "author": [
+          {
+            "@type": "Person",
+            "name": "JooYoung Seo",
+            "url": "https://jooyoungseo.github.io",
+            "jobTitle": "Assistant Professor",
+            "affiliation": {
+              "@type": "Organization",
+              "name": "School of Information Sciences, University of Illinois Urbana-Champaign"
+            },
+            "sameAs": [
+              "https://scholar.google.com/citations?user=c0x8E5YAAAAJ&hl=en",
+              "https://www.linkedin.com/in/jooyoungseo",
+              "https://github.com/jooyoungseo",
+              "https://ischool.illinois.edu/people/jooyoung-seo"
+            ]
+          },
+          {
+            "@type": "Person",
+            "name": "Niranjan Kalaiselvan",
+            "sameAs": ["https://github.com/nk46"]
+          }
+        ],
+        "publisher": {
           "@type": "Organization",
           "name": "(x)Ability Design Lab",
-          "url": "https://xability.github.io/"
+          "url": "https://xabilitylab.ischool.illinois.edu/",
+          "sameAs": [
+            "https://github.com/xability",
+            "https://xabilitylab.ischool.illinois.edu/"
+          ]
+        },
+        "softwareHelp": {
+          "@type": "WebPage",
+          "url": "https://r.maidr.ai/articles/"
+        }
+      }
+      </script>
+      <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "maidr R Package Documentation",
+        "url": "https://r.maidr.ai/",
+        "inLanguage": "en",
+        "publisher": {
+          "@type": "Organization",
+          "name": "(x)Ability Design Lab",
+          "url": "https://xabilitylab.ischool.illinois.edu/"
         }
       }
       </script>

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -11,11 +11,11 @@ template:
   bootswatch: flatly
   opengraph:
     image:
-      src: man/figures/logo.svg
+      src: https://raw.githubusercontent.com/xability/maidr/refs/heads/main/media/logo.jpg
       alt: "maidr hex sticker logo - accessible data visualization for R"
     twitter:
       creator: "@seo_jooyoung"
-      card: summary_large_image
+      card: summary
   includes:
     in_header: |
       <script>document.documentElement.setAttribute('lang', 'en');</script>

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,5 @@
 url: https://r.maidr.ai/
+lang: en
 
 home:
   title: "maidr - Accessible ggplot2 & R Plots with Sonification"
@@ -18,7 +19,6 @@ template:
       card: summary
   includes:
     in_header: |
-      <script>document.documentElement.setAttribute('lang', 'en');</script>
       <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/pkgdown/extra/llms.txt
+++ b/pkgdown/extra/llms.txt
@@ -1,0 +1,16 @@
+# maidr
+
+> maidr (Multimodal Access and Interactive Data Representation) is an R package that makes ggplot2 and Base R data visualizations accessible to users with visual impairments through keyboard navigation, screen reader support, and sonification.
+
+maidr converts standard R plots into interactive HTML/SVG formats. It supports bar charts, histograms, scatter plots, line plots, box plots, violin plots, heatmaps, density curves, faceted plots, multi-panel layouts, and multi-layered combinations. It integrates with RMarkdown and Shiny applications.
+
+## Documentation
+- [Getting Started](https://r.maidr.ai/articles/getting-started.html): Installation and basic workflow
+- [Examples](https://r.maidr.ai/articles/examples.html): All supported plot types with code
+- [Shiny Integration](https://r.maidr.ai/articles/shiny-integration.html): Using maidr in Shiny apps
+- [Function Reference](https://r.maidr.ai/reference/index.html): Complete API documentation
+
+## Optional
+- [News / Changelog](https://r.maidr.ai/news/index.html): Version history
+- [GitHub](https://github.com/xability/r-maidr): Source code
+- [CRAN](https://cran.r-project.org/package=maidr): CRAN package page

--- a/pkgdown/extra/llms.txt
+++ b/pkgdown/extra/llms.txt
@@ -1,16 +1,18 @@
-# maidr
+# maidr (R package)
 
-> maidr (Multimodal Access and Interactive Data Representation) is an R package that makes ggplot2 and Base R data visualizations accessible to users with visual impairments through keyboard navigation, screen reader support, and sonification.
+> maidr is an R package that makes ggplot2 and Base R data visualizations accessible to blind and low-vision users through keyboard navigation, screen reader support, and sonification. Developed by the (x)Ability Design Lab at the University of Illinois Urbana-Champaign.
 
-maidr converts standard R plots into interactive HTML/SVG formats. It supports bar charts, histograms, scatter plots, line plots, box plots, violin plots, heatmaps, density curves, faceted plots, multi-panel layouts, and multi-layered combinations. It integrates with RMarkdown and Shiny applications.
+maidr converts standard R plots into interactive HTML/SVG formats with audio sonification, braille output, and text descriptions. It supports bar charts, histograms, scatter plots, line plots, box plots, violin plots, heatmaps, density curves, faceted plots, multi-panel layouts, and multi-layered combinations. Integrates with RMarkdown and Shiny applications.
 
-## Documentation
+## Docs
 - [Getting Started](https://r.maidr.ai/articles/getting-started.html): Installation and basic workflow
 - [Examples](https://r.maidr.ai/articles/examples.html): All supported plot types with code
 - [Shiny Integration](https://r.maidr.ai/articles/shiny-integration.html): Using maidr in Shiny apps
 - [Function Reference](https://r.maidr.ai/reference/index.html): Complete API documentation
 
 ## Optional
+- [CRAN](https://cran.r-project.org/package=maidr): Install with `install.packages("maidr")`
+- [GitHub](https://github.com/xability/r-maidr): Source code and issue tracker
 - [News / Changelog](https://r.maidr.ai/news/index.html): Version history
-- [GitHub](https://github.com/xability/r-maidr): Source code
-- [CRAN](https://cran.r-project.org/package=maidr): CRAN package page
+- [maidr JS Engine](https://maidr.ai/): The core JavaScript library that powers r-maidr
+- [maidr for Python](https://py.maidr.ai/): The Python package counterpart

--- a/pkgdown/extra/robots.txt
+++ b/pkgdown/extra/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://r.maidr.ai/sitemap.xml

--- a/pkgdown/favicon/site.webmanifest
+++ b/pkgdown/favicon/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "",
-  "short_name": "",
+  "name": "maidr for R",
+  "short_name": "maidr",
   "icons": [
     {
       "src": "/web-app-manifest-192x192.png",


### PR DESCRIPTION
## Summary
Adds foundational SEO and Generative Engine Optimization (GEO) support to the r-maidr pkgdown site:

- **Open Graph + Twitter Card** — enables rich link previews on social media, Slack, Discord, etc.
- **Homepage title & description** — SEO-optimized metadata via `home:` config
- **JSON-LD structured data** — `SoftwareSourceCode` schema for rich search results
- **`lang="en"` attribute** — added to HTML pages for accessibility and SEO (WCAG 3.1.1)
- **robots.txt** — explicit crawl rules pointing to sitemap
- **llms.txt** — structured summary for AI search engines (ChatGPT, Perplexity, Gemini, etc.)
- **site.webmanifest** — fixed empty name/short_name fields

## Test plan
- [ ] `pkgdown::build_site()` succeeds
- [ ] Verify OG/Twitter meta tags in rendered HTML source
- [ ] Validate JSON-LD at https://search.google.com/structured-data/testing-tool
- [ ] Verify robots.txt and llms.txt are accessible at site root after build

🤖 Generated with [Claude Code](https://claude.com/claude-code)