### PR TITLE
fix(pkgdown): reattach BaseRAdapter roxygen block, build site on PRs

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -3,6 +3,10 @@
 on:
   push:
     branches: [main, master]
+  # Build (but do not deploy — see the gate on the deploy step) on PRs so
+  # site-breaking changes like a missing reference-index topic surface
+  # before merge instead of on main.
+  pull_request:
   release:
     types: [published]
   workflow_dispatch:

--- a/R/base_r_adapter.R
+++ b/R/base_r_adapter.R
@@ -1,12 +1,9 @@
-#' Base R System Adapter
+#' chartSeries TA Advisory Warning State
 #'
-#' Adapter for the Base R plotting system. This adapter uses function patching
-#' to intercept Base R plotting calls and detect plot types.
+#' Environment used to suppress repeat chartSeries `TA` advisory warnings
+#' within a single session.
 #'
-#' @format An R6 class inheriting from SystemAdapter
 #' @keywords internal
-
-# Environment used to suppress repeat warnings within a single session.
 .maidr_chartseries_ta_warned <- new.env(parent = emptyenv())
 .maidr_chartseries_ta_warned$value <- FALSE
 
@@ -51,6 +48,13 @@ warn_chartseries_ta_unsupported <- function() {
   invisible(NULL)
 }
 
+#' Base R System Adapter
+#'
+#' Adapter for the Base R plotting system. This adapter uses function patching
+#' to intercept Base R plotting calls and detect plot types.
+#'
+#' @format An R6 class inheriting from SystemAdapter
+#' @keywords internal
 BaseRAdapter <- R6::R6Class(
   "BaseRAdapter",
   inherit = SystemAdapter,

--- a/man/BaseRAdapter.Rd
+++ b/man/BaseRAdapter.Rd
@@ -2,15 +2,15 @@
 % Please edit documentation in R/base_r_adapter.R
 \name{BaseRAdapter}
 \alias{BaseRAdapter}
-\title{Initialize the Base R adapter
-Check if this adapter can handle a plot object}
-\description{
-Initialize the Base R adapter
-Check if this adapter can handle a plot object
-
-Initialize the Base R adapter
-Check if this adapter can handle a plot object
+\title{Base R System Adapter}
+\format{
+An R6 class inheriting from SystemAdapter
 }
+\description{
+Adapter for the Base R plotting system. This adapter uses function patching
+to intercept Base R plotting calls and detect plot types.
+}
+\keyword{internal}
 \section{Super class}{
 \code{\link[maidr:SystemAdapter]{maidr::SystemAdapter}} -> \code{BaseRAdapter}
 }

--- a/man/dot-maidr_chartseries_ta_warned.Rd
+++ b/man/dot-maidr_chartseries_ta_warned.Rd
@@ -3,15 +3,15 @@
 \docType{data}
 \name{.maidr_chartseries_ta_warned}
 \alias{.maidr_chartseries_ta_warned}
-\title{Base R System Adapter}
+\title{chartSeries TA Advisory Warning State}
 \format{
-An R6 class inheriting from SystemAdapter
+An object of class \code{environment} of length 1.
 }
 \usage{
 .maidr_chartseries_ta_warned
 }
 \description{
-Adapter for the Base R plotting system. This adapter uses function patching
-to intercept Base R plotting calls and detect plot types.
+Environment used to suppress repeat chartSeries \code{TA} advisory warnings
+within a single session.
 }
 \keyword{internal}


### PR DESCRIPTION
Fixes the pkgdown workflow failure on `main`, and makes pkgdown build on PRs so this class of breakage surfaces before merge:

```
Error in `build_reference_index()`:
! In _pkgdown.yml, 1 topic missing from index: "BaseRAdapter".
```

## Root cause

This predates #45 — the same failure occurred on the previous `main` push (the #44 merge on 2026-07-11). The candlestick work in #44 inserted the chartSeries `TA` warning environment (`.maidr_chartseries_ta_warned`) and its helper between the `"Base R System Adapter"` roxygen block and the `BaseRAdapter` class it documented. roxygen2 attaches a block to the next top-level expression, so the block — including `@keywords internal` — landed on the environment instead (producing `man/dot-maidr_chartseries_ta_warned.Rd` titled "Base R System Adapter" with an R6 `\format`), while `man/BaseRAdapter.Rd` was regenerated from the R6 inline method comments alone: garbled title/description and, critically, no `\keyword{internal}`. pkgdown requires every non-internal topic to appear in the `_pkgdown.yml` reference index, hence the failure.

## Fix

- Move the class-level roxygen block back onto `BaseRAdapter <- R6::R6Class(` in `R/base_r_adapter.R`, and give `.maidr_chartseries_ta_warned` its own small `@keywords internal` doc block, mirroring the other session-state environments (`.maidr_base_r_session`, `.maidr_patching_env`).
- Update the two generated Rd files to match: `BaseRAdapter.Rd` gets its proper title/format/description back plus `\keyword{internal}` (placed as in `Ggplot2Adapter.Rd`); `dot-maidr_chartseries_ta_warned.Rd` now describes the environment it actually documents.

The Rd files were hand-edited to stay consistent with the source since this environment has no R toolchain; running `devtools::document()` should reproduce them (modulo roxygen2's usual R6 keyword quirks, which are cosmetic and don't affect pkgdown).

## Build pkgdown on PRs (without touching main)

The workflow only ran on pushes to `main`, which is why this breakage was only discovered post-merge. The repo's copy of the upstream r-lib template had dropped the `pull_request:` trigger while keeping the machinery that supports it — the deploy step is already gated with `if: github.event_name != 'pull_request'` and the concurrency group already special-cases PR runs. Restoring the trigger means PRs run the site build as a pure check: no gh-pages deploy, no effect on the published site or `main`. The pkgdown run on this very PR verifies the BaseRAdapter fix pre-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015snZTWgDZv2eAYfXh6ihhi