### PR TITLE
ci: publish reviews via tag mode (fixes silent no-op reviews)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,11 +6,15 @@ on:
 
 jobs:
   claude-review:
-    # Fork PRs are not given repository secrets, so CLAUDE_CODE_OAUTH_TOKEN
-    # would be empty and this job would fail on every external contribution.
-    # Skip it cleanly instead. pull_request_target is deliberately not used as
-    # the workaround: it would run untrusted PR code with write-scoped secrets.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Neither fork PRs nor Dependabot PRs are given repository secrets, so
+    # CLAUDE_CODE_OAUTH_TOKEN would be empty and this job would fail rather
+    # than review anything. Skip cleanly instead. pull_request_target is
+    # deliberately not used as the workaround: it would run with write-scoped
+    # secrets on untrusted input, and the action does not treat it as an entity
+    # context, so its own write-permission check never runs.
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:
@@ -30,6 +34,18 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Forces tag mode, where the action creates a tracking comment up
+          # front and the review is written into it through
+          # mcp__github_comment__update_claude_comment. Without this the run is
+          # in agent mode, where publishing depends on the agent choosing to
+          # shell out to `gh pr comment`; if it ends its final turn with text
+          # instead, nothing is published and the job still reports success.
+          # That is exactly what #48 did -- 26 turns, $1.96, zero comments.
+          # The prompt below survives: tag mode appends it as
+          # <custom_instructions> to its own.
+          track_progress: true
+
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -50,9 +66,9 @@ jobs:
             If the repository has a CLAUDE.md, follow it for style and
             conventions. Be constructive and helpful in your feedback.
 
-            Use `gh pr comment` with your Bash tool to leave your review as a
-            comment on the PR.
-
+          # No claude_args here on purpose. Tag mode builds its own
+          # `--allowedTools` list -- the one carrying
+          # mcp__github_comment__update_claude_comment -- and then appends
+          # whatever claude_args says. A second --allowed-tools flag risks
+          # overriding that list and taking the comment-update tool with it.
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'


### PR DESCRIPTION
Follow-up to the r-maidr#48 investigation. Fixes the reason a review can run, cost real money, report success, and publish nothing.

## What happened

r-maidr#48's review job finished `is_error: false` after **26 turns and $1.96** — and posted zero comments. The check was green.

Cause is structural, not environmental. Everything environmental was ruled out by comparison against a maidr run that *did* post: identical `permissions:`, identical `CLAUDE_ARGS`, both `Using GITHUB_TOKEN from OIDC`, both `OVERRIDE_GITHUB_TOKEN` empty. The 13 permission denials are normal noise — the working maidr run had 6.

The difference is that **agent mode publishes nothing on its own**. The prompt asks the agent to shell out to `gh pr comment`. If it ends its final turn with text instead of that tool call — which gets likelier as the diff grows — the review is simply lost, and nothing in the job notices.

## The fix

`track_progress: true` forces **tag mode** ([`detectMode`](https://github.com/anthropics/claude-code-action/blob/main/src/modes/detector.ts)). The action creates a tracking comment *before* the model runs and the review is written into it through `mcp__github_comment__update_claude_comment`. Publishing stops being something the agent may or may not elect to do.

The custom review prompt is preserved — tag mode appends it as `<custom_instructions>` to its own ([`create-prompt`](https://github.com/anthropics/claude-code-action/blob/main/src/create-prompt/index.ts)).

## Why `claude_args` goes too

Tag mode builds its own `--allowedTools` list — the one carrying `mcp__github_comment__update_claude_comment` — and then appends `claude_args` verbatim ([`modes/tag`](https://github.com/anthropics/claude-code-action/blob/main/src/modes/tag/index.ts)). Leaving a second `--allowed-tools` flag on the command line risks overriding that list and taking the publishing tool with it. Tag mode supplies `Read`/`LS`/CI tools itself, and pre-fetches PR context, so the `Bash(gh …)` allowlist is no longer load-bearing.

## Not applied to py-maidr

`validateTrackProgressEvent` **throws** for any event outside `pull_request`/`issues`/`issue_comment`/`pull_request_review_comment`/`pull_request_review`. py-maidr's review workflow runs on `pull_request_target`, so `track_progress: true` there would hard-fail the job. It stays in agent mode; its separate exposure is tracked in xability/py-maidr#300.

## Verifying

The default-branch guard means this PR cannot demonstrate the fix on itself. After merge, the next `opened`/`synchronize` on any PR should show a Claude tracking comment appear immediately and fill in — r-maidr#48 is the natural test case, since it is the one that failed.

`actionlint 1.7.12` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Also adds the Dependabot half of the skip guard, which this repo missed when maidr and py-maidr got it.