### PR TITLE
ci: verify MAIDR bundle against npm integrity hash, attribute to xabilitylab

### DIFF
--- a/.github/scripts/fetch-maidr-bundle.sh
+++ b/.github/scripts/fetch-maidr-bundle.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# Resolve, download, verify, and install the bundled ``maidr.js`` /
+# ``maidr.css`` assets. Shared by the scheduled refresh workflow
+# (``update-maidr-bundle.yml``) and the local maintainer tool
+# (``tools/update-maidr-assets.R``) so the download + integrity-check +
+# install logic lives in exactly one place and cannot drift between the two.
+#
+# The assets are extracted from the official npm tarball, whose contents are
+# verified against the ``dist.integrity`` (SRI) / ``dist.shasum`` hash
+# published in the npm registry metadata. This gives a real supply-chain
+# guarantee: a tampered CDN/registry response fails the hash check instead of
+# being written into the bundle (and, at CRAN submission time, shipped in the
+# package).
+#
+# On success the script installs the assets into
+# ``inst/htmlwidgets/lib/maidr-<VERSION>/``, removes any stale
+# ``maidr-*`` lib directories, and rewrites the version references in
+# ``R/html_dependencies.R`` and ``inst/htmlwidgets/maidr.yaml`` so the
+# package always points at the freshly installed bundle.
+#
+# Usage (from the package root):
+#   .github/scripts/fetch-maidr-bundle.sh [VERSION]
+#
+#   VERSION   maidr npm version to fetch. Resolves the latest published
+#             version on npm when empty or omitted.
+#
+# The resolved version is printed as the final line of stdout so callers can
+# capture it, e.g. ``VERSION=$(.github/scripts/fetch-maidr-bundle.sh)``. All
+# progress output goes to stderr to keep stdout limited to the version string.
+set -euo pipefail
+
+VERSION="${1:-}"
+
+REGISTRY="https://registry.npmjs.org/maidr"
+LIB_ROOT="inst/htmlwidgets/lib"
+R_VERSION_FILE="R/html_dependencies.R"
+YAML_FILE="inst/htmlwidgets/maidr.yaml"
+
+# Fail fast with a clear message when not run from the package root, rather
+# than half-updating whatever directory we happen to be in.
+if [ ! -f DESCRIPTION ] || [ ! -d "$LIB_ROOT" ]; then
+  echo "Run this script from the r-maidr package root" >&2
+  exit 1
+fi
+
+if [ -z "$VERSION" ]; then
+  VERSION=$(curl -sSfL "$REGISTRY/latest" | jq -r '.version')
+fi
+if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+  echo "Failed to resolve maidr.js version" >&2
+  exit 1
+fi
+
+# Validate the version shape before splicing it into any URL or file path.
+# This rejects malformed or hostile values (e.g. a caller-supplied version)
+# so they cannot build an unintended request path or escape the lib dir.
+if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([-+.][0-9A-Za-z.-]+)*$'; then
+  echo "Refusing to fetch: '$VERSION' is not a valid maidr version" >&2
+  exit 1
+fi
+
+DEST_DIR="$LIB_ROOT/maidr-$VERSION"
+echo "Fetching bundled maidr.js v${VERSION} into ${DEST_DIR}" >&2
+
+# Fetch the registry metadata for this exact version to get the tarball URL
+# and its published integrity hash.
+META=$(curl -sSfL "$REGISTRY/$VERSION")
+TARBALL=$(printf '%s' "$META" | jq -r '.dist.tarball // empty')
+INTEGRITY=$(printf '%s' "$META" | jq -r '.dist.integrity // empty')
+SHASUM=$(printf '%s' "$META" | jq -r '.dist.shasum // empty')
+if [ -z "$TARBALL" ]; then
+  echo "Failed to resolve npm tarball URL for maidr@$VERSION" >&2
+  exit 1
+fi
+
+WORK=$(mktemp -d)
+# shellcheck disable=SC2064  # expand WORK now so the trap removes this dir
+trap "rm -rf '$WORK'" EXIT
+TGZ="$WORK/maidr.tgz"
+curl -sSfL -o "$TGZ" "$TARBALL"
+
+# Verify the tarball against the registry-published hash. Prefer the SRI
+# ``integrity`` field (sha512); fall back to the legacy ``shasum`` (sha1).
+if [ -n "$INTEGRITY" ]; then
+  ALGO=${INTEGRITY%%-*}
+  EXPECTED=${INTEGRITY#*-}
+  ACTUAL=$(openssl dgst "-${ALGO}" -binary "$TGZ" | openssl base64 -A)
+  if [ "$ACTUAL" != "$EXPECTED" ]; then
+    echo "Integrity check failed for maidr@$VERSION tarball ($ALGO)" >&2
+    exit 1
+  fi
+  echo "Verified tarball ${ALGO} integrity" >&2
+elif [ -n "$SHASUM" ]; then
+  ACTUAL=$(sha1sum "$TGZ" | awk '{print $1}')
+  if [ "$ACTUAL" != "$SHASUM" ]; then
+    echo "Shasum check failed for maidr@$VERSION tarball" >&2
+    exit 1
+  fi
+  echo "Verified tarball shasum" >&2
+else
+  echo "No integrity/shasum in registry metadata for maidr@$VERSION" >&2
+  exit 1
+fi
+
+# Extract the bundled assets from the verified tarball. npm tarballs place
+# published files under ``package/``.
+tar -xzf "$TGZ" -C "$WORK" package/dist/maidr.js package/dist/maidr.css
+
+# Defense-in-depth sanity checks on the extracted payloads before touching
+# the package tree: non-empty, and not an HTML error page masquerading as
+# JS / CSS. The check is a positive match: fail when the payload *starts*
+# with an HTML marker.
+for asset in maidr.js maidr.css; do
+  test -s "$WORK/package/dist/${asset}"
+  if head -c 128 "$WORK/package/dist/${asset}" | grep -qiE "^[[:space:]]*<!DOCTYPE|^[[:space:]]*<html"; then
+    echo "${asset} looks like an HTML error page" >&2
+    exit 1
+  fi
+done
+
+# Install into the versioned lib directory and drop any stale bundles so a
+# version bump cannot leave two maidr-* dirs behind.
+mkdir -p "$DEST_DIR"
+cp "$WORK/package/dist/maidr.js" "$DEST_DIR/maidr.js"
+cp "$WORK/package/dist/maidr.css" "$DEST_DIR/maidr.css"
+for dir in "$LIB_ROOT"/maidr-*/; do
+  [ -d "$dir" ] || continue
+  if [ "${dir%/}" != "$DEST_DIR" ]; then
+    echo "Removing stale bundle dir ${dir%/}" >&2
+    rm -rf "$dir"
+  fi
+done
+
+# Point the package at the installed bundle: MAIDR_VERSION in the R source
+# and the version/src entries in the htmlwidgets dependency manifest.
+sed -i.bak -E "s/MAIDR_VERSION <- \"[^\"]*\"/MAIDR_VERSION <- \"$VERSION\"/" "$R_VERSION_FILE"
+sed -i.bak -E "s/^([[:space:]]*version:).*/\1 $VERSION/" "$YAML_FILE"
+sed -i.bak -E "s|^([[:space:]]*src:) htmlwidgets/lib/maidr-.*|\1 htmlwidgets/lib/maidr-$VERSION|" "$YAML_FILE"
+rm -f "$R_VERSION_FILE.bak" "$YAML_FILE.bak"
+
+# The rewrites above are pattern-based; verify they actually landed so a
+# drifted source file fails loudly instead of shipping a version mismatch.
+grep -qF "MAIDR_VERSION <- \"$VERSION\"" "$R_VERSION_FILE"
+grep -qF "version: $VERSION" "$YAML_FILE"
+grep -qF "src: htmlwidgets/lib/maidr-$VERSION" "$YAML_FILE"
+
+echo "$VERSION"

--- a/.github/scripts/fetch-maidr-bundle.sh
+++ b/.github/scripts/fetch-maidr-bundle.sh
@@ -92,7 +92,9 @@ if [ -n "$INTEGRITY" ]; then
   fi
   echo "Verified tarball ${ALGO} integrity" >&2
 elif [ -n "$SHASUM" ]; then
-  ACTUAL=$(sha1sum "$TGZ" | awk '{print $1}')
+  # openssl rather than sha1sum: the latter is GNU coreutils and absent on
+  # stock macOS, and openssl is already required for the SRI path above.
+  ACTUAL=$(openssl dgst -sha1 "$TGZ" | awk '{print $NF}')
   if [ "$ACTUAL" != "$SHASUM" ]; then
     echo "Shasum check failed for maidr@$VERSION tarball" >&2
     exit 1

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -35,7 +35,6 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
-          http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: ${{ runner.os != 'macOS' }}
 
       # cache-version: increment to invalidate stale package caches when

--- a/.github/workflows/update-maidr-bundle.yml
+++ b/.github/workflows/update-maidr-bundle.yml
@@ -1,11 +1,33 @@
 name: Update MAIDR Bundle
 
+# Keeps the offline-bundled ``maidr.js`` / ``maidr.css`` under
+# ``inst/htmlwidgets/lib/`` in sync with the upstream npm release and
+# commits the refresh directly to ``main``.
+#
+# Unlike py-maidr — where the routine refresh happens inside the automated
+# release workflow so the bundle ships with each release — r-maidr has no
+# release pipeline to hook into (CRAN submissions are manual), so the
+# scheduled refresh here is what keeps ``main`` current: whatever is bundled
+# on ``main`` at submission time is what ships to CRAN. The download is
+# verified against the integrity hash published in the npm registry
+# metadata (see ``.github/scripts/fetch-maidr-bundle.sh``), so a tampered
+# CDN/registry response fails the job instead of landing on ``main``.
+#
+# The commit uses the ``chore:`` prefix so a bundle refresh reads as
+# maintenance, not a feature, in the history.
+
 on:
   schedule:
-    # Run daily at 9 AM UTC
+    # Run daily at 9 AM UTC so new npm releases land on ``main`` within
+    # 24 hours. The commit step below is a no-op when the bundle is
+    # already current, so the daily cadence adds no commit noise.
     - cron: '0 9 * * *'
   workflow_dispatch:
-    # Allow manual triggering
+    inputs:
+      maidr_version:
+        description: "Explicit maidr.js version (defaults to latest on npm)"
+        required: false
+        default: ""
 
 permissions:
   contents: write
@@ -17,73 +39,31 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
-      - name: Setup R
-        uses: r-lib/actions/setup-r@v2
-        with:
-          r-version: 'release'
-
-      - name: Install R dependencies
+      - name: Resolve, download and verify bundled assets
+        id: bundle
+        env:
+          # Pass the dispatch input through the environment rather than
+          # interpolating ${{ ... }} into the script text, which would be a
+          # shell-injection surface in a job holding contents: write.
+          MAIDR_VERSION: ${{ github.event.inputs.maidr_version }}
         run: |
-          install.packages(c('jsonlite', 'rprojroot'))
-        shell: Rscript {0}
+          set -euo pipefail
+          # Resolve (or use the requested version), download, verify, and
+          # install the bundle via the shared script (also used by
+          # tools/update-maidr-assets.R for local refreshes). The script
+          # updates R/html_dependencies.R and inst/htmlwidgets/maidr.yaml
+          # to match the installed version.
+          VERSION=$(.github/scripts/fetch-maidr-bundle.sh "$MAIDR_VERSION")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Get latest MAIDR version from npm
-        id: npm-version
-        run: |
-          LATEST_VERSION=$(curl -s https://registry.npmjs.org/maidr/latest | jq -r '.version')
-          echo "version=$LATEST_VERSION" >> $GITHUB_OUTPUT
-          echo "Latest MAIDR version: $LATEST_VERSION"
-
-      - name: Get current bundled version
-        id: current-version
-        run: |
-          CURRENT_VERSION=$(grep 'MAIDR_VERSION <-' R/html_dependencies.R | sed 's/.*"\(.*\)".*/\1/')
-          echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
-          echo "Current bundled version: $CURRENT_VERSION"
-
-      - name: Check if update needed
-        id: check-update
-        run: |
-          if [ "${{ steps.npm-version.outputs.version }}" != "${{ steps.current-version.outputs.version }}" ]; then
-            echo "needs_update=true" >> $GITHUB_OUTPUT
-            echo "Update needed: ${{ steps.current-version.outputs.version }} -> ${{ steps.npm-version.outputs.version }}"
-          else
-            echo "needs_update=false" >> $GITHUB_OUTPUT
-            echo "Already up to date"
-          fi
-
-      - name: Download new MAIDR assets
-        if: steps.check-update.outputs.needs_update == 'true'
-        run: |
-          Rscript tools/update-maidr-assets.R ${{ steps.npm-version.outputs.version }}
-
-      - name: Update version in R code
-        if: steps.check-update.outputs.needs_update == 'true'
-        run: |
-          VERSION="${{ steps.npm-version.outputs.version }}"
-          OLD_VERSION="${{ steps.current-version.outputs.version }}"
-
-          # Update R/html_dependencies.R
-          sed -i 's/MAIDR_VERSION <- "[^"]*"/MAIDR_VERSION <- "'"$VERSION"'"/' R/html_dependencies.R
-          echo "Updated R/html_dependencies.R"
-
-          # Update inst/htmlwidgets/maidr.yaml
-          sed -i "s/version: .*/version: $VERSION/" inst/htmlwidgets/maidr.yaml
-          sed -i "s|src: htmlwidgets/lib/maidr-.*|src: htmlwidgets/lib/maidr-$VERSION|" inst/htmlwidgets/maidr.yaml
-          echo "Updated inst/htmlwidgets/maidr.yaml"
-
-          # Show changes
-          echo "=== Changes ==="
-          git diff --stat
-
-      - name: Commit and push changes
-        if: steps.check-update.outputs.needs_update == 'true'
+      - name: Commit updated bundle to main
+        # git-auto-commit-action is a no-op when the download produced no
+        # change, so an already-current bundle simply commits nothing.
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "chore: update MAIDR bundle to v${{ steps.npm-version.outputs.version }}"
-          commit_user_name: "github-actions[bot]"
-          commit_user_email: "github-actions[bot]@users.noreply.github.com"
+          commit_message: "chore: update MAIDR bundle to v${{ steps.bundle.outputs.version }}"
+          commit_user_name: "xabilitylab"
+          commit_user_email: "187909674+xabilitylab@users.noreply.github.com"
+          commit_author: "xabilitylab <187909674+xabilitylab@users.noreply.github.com>"
           file_pattern: "R/html_dependencies.R inst/htmlwidgets/"

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -27,8 +27,10 @@ jobs:
 
       # actionlint validates the workflow YAML and shellchecks inline `run`
       # blocks, catching the class of shell/quoting bugs this automation
-      # is prone to.
+      # is prone to. Both the installer script and the release artifact it
+      # downloads are pinned to a tagged version so the bytes fetched here
+      # are reviewable and cannot change out from under the job.
       - name: actionlint
         run: |
-          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12
           ./actionlint -color

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,34 @@
+name: workflow-lint
+
+# The bundle-refresh automation in this repo is shell embedded in YAML — a
+# class of code that has historically hidden subtle quoting/logic bugs (see
+# xability/py-maidr#286 for the same hardening). ShellCheck covers the
+# standalone scripts and actionlint validates the workflow YAML, including
+# shellchecking inline `run` blocks.
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+permissions: read-all
+
+jobs:
+  workflow-lint:
+    name: Lint workflows and shell scripts
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # shellcheck is pre-installed on the ubuntu-latest runner image.
+      - name: ShellCheck shell scripts
+        run: shellcheck .github/scripts/*.sh
+
+      # actionlint validates the workflow YAML and shellchecks inline `run`
+      # blocks, catching the class of shell/quoting bugs this automation
+      # is prone to.
+      - name: actionlint
+        run: |
+          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ./actionlint -color

--- a/tools/update-maidr-assets.R
+++ b/tools/update-maidr-assets.R
@@ -1,124 +1,50 @@
 #!/usr/bin/env Rscript
 #' Update Bundled MAIDR Assets
 #'
-#' This script downloads the latest (or specified) version of MAIDR JavaScript
-#' and CSS files from npm/CDN and updates the local bundled copies.
+#' Thin wrapper around `.github/scripts/fetch-maidr-bundle.sh`, which is the
+#' single source of truth for resolving, downloading, verifying, and
+#' installing the bundled MAIDR JavaScript and CSS files. The same script is
+#' used by the scheduled refresh workflow (`update-maidr-bundle.yml`), so the
+#' download + integrity-check logic cannot drift between CI and local use.
+#'
+#' The shell script verifies the npm tarball against the integrity hash
+#' published in the npm registry metadata, installs the assets into
+#' `inst/htmlwidgets/lib/maidr-<version>/`, removes stale bundle
+#' directories, and updates the version references in
+#' `R/html_dependencies.R` and `inst/htmlwidgets/maidr.yaml`.
+#'
+#' Requires: bash, curl, jq, openssl, tar (available on macOS/Linux and on
+#' Windows via Git Bash).
 #'
 #' Usage:
 #'   Rscript tools/update-maidr-assets.R           # Uses latest version
 #'   Rscript tools/update-maidr-assets.R 3.50.0    # Uses specific version
 #'
 #' After running this script, you must:
-#' 1. Update MAIDR_VERSION in R/html_dependencies.R
-#' 2. Update version in inst/htmlwidgets/maidr.yaml
-#' 3. Run R CMD check to verify everything works
-#' 4. Commit the changes
+#' 1. Run R CMD check to verify everything works
+#' 2. Commit the changes
 
-# Parse command line arguments
 args <- commandArgs(trailingOnly = TRUE)
 
-# Get version to download
-get_latest_version <- function() {
-  url <- "https://registry.npmjs.org/maidr/latest"
-  tryCatch({
-    response <- jsonlite::fromJSON(url)
-    response$version
-
-  }, error = function(e) {
-    stop("Failed to fetch latest version from npm: ", e$message)
-  })
-}
-
-version <- if (length(args) > 0) args[1] else get_latest_version()
-cat("Updating MAIDR assets to version:", version, "\n\n")
-
-# Define paths
 pkg_root <- rprojroot::find_package_root_file()
-lib_dir <- file.path(pkg_root, "inst", "htmlwidgets", "lib", paste0("maidr-", version))
-old_lib_dirs <- list.dirs(
-  file.path(pkg_root, "inst", "htmlwidgets", "lib"),
-  full.names = TRUE,
-  recursive = FALSE
-)
-old_lib_dirs <- old_lib_dirs[grepl("^maidr-", basename(old_lib_dirs))]
-
-# CDN base URL
-cdn_base <- sprintf("https://cdn.jsdelivr.net/npm/maidr@%s/dist", version)
-
-# Files to download
-files <- c(
-  "maidr.js",
-  "maidr.css"
-)
-
-# Create new directory
-if (!dir.exists(lib_dir)) {
-  dir.create(lib_dir, recursive = TRUE)
-  cat("Created directory:", lib_dir, "\n")
+script <- file.path(pkg_root, ".github", "scripts", "fetch-maidr-bundle.sh")
+if (!file.exists(script)) {
+  stop("Shared fetch script not found: ", script)
 }
 
-# Download files
-cat("\nDownloading files from CDN...\n")
-for (file in files) {
-  url <- paste0(cdn_base, "/", file)
-  dest <- file.path(lib_dir, file)
-
-  cat("  Downloading", file, "...")
-  tryCatch({
-    download.file(url, dest, mode = "wb", quiet = TRUE)
-    file_size <- file.info(dest)$size
-    cat(" OK (", format(file_size, big.mark = ","), " bytes)\n", sep = "")
-  }, error = function(e) {
-    cat(" FAILED\n")
-    warning("Failed to download ", file, ": ", e$message)
-  })
+# The script must run from the package root and prints the installed version
+# as its final stdout line; everything else goes to stderr.
+old_wd <- setwd(pkg_root)
+on.exit(setwd(old_wd), add = TRUE)
+status <- system2("bash", c(shQuote(script), shQuote(args)))
+if (status != 0) {
+  stop("fetch-maidr-bundle.sh failed with exit status ", status)
 }
 
-# Verify downloads
-cat("\nVerifying downloads...\n")
-all_ok <- TRUE
-for (file in files) {
-  dest <- file.path(lib_dir, file)
-  if (file.exists(dest) && file.info(dest)$size > 100) {
-    cat("  ", file, ": OK\n")
-  } else {
-    cat("  ", file, ": MISSING or EMPTY\n")
-    all_ok <- FALSE
-  }
-}
-
-if (!all_ok) {
-  stop("Some files failed to download. Please check and retry.")
-}
-
-# Remove old version directories
-if (length(old_lib_dirs) > 0) {
-  cat("\nRemoving old version directories...\n")
-  for (old_dir in old_lib_dirs) {
-    if (old_dir != lib_dir) {
-      cat("  Removing:", basename(old_dir), "\n")
-      unlink(old_dir, recursive = TRUE)
-    }
-  }
-}
-
-# Print next steps
-cat("\n")
-cat("========================================\n")
-cat("SUCCESS! MAIDR assets updated to version", version, "\n")
-cat("========================================\n")
 cat("\n")
 cat("Next steps:\n")
-cat("1. Update MAIDR_VERSION in R/html_dependencies.R:\n")
-cat("   MAIDR_VERSION <- \"", version, "\"\n", sep = "")
-cat("\n")
-cat("2. Update version and path in inst/htmlwidgets/maidr.yaml:\n")
-cat("   version: ", version, "\n", sep = "")
-cat("   src: htmlwidgets/lib/maidr-", version, "\n", sep = "")
-cat("\n")
-cat("3. Run R CMD check:\n")
+cat("1. Run R CMD check:\n")
 cat("   devtools::check()\n")
 cat("\n")
-cat("4. Commit the changes:\n")
-cat("   git add -A && git commit -m \"chore: update MAIDR to ", version, "\"\n", sep = "")
-cat("\n")
+cat("2. Commit the changes:\n")
+cat('   git add -A && git commit -m "chore: update MAIDR bundle"\n')


### PR DESCRIPTION
Ports the bundle-refresh hardening from xability/py-maidr#286 to r-maidr.

## What changed

- **New shared script `.github/scripts/fetch-maidr-bundle.sh`** — single source of truth for resolving, downloading, verifying, and installing the bundled `maidr.js` / `maidr.css`. The assets are extracted from the official npm tarball and verified against the `dist.integrity` (SRI sha512) hash published in the npm registry metadata, so a tampered CDN/registry response fails the job instead of landing on `main` and shipping to CRAN. The script also installs the versioned `inst/htmlwidgets/lib/maidr-<version>/` dir, prunes stale bundle dirs, rewrites the version references in `R/html_dependencies.R` and `inst/htmlwidgets/maidr.yaml`, and verifies the rewrites actually landed. Previously the workflow downloaded straight from jsDelivr with no integrity check, with the logic split between workflow YAML and `tools/update-maidr-assets.R`.
- **`update-maidr-bundle.yml` reworked** to call the shared script in a single step. The auto-commit is now attributed to `xabilitylab` instead of `github-actions[bot]` (same as py-maidr). Manual dispatch gains an optional `maidr_version` input, passed through `env:` rather than `${{ }}` interpolation into the script text (script-injection surface in a job holding `contents: write`) and validated against a semver shape before it reaches any URL or file path.
- **New `workflow-lint` CI job** — ShellCheck over `.github/scripts/*.sh` plus actionlint over the workflow YAML (including inline `run` blocks), mirroring the job added to py-maidr. Fixed the one pre-existing actionlint error it surfaced: `R-CMD-check.yaml` referenced `matrix.config.http-user-agent`, which no matrix entry defines (r-lib template leftover).
- **`tools/update-maidr-assets.R` rewritten as a thin wrapper** over the shared script, so local maintainer refreshes go through the same verified path as CI and the download logic cannot drift between the two.

## Deviation from py-maidr#286: the daily schedule is kept

py-maidr moved the routine refresh into its release workflow and dropped the cron, so the bundle ships with each automated PyPI release instead of trickling onto `main`. r-maidr has no release pipeline to hook into — CRAN submissions are manual, and whatever is bundled on `main` at submission time is what ships. The daily schedule therefore remains the mechanism that keeps `main` current; what changes is that every refresh is now integrity-verified and properly attributed. If a release automation is added later, the shared script is ready to be called from it the same way py-maidr's release job does.

## Testing

- Ran `fetch-maidr-bundle.sh` end-to-end against npm: resolving latest (3.73.0) reproduces the currently bundled files byte-for-byte (lib dir, `html_dependencies.R`, and `maidr.yaml` all identical, so the no-op path commits nothing); pinning an explicit older version (3.72.1) installs it, removes the stale `maidr-3.73.0` dir, and updates both version references correctly; a hostile version string (`1.2.3";rm -rf /`) is rejected before any URL is built.
- `shellcheck` passes on the new script; `actionlint` passes on all five workflows (it fails on current `main` due to the `http-user-agent` reference fixed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015snZTWgDZv2eAYfXh6ihhi

---
_Generated by [Claude Code](https://claude.ai/code/session_015snZTWgDZv2eAYfXh6ihhi)_