### PR TITLE
ci: add semantic-release pipeline for automated versioning and NEWS.md

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -25,6 +25,8 @@
 ^_pkgdown\.yml$
 ^pkgdown$
 ^\.github$
+^\.releaserc\.json$
+^\.commitlintrc\.cjs$
 ^doc$
 ^Meta$
 ^CRAN-SUBMISSION$

--- a/.commitlintrc.cjs
+++ b/.commitlintrc.cjs
@@ -1,0 +1,12 @@
+// Mirrors py-maidr's commitlint configuration so contributors see the
+// same conventional-commit rules across the maidr repositories.
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "body-max-line-length": [0, "always", 0], // Disable line length checking for the body
+    "body-max-length": [0, "always", Infinity], // Disable total body length checking
+    "header-max-length": [0, "always", 0], // Disable header length checking
+    "footer-max-line-length": [0, "always", 0], // Disable line length checking for the footer
+    "footer-max-length": [0, "always", Infinity], // Disable total footer length checking
+  },
+};

--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -58,7 +58,10 @@ git push origin v0.4.0
 
 The release job fails with an explicit error until this tag exists —
 otherwise semantic-release would treat the next release as the first ever
-and publish 1.0.0.
+and publish 1.0.0. On every run the job also verifies that the newest
+`v*` tag matches the `Version:` in `DESCRIPTION` (an invariant each
+automated release re-establishes), so an unrelated or stale tag can never
+silently become the release baseline.
 
 ## CRAN releases stay manual
 

--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -1,0 +1,84 @@
+# Release process
+
+r-maidr uses [semantic-release](https://github.com/semantic-release/semantic-release)
+to automate version bumps, `NEWS.md` generation, Git tags, and GitHub
+releases — the same commit-driven model as the sibling repositories
+[py-maidr](https://github.com/xability/py-maidr) (python-semantic-release)
+and [maidr](https://github.com/xability/maidr) (semantic-release), adapted
+to R package conventions.
+
+## How it works
+
+Every push to `main` runs `.github/workflows/release.yml`:
+
+1. **R-CMD-check (release gate)** — a release is only cut when the package
+   checks cleanly on ubuntu / R release.
+2. **commit-lint** — the pushed commit must follow
+   [conventional commits](https://www.conventionalcommits.org/)
+   (config: `.commitlintrc.cjs`, mirroring py-maidr).
+3. **Semantic Release** — analyzes all commits since the last `v*` tag:
+
+   | Commit | Effect |
+   |---|---|
+   | `feat: ...` | minor bump (`0.4.0` → `0.5.0`) |
+   | `fix: ...`, `perf: ...` | patch bump (`0.4.0` → `0.4.1`) |
+   | `feat!: ...` or `BREAKING CHANGE:` footer | major bump (`0.4.0` → `1.0.0`) |
+   | `docs:`, `chore:`, `ci:`, `refactor:`, `style:`, `test:`, `build:` | no release |
+
+   When a release is due, semantic-release (config: `.releaserc.json`):
+
+   - prepends a new section to `NEWS.md`, using R-style `# maidr X.Y.Z`
+     headings so pkgdown and `utils::news()` keep parsing it. Visible
+     changelog sections are **New Features** (`feat`), **Bug Fixes**
+     (`fix`), **Performance Improvements** (`perf`), and
+     **Documentation** (`docs`); maintenance commit types are excluded to
+     keep the CRAN-facing NEWS readable,
+   - rewrites `Version:` in `DESCRIPTION` via
+     `.github/scripts/set-version.sh` (which rejects anything that is not
+     a plain `x.y.z`, since R does not accept semver prerelease suffixes),
+   - commits `DESCRIPTION` + `NEWS.md` back to `main` as
+     `chore(release): X.Y.Z [skip ci]`,
+   - tags `vX.Y.Z` and publishes a GitHub release with the same notes.
+
+Pushes made with the workflow's `GITHUB_TOKEN` do not re-trigger
+workflows, so the release commit cannot start a release loop; the
+`[skip ci]` marker is belt-and-suspenders for tokens that do.
+
+## One-time bootstrap
+
+semantic-release derives the current version from Git tags, and this
+repository historically had none. Before the first automated release, a
+maintainer must seed a baseline tag matching the `Version:` already in
+`DESCRIPTION`, placed on the commit that introduced that version:
+
+```sh
+git tag v0.4.0 <commit-sha>
+git push origin v0.4.0
+```
+
+The release job fails with an explicit error until this tag exists —
+otherwise semantic-release would treat the next release as the first ever
+and publish 1.0.0.
+
+## CRAN releases stay manual
+
+CRAN has no submission API, so this pipeline intentionally stops at the
+GitHub release. After any automated release, `main` carries a
+submission-ready `Version` and `NEWS.md`; when a CRAN release is wanted,
+build and submit from `main` as before (`R CMD build`, update
+`cran-comments.md`, submit, confirm). The daily
+`update-maidr-bundle.yml` refresh keeps the bundled maidr.js on `main`
+current, so whatever is on `main` at submission time is what ships.
+
+## Differences from the sibling repos
+
+- **Changelog file** is `NEWS.md` (R convention), not `CHANGELOG.md`.
+- **Changelog contents are curated**: py-maidr includes every commit type
+  in its changelog; r-maidr hides maintenance types because `NEWS.md`
+  ships to CRAN users.
+- **No `major_on_zero=false`**: python-semantic-release keeps py-maidr on
+  0.x even for breaking changes; node semantic-release follows semver
+  strictly, so a breaking-change commit here moves r-maidr to 1.0.0.
+  Avoid `!`/`BREAKING CHANGE` until 1.0.0 is intended.
+- **Trigger** is push-to-main (like py-maidr), not weekly cron (like
+  maidr).

--- a/.github/scripts/set-version.sh
+++ b/.github/scripts/set-version.sh
@@ -20,5 +20,5 @@ fi
 sed -i.bak "s/^Version: .*/Version: ${VERSION}/" DESCRIPTION
 rm -f DESCRIPTION.bak
 
-grep -q "^Version: ${VERSION}$" DESCRIPTION
+grep -qxF "Version: ${VERSION}" DESCRIPTION
 echo "DESCRIPTION Version set to ${VERSION}"

--- a/.github/scripts/set-version.sh
+++ b/.github/scripts/set-version.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Write the version computed by semantic-release into DESCRIPTION.
+#
+# Invoked by the @semantic-release/exec prepare step (see .releaserc.json)
+# so the Version field always matches the Git tag / GitHub release; the
+# @semantic-release/git plugin then commits the updated DESCRIPTION back
+# to main together with the regenerated NEWS.md.
+set -euo pipefail
+
+VERSION="${1:?usage: set-version.sh <version>}"
+
+# R package versions must be plain x.y.z — reject semver prerelease/build
+# suffixes (e.g. 1.0.0-rc.1) so a misconfigured release channel can never
+# write a version that R CMD check would reject.
+if ! [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Refusing to write non x.y.z version '${VERSION}' to DESCRIPTION" >&2
+  exit 1
+fi
+
+sed -i.bak "s/^Version: .*/Version: ${VERSION}/" DESCRIPTION
+rm -f DESCRIPTION.bak
+
+grep -q "^Version: ${VERSION}$" DESCRIPTION
+echo "DESCRIPTION Version set to ${VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,9 @@ name: Release
 # the commit that introduced it, e.g.:
 #   git tag v0.4.0 <commit-sha> && git push origin v0.4.0
 # The guard step below fails loudly (instead of silently releasing 1.0.0)
-# until that tag exists.
+# until that tag exists, and on every run it also requires the newest
+# ``v*`` tag to match DESCRIPTION's Version, so an unrelated or stale tag
+# can never silently become the release baseline.
 
 on:
   push:
@@ -99,14 +101,23 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.ref_name }}
 
-      - name: Ensure baseline tag exists
+      - name: Ensure release baseline matches DESCRIPTION
         # Without any v* tag semantic-release treats the next release as
-        # the first ever and jumps straight to 1.0.0. Refuse to run until
-        # a maintainer seeds the baseline tag described in the header.
+        # the first ever and jumps straight to 1.0.0, and with a wrong or
+        # stale tag it would compute the next version from the wrong
+        # baseline. Refuse to run unless the newest v* tag agrees with the
+        # Version currently in DESCRIPTION — an invariant every automated
+        # release re-establishes, so a mismatch always means manual drift
+        # that needs a maintainer's attention.
         run: |
-          if [ -z "$(git tag --list 'v*')" ]; then
-            CURRENT=$(sed -n 's/^Version: //p' DESCRIPTION)
+          CURRENT=$(sed -n 's/^Version: //p' DESCRIPTION)
+          LATEST_TAG=$(git tag --list 'v*' --sort=-v:refname | head -n 1)
+          if [ -z "${LATEST_TAG}" ]; then
             echo "::error::No v* tag found. Create a baseline tag for the current version first, e.g.: git tag v${CURRENT} <commit-that-set-${CURRENT}> && git push origin v${CURRENT}"
+            exit 1
+          fi
+          if [ "${LATEST_TAG}" != "v${CURRENT}" ]; then
+            echo "::error::Newest tag ${LATEST_TAG} does not match DESCRIPTION Version ${CURRENT}. Re-align the baseline tag and DESCRIPTION before releasing."
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,130 @@
+name: Release
+
+# Automated version + changelog management for r-maidr, mirroring the
+# semantic-release pipelines already used by the sibling repositories:
+# py-maidr (python-semantic-release) and maidr (semantic-release).
+#
+# Conventional commits on ``main`` drive the whole release:
+#   feat            -> minor bump
+#   fix / perf      -> patch bump
+#   BREAKING CHANGE -> major bump
+#   anything else   -> no release
+#
+# When a release is due, semantic-release (configured in .releaserc.json):
+#   1. computes the next version from commits since the last ``v*`` tag,
+#   2. prepends a generated section to NEWS.md (R-style ``# maidr X.Y.Z``
+#      headings so pkgdown and utils::news() keep parsing it),
+#   3. rewrites the Version field in DESCRIPTION
+#      (.github/scripts/set-version.sh),
+#   4. commits DESCRIPTION + NEWS.md back to main, tags ``vX.Y.Z``, and
+#      publishes a GitHub release with the same notes.
+#
+# CRAN submission stays manual — CRAN has no submission API — but after
+# this workflow runs, main always carries a submission-ready Version and
+# NEWS.md, so a maintainer can build and submit whenever a CRAN release
+# is wanted.
+#
+# One-time bootstrap: semantic-release derives versions from Git tags and
+# this repository historically had none. Before the first automated
+# release, create a baseline tag matching the Version in DESCRIPTION on
+# the commit that introduced it, e.g.:
+#   git tag v0.4.0 <commit-sha> && git push origin v0.4.0
+# The guard step below fails loudly (instead of silently releasing 1.0.0)
+# until that tag exists.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: R-CMD-check (release gate)
+    runs-on: ubuntu-latest
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: release
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+          cache-version: 2
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'
+
+  commit-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lint commit messages
+        uses: wagoid/commitlint-github-action@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          failOnWarnings: 'false'
+          commitDepth: 1
+
+  release:
+    name: Semantic Release
+    runs-on: ubuntu-latest
+    concurrency: push
+    needs: [check, commit-lint]
+    if: github.repository == 'xability/r-maidr'
+    permissions:
+      contents: write # push the release commit + tag, create the GitHub release
+      issues: write # comment on issues resolved by the release
+      pull-requests: write # comment on PRs included in the release
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref_name }}
+
+      - name: Ensure baseline tag exists
+        # Without any v* tag semantic-release treats the next release as
+        # the first ever and jumps straight to 1.0.0. Refuse to run until
+        # a maintainer seeds the baseline tag described in the header.
+        run: |
+          if [ -z "$(git tag --list 'v*')" ]; then
+            CURRENT=$(sed -n 's/^Version: //p' DESCRIPTION)
+            echo "::error::No v* tag found. Create a baseline tag for the current version first, e.g.: git tag v${CURRENT} <commit-that-set-${CURRENT}> && git push origin v${CURRENT}"
+            exit 1
+          fi
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+
+      - name: Semantic Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # commit-analyzer, release-notes-generator, and github ship with
+        # semantic-release itself; only the extra plugins and the
+        # conventionalcommits preset need to be provided explicitly.
+        run: |
+          npx --yes \
+            --package semantic-release@24 \
+            --package @semantic-release/changelog@6 \
+            --package @semantic-release/exec@7 \
+            --package @semantic-release/git@10 \
+            --package conventional-changelog-conventionalcommits@8 \
+            semantic-release

--- a/.github/workflows/update-maidr-bundle.yml
+++ b/.github/workflows/update-maidr-bundle.yml
@@ -5,16 +5,18 @@ name: Update MAIDR Bundle
 # commits the refresh directly to ``main``.
 #
 # Unlike py-maidr — where the routine refresh happens inside the automated
-# release workflow so the bundle ships with each release — r-maidr has no
-# release pipeline to hook into (CRAN submissions are manual), so the
-# scheduled refresh here is what keeps ``main`` current: whatever is bundled
-# on ``main`` at submission time is what ships to CRAN. The download is
+# release workflow so the bundle ships with each release — r-maidr keeps
+# the refresh on this daily schedule because CRAN submissions are built
+# from ``main``, not from release artifacts: whatever is bundled on
+# ``main`` at submission time is what ships to CRAN. The download is
 # verified against the integrity hash published in the npm registry
 # metadata (see ``.github/scripts/fetch-maidr-bundle.sh``), so a tampered
 # CDN/registry response fails the job instead of landing on ``main``.
 #
 # The commit uses the ``chore:`` prefix so a bundle refresh reads as
-# maintenance, not a feature, in the history.
+# maintenance, not a feature, in the history — and so the semantic-release
+# pipeline (see ``release.yml``) never cuts a release for a bundle
+# refresh.
 
 on:
   schedule:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,55 @@
+{
+  "branches": ["main"],
+  "tagFormat": "v${version}",
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "types": [
+            { "type": "feat", "section": "New Features" },
+            { "type": "fix", "section": "Bug Fixes" },
+            { "type": "perf", "section": "Performance Improvements" },
+            { "type": "docs", "section": "Documentation" },
+            { "type": "refactor", "hidden": true },
+            { "type": "style", "hidden": true },
+            { "type": "test", "hidden": true },
+            { "type": "build", "hidden": true },
+            { "type": "chore", "hidden": true },
+            { "type": "ci", "hidden": true }
+          ]
+        },
+        "writerOpts": {
+          "headerPartial": "# maidr {{version}}\n"
+        }
+      }
+    ],
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "NEWS.md"
+      }
+    ],
+    [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": ".github/scripts/set-version.sh ${nextRelease.version}"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["DESCRIPTION", "NEWS.md"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]"
+      }
+    ],
+    "@semantic-release/github"
+  ]
+}


### PR DESCRIPTION
## Summary

Brings r-maidr in line with py-maidr (python-semantic-release) and maidr (semantic-release): conventional commits on `main` now drive the version bump, changelog, Git tag, and GitHub release automatically, adapted to R package conventions.

- `feat:` → minor, `fix:`/`perf:` → patch, `BREAKING CHANGE` → major, everything else → no release (same rules as py-maidr)
- Changelog is written to **`NEWS.md`** (not CHANGELOG.md) with R-style `# maidr X.Y.Z` headings so pkgdown and `utils::news()` keep parsing it
- `Version:` in **`DESCRIPTION`** is rewritten via `@semantic-release/exec` + `.github/scripts/set-version.sh`, which rejects any non-`x.y.z` version R would not accept
- Visible NEWS sections are curated to **New Features / Bug Fixes / Performance Improvements / Documentation**; maintenance types (`chore`, `ci`, …) are hidden so the daily `chore: update MAIDR bundle` commits never pollute the CRAN-facing NEWS
- CRAN submission intentionally stays manual (CRAN has no submission API); after each automated release `main` carries a submission-ready Version + NEWS.md

## Changes

| File | Purpose |
|---|---|
| `.releaserc.json` | semantic-release plugin chain: commit-analyzer → release-notes-generator (conventionalcommits preset, R-style header) → changelog (NEWS.md) → exec (DESCRIPTION bump) → git (release commit `chore(release): X.Y.Z [skip ci]`) → github |
| `.github/workflows/release.yml` | On push to `main`: R-CMD-check gate + commitlint, then semantic-release with pinned plugin versions |
| `.github/scripts/set-version.sh` | Writes the computed version into DESCRIPTION; validates `x.y.z` format |
| `.commitlintrc.cjs` | Same commitlint rules as py-maidr |
| `.github/RELEASE.md` | Pipeline documentation: bootstrap step, CRAN flow, differences from sibling repos |
| `.Rbuildignore` | Excludes the new tooling files from the R build |
| `.github/workflows/update-maidr-bundle.yml` | Refreshes the stale "no release pipeline" comment |

## One-time setup after merge

This repo has no Git tags, and semantic-release derives versions from tags — without one it would publish **1.0.0** as the "first" release. The release job includes a guard that fails loudly until a maintainer seeds the baseline tag matching the current DESCRIPTION version:

```sh
git tag v0.4.0 d1a374b   # the commit that set Version: 0.4.0
git push origin v0.4.0
```

## Verification

- Release-notes generation was tested locally against this exact `.releaserc.json` with the real `@semantic-release/release-notes-generator@14` + `conventional-changelog-conventionalcommits@8`: output is `# maidr 0.5.0` with curated `### New Features` / `### Bug Fixes` / `### Performance Improvements` / `### Documentation` sections, and `chore:`/`ci:` commits are correctly excluded
- `set-version.sh` verified on a copy of DESCRIPTION: rewrites `Version:` correctly and rejects `1.0.0-rc.1`
- Workflow YAML and `.releaserc.json` parse cleanly

## Notes for reviewers

- One behavioral difference from py-maidr: python-semantic-release has `major_on_zero=false` (breaking changes keep 0.x), but node semantic-release follows semver strictly — a `feat!:`/`BREAKING CHANGE` commit here moves the package to 1.0.0. Documented in `.github/RELEASE.md`; avoid `!` until 1.0.0 is intended.
- The release commit is pushed with the workflow `GITHUB_TOKEN`, which does not re-trigger workflows (no release loop); `[skip ci]` is belt-and-suspenders. If `main` gains branch protection that blocks the push, a PAT (like maidr's `SEMANTIC_RELEASE_TOKEN`) would be needed instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkvuwdQiv2yNxAURrvqpGR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkvuwdQiv2yNxAURrvqpGR)_