### PR TITLE
ci: add Claude Code review workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,6 +6,12 @@ on:
 
 jobs:
   claude-review:
+    # Fork PRs are not given repository secrets, so CLAUDE_CODE_OAUTH_TOKEN
+    # would be empty and this job would fail on every external contribution.
+    # Skip it cleanly instead. pull_request_target is deliberately not used as
+    # the workaround: it would run untrusted PR code with write-scoped secrets.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,52 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Please review this pull request and provide feedback on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security concerns
+            - Test coverage
+
+            This is an R package. Hold changes to R-package conventions:
+            roxygen2 docs kept in sync with `man/` and `NAMESPACE`, testthat
+            coverage for new behaviour, `.lintr` / `air.toml` style, and CRAN
+            policy (no writes outside tempdir, no unconditional network access,
+            examples that run clean under `R CMD check`).
+
+            If the repository has a CLAUDE.md, follow it for style and
+            conventions. Be constructive and helpful in your feedback.
+
+            Use `gh pr comment` with your Bash tool to leave your review as a
+            comment on the PR.
+
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,41 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,20 @@ on:
 
 jobs:
   claude:
+    # This repository is public, so anyone can write '@claude' anywhere. The
+    # action itself already refuses actors without write access, but gating
+    # here means a drive-by mention never starts a runner or spends the OAuth
+    # token in the first place.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Why

`xability/maidr` runs an automatic Claude review on every PR; `xability/r-maidr` did not. Diagnosis:

| Prerequisite | maidr | r-maidr (before) |
|---|---|---|
| Claude GitHub App installed | ✅ | ✅ already installed |
| `CLAUDE_CODE_OAUTH_TOKEN` repo secret | ✅ | ✅ already present |
| Actions enabled, all actions allowed, write default perms | ✅ | ✅ |
| `.github/workflows/claude-code-review.yml` | ✅ | ❌ **never existed** (0 commits touching that path) |
| `.github/workflows/claude.yml` | ✅ | ❌ missing |

So everything except the workflow files themselves was already in place.

## What

- **`claude-code-review.yml`** — reviews every PR on `opened`/`synchronize`. Prompt adapted from maidr's to R-package conventions: roxygen2 docs in sync with `man/`+`NAMESPACE`, testthat coverage, `.lintr`/`air.toml` style, CRAN policy.
- **`claude.yml`** — responds to `@claude` mentions in issues, PR comments, and PR reviews.

Both pass `actionlint 1.7.12` clean, matching this repo's `workflow-lint` gate.

## Self-test

`pull_request` workflows run from the PR head, so this PR should trigger `Claude Code Review` on itself — a Claude review comment appearing below is the proof the fix works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)