### PR TITLE
fix(shiny): render Base R plots from render_maidr()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,15 @@
 
 ## Bug Fixes
 
+* Shiny: `render_maidr()` renders Base R plots again. It branched on the
+  expression's return value, which says nothing about whether anything was
+  drawn -- `plot()` returns NULL invisibly, so it was treated as an empty
+  reactive and rendered a silent blank, while `barplot()` and `hist()`
+  return a non-plot value and errored the output slot with "Input must be a
+  ggplot object". Only ggplot worked. `render_maidr()` now asks whether the
+  expression actually recorded any drawing, so all three render. An
+  expression that draws nothing and returns NULL still renders nothing.
+
 * Base R: recorded plot calls now capture non-standard-evaluation arguments
   safely, so `curve(sin(x))` no longer errors or records stale values;
   replay evaluates them in the original environment.

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -30,7 +30,12 @@ maidr_output <- function(output_id, width = "100%", height = "400px") {
 #' Creates a Shiny render function for MAIDR widgets using htmlwidgets.
 #' This provides automatic dependency injection and robust JavaScript initialization.
 #'
-#' @param expr An expression that returns a ggplot object
+#' @param expr An expression that draws a plot. Either a ggplot object, or
+#'   Base R plotting calls -- their return values differ
+#'   (\code{plot()} returns NULL, \code{barplot()} returns bar midpoints)
+#'   and are ignored; what counts is whether the expression drew. An
+#'   expression that draws nothing and returns NULL renders nothing, per
+#'   Shiny convention.
 #' @param env The environment in which to evaluate expr
 #' @param quoted Is expr a quoted expression
 #' @return A Shiny render function for use in server
@@ -54,11 +59,48 @@ render_maidr <- function(expr, env = parent.frame(), quoted = FALSE) {
 
   shiny::installExprFunction(expr, "func", env, quoted)
 
-  # Standard Shiny convention: a NULL reactive result renders nothing
-  # instead of erroring the output slot.
+  # A Base R plotting call's RETURN VALUE says nothing useful about whether
+  # it drew. `plot()` returns NULL invisibly, `barplot()` returns the bar
+  # midpoints, `hist()` returns the histogram object. Branching on that
+  # value broke both shapes in Shiny: `render_maidr({ plot(x, y) })` was
+  # treated as an empty reactive and rendered a silent blank, while
+  # `render_maidr({ barplot(...) })` passed a numeric matrix to
+  # maidr_widget() and errored the output slot. Only ggplot happened to work.
+  #
+  # Ask the recorder instead: did THIS evaluation draw anything? A count
+  # taken before and after is what distinguishes "drew, then returned
+  # something unhelpful" from "returned without drawing". Checking merely
+  # that the device is non-empty would re-render the previous plot every
+  # time a reactive later returns NULL.
   expr2 <- quote({
+    device_before <- grDevices::dev.cur()
+    calls_before <- length(get_device_calls(device_before))
+
     plot_result <- func()
-    if (is.null(plot_result)) NULL else maidr_widget(plot_result)
+
+    device_after <- grDevices::dev.cur()
+    drew_something <- if (identical(device_after, device_before)) {
+      length(get_device_calls(device_after)) > calls_before
+    } else {
+      # The evaluation opened its own device -- the usual case, since the
+      # first Base R call in a session opens maidr's temp device
+      has_device_calls(device_after)
+    }
+
+    if (inherits(plot_result, "ggplot")) {
+      maidr_widget(plot_result)
+    } else if (drew_something && is_patching_active()) {
+      # A Base R call that drew to the recorded device; its return value is
+      # irrelevant, so hand over to Base R auto-detection
+      maidr_widget(NULL)
+    } else if (is.null(plot_result)) {
+      # Shiny's convention: an empty reactive renders nothing
+      NULL
+    } else {
+      # Not a plot and nothing was drawn -- let maidr_widget() raise its
+      # own "Input must be a ggplot object" error rather than fail silently
+      maidr_widget(plot_result)
+    }
   })
 
   htmlwidgets::shinyRenderWidget(expr2, maidr_widget_output, environment(), quoted)

--- a/man/render_maidr.Rd
+++ b/man/render_maidr.Rd
@@ -7,7 +7,12 @@
 render_maidr(expr, env = parent.frame(), quoted = FALSE)
 }
 \arguments{
-\item{expr}{An expression that returns a ggplot object}
+\item{expr}{An expression that draws a plot. Either a ggplot object, or
+Base R plotting calls -- their return values differ
+(\code{plot()} returns NULL, \code{barplot()} returns bar midpoints)
+and are ignored; what counts is whether the expression drew. An
+expression that draws nothing and returns NULL renders nothing, per
+Shiny convention.}
 
 \item{env}{The environment in which to evaluate expr}
 

--- a/tests/testthat/test-shiny-render.R
+++ b/tests/testthat/test-shiny-render.R
@@ -1,0 +1,166 @@
+# Regression tests for render_maidr()'s handling of Base R plot calls.
+#
+# A Base R plotting call's return value says nothing about whether it drew:
+# plot() returns NULL invisibly, barplot() returns the bar midpoints, hist()
+# returns the histogram object. render_maidr() used to branch on that value,
+# which meant plot() rendered a silent blank and barplot()/hist() errored the
+# output slot. Only ggplot worked.
+#
+# These exercise the real reactive path via shiny::testServer().
+
+rendered_nothing <- function(value) {
+  # htmlwidgets serialises "render nothing" as a payload whose x is null
+  is.null(value) || grepl('^\\{"x":null', as.character(value))
+}
+
+setup_clean_shiny <- function() {
+  maidr:::clear_all_device_storage()
+}
+
+test_that("render_maidr() renders a Base R plot() that returns NULL", {
+  testthat::skip_if_not_installed("shiny")
+  setup_clean_shiny()
+
+  server <- function(input, output, session) {
+    output$p <- render_maidr({
+      plot(1:10, (1:10)^2)
+    })
+  }
+
+  shiny::testServer(server, {
+    testthat::expect_false(rendered_nothing(output$p))
+  })
+
+  setup_clean_shiny()
+})
+
+test_that("render_maidr() renders barplot(), whose return value is not a plot", {
+  testthat::skip_if_not_installed("shiny")
+  setup_clean_shiny()
+
+  # barplot() returns the bar midpoints; passing that to maidr_widget()
+  # used to error the output slot with "Input must be a ggplot object"
+  server <- function(input, output, session) {
+    output$p <- render_maidr({
+      barplot(c(a = 1, b = 2, c = 3))
+    })
+  }
+
+  shiny::testServer(server, {
+    testthat::expect_false(rendered_nothing(output$p))
+  })
+
+  setup_clean_shiny()
+})
+
+test_that("render_maidr() renders hist()", {
+  testthat::skip_if_not_installed("shiny")
+  setup_clean_shiny()
+
+  server <- function(input, output, session) {
+    output$p <- render_maidr({
+      hist(c(1, 2, 2, 3, 3, 3, 4))
+    })
+  }
+
+  shiny::testServer(server, {
+    testthat::expect_false(rendered_nothing(output$p))
+  })
+
+  setup_clean_shiny()
+})
+
+test_that("render_maidr() keeps a low-level overlay with its plot", {
+  testthat::skip_if_not_installed("shiny")
+  setup_clean_shiny()
+
+  server <- function(input, output, session) {
+    output$p <- render_maidr({
+      plot(1:5, 1:5)
+      abline(h = 2)
+    })
+  }
+
+  shiny::testServer(server, {
+    testthat::expect_false(rendered_nothing(output$p))
+  })
+
+  setup_clean_shiny()
+})
+
+test_that("render_maidr() still renders a ggplot", {
+  testthat::skip_if_not_installed("shiny")
+  testthat::skip_if_not_installed("ggplot2")
+  setup_clean_shiny()
+
+  server <- function(input, output, session) {
+    output$p <- render_maidr({
+      ggplot2::ggplot(mtcars, ggplot2::aes(factor(cyl))) + ggplot2::geom_bar()
+    })
+  }
+
+  shiny::testServer(server, {
+    testthat::expect_false(rendered_nothing(output$p))
+  })
+
+  setup_clean_shiny()
+})
+
+test_that("render_maidr() renders nothing for an empty reactive", {
+  testthat::skip_if_not_installed("shiny")
+  setup_clean_shiny()
+
+  server <- function(input, output, session) {
+    output$p <- render_maidr({
+      NULL
+    })
+  }
+
+  shiny::testServer(server, {
+    testthat::expect_true(rendered_nothing(output$p))
+  })
+
+  setup_clean_shiny()
+})
+
+test_that("render_maidr() does not re-render a previous plot when a reactive goes empty", {
+  testthat::skip_if_not_installed("shiny")
+  setup_clean_shiny()
+
+  # The tempting fix -- "if the result is NULL but the device has calls,
+  # render those" -- reads a device that still holds the PREVIOUS
+  # evaluation's calls, so an empty reactive would redraw the old plot.
+  # Only calls recorded during THIS evaluation count.
+  server <- function(input, output, session) {
+    output$p <- render_maidr({
+      if (isTRUE(input$go)) plot(1:10, 1:10) else NULL
+    })
+  }
+
+  shiny::testServer(server, {
+    session$setInputs(go = TRUE)
+    testthat::expect_false(rendered_nothing(output$p))
+
+    session$setInputs(go = FALSE)
+    testthat::expect_true(rendered_nothing(output$p))
+  })
+
+  setup_clean_shiny()
+})
+
+test_that("render_maidr() still errors for a non-plot value", {
+  testthat::skip_if_not_installed("shiny")
+  setup_clean_shiny()
+
+  server <- function(input, output, session) {
+    output$p <- render_maidr({
+      42
+    })
+  }
+
+  shiny::testServer(server, {
+    testthat::expect_error(output$p, "Input must be a ggplot object")
+  })
+
+  setup_clean_shiny()
+})


### PR DESCRIPTION
Closes #56.

## The problem

`render_maidr()` decided what to render by looking at the expression's **return value**. That value says nothing about whether anything was drawn, and every Base R plotting function returns something different:

| expression | returns | what happened in Shiny |
|---|---|---|
| `plot(x, y)` | `NULL` invisibly | treated as an empty reactive → **silent blank** |
| `barplot(...)` | bar midpoints | passed to `maidr_widget()` → **error**: "Input must be a ggplot object" |
| `hist(...)` | histogram object | same **error** |
| a ggplot | the ggplot | worked |

So of the four shapes a user can put in `render_maidr()`, only ggplot worked — one failed silently and two failed loudly. The Base R auto-detection that `maidr_widget(NULL)` provides was unreachable from Shiny, because the NULL short-circuit ran before it.

Both halves were introduced together in #48: the NULL short-circuit was added to stop an empty reactive from erroring the output slot, and `maidr_widget(plot = NULL)` was added for Base R auto-detection. Each is reasonable alone; together the first hides the second.

## The fix

Ask the recorder rather than the return value: **did this evaluation draw anything?**

The recorded-call count is sampled before and after the expression runs. That is what separates "drew, then returned something unhelpful" from "returned without drawing".

The obvious shortcut — "if the result is NULL but the device has calls, render those" — is wrong in the other direction, and this was worth being careful about. The device still holds the *previous* evaluation's calls, so an empty reactive would silently redraw the stale plot:

```r
output$p <- render_maidr({
  if (isTRUE(input$go)) plot(1:10, 1:10) else NULL
})
```

With the shortcut, toggling `go` off keeps showing the old chart. Sampling before/after gets it right, and there is a regression test pinning exactly that sequence.

A non-plot value that drew nothing (`render_maidr({ 42 })`) still raises `maidr_widget()`'s own error rather than failing quietly.

## Verification

Exercised through the real reactive path with `shiny::testServer()`, not by reading:

```
plot(x, y)                    rendered      (was: silent blank)
barplot()                     rendered      (was: error)
hist()                        rendered      (was: error)
plot() + abline() overlay     rendered
ggplot                        rendered      (unchanged)
NULL, nothing drawn           blank         (unchanged, correct)
42                            error         (unchanged, correct)
stale-render guard            blank         (go=TRUE renders, go=FALSE blanks)
```

Full suite: **2771 pass, 0 fail** (2762 before; 8 new tests in `tests/testthat/test-shiny-render.R`).

## Note

While regenerating docs I found that `roxygen2::roxygenise()` does not round-trip cleanly on this repo — it rewrites `man/BaseRAdapter.Rd` with a dozen junk `\keyword{}` entries and downgrades `\code{TA}` to literal backticks in `man/dot-maidr_chartseries_ta_warned.Rd`, in both directions of the `Roxygen: list(markdown = TRUE)` setting. Those are pre-existing and unrelated to this change, so this PR reverts that drift and touches only `man/render_maidr.Rd`. Worth a separate look, since it means anyone regenerating docs silently degrades them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHiQLtv3om84NnECwsL8Z9)_