### PR TITLE
fix(ggplot2): announce each violin's own box statistics, and render width = 0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,10 @@
   quartile as 0. A violin on a continuous axis matched labels by position
   index, announcing a `7` for `cyl` that no car has. All three now report
   each group's own quartiles under its own label, dodged violins included.
+* ggplot2: `geom_violin(width = 0)` no longer errors out of rendering with
+  "missing value where TRUE/FALSE needed". A violin drawn with no width has
+  nothing to scale the density against; it now renders, and any positive
+  widths in the same layer still scale normally.
 * ggplot2: a plot placed after an `inset_element()`, `free()` or
   `wrap_elements()` in a patchwork is described again. Those wrappers put a
   plot in a cell panel discovery does not recognise, so it contributes no

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,16 @@
   last-added plot's data -- the same numbers announced in three places, only
   one of them reachable. Panels are now consumed per plot, so each is
   announced once, on its own panel.
+* ggplot2: the box statistics of a violin plot now describe the group they
+  are announced with. The quartiles were recomputed from the drawn geometry
+  rather than read from ggplot2's own `stat_boxplot` output, so a violin
+  split by `fill` announced one set of class-wide numbers over every one of
+  its dodged violins -- `aes(class, hwy, fill = drv)` emitted 7 labels for
+  12 violins, each repeated. A `coord_flip()` violin read its labels off the
+  vertical axis, which is now the continuous one, and reported every
+  quartile as 0. A violin on a continuous axis matched labels by position
+  index, announcing a `7` for `cyl` that no car has. All three now report
+  each group's own quartiles under its own label, dodged violins included.
 * ggplot2: a plot placed after an `inset_element()`, `free()` or
   `wrap_elements()` in a patchwork is described again. Those wrappers put a
   plot in a cell panel discovery does not recognise, so it contributes no

--- a/R/ggplot2_violin_layer_processor.R
+++ b/R/ggplot2_violin_layer_processor.R
@@ -32,14 +32,35 @@ Ggplot2ViolinLayerProcessor <- R6::R6Class(
       }, logical(1)))
 
       if (!has_boxplot) {
-        plot <- plot + ggplot2::geom_boxplot(
+        # Never set an aesthetic the violin maps. ggplot2 derives `group` from
+        # the discrete aesthetics a layer actually carries, so pinning
+        # `fill = "white"` over an `aes(fill = ...)` drops fill from the box's
+        # grouping: a violin dodged into 12 groups gets 7 boxes, and reading
+        # statistics or selectors back by group pairs them with the wrong
+        # violins. Inheriting the aesthetic keeps the two layers in step.
+        mapping <- tryCatch(
+          self$get_effective_mapping(plot),
+          error = function(e) list()
+        )
+        mapped <- names(mapping)
+
+        args <- list(
           width = 0.1,
-          fill = "white",
-          color = "black",
           alpha = 0.9,
           outlier.shape = 16,
-          outlier.size = 1.5
+          outlier.size = 1.5,
+          # The box is far narrower than the violin, so it only lands inside
+          # its own violin if it dodges across the violin's width.
+          position = ggplot2::position_dodge(width = 0.9)
         )
+        if (!"fill" %in% mapped) {
+          args$fill <- "white"
+        }
+        if (!any(c("colour", "color") %in% mapped)) {
+          args$colour <- "black"
+        }
+
+        plot <- plot + do.call(ggplot2::geom_boxplot, args)
       }
       plot
     },
@@ -190,90 +211,91 @@ Ggplot2ViolinLayerProcessor <- R6::R6Class(
       is_horizontal <- isTRUE(layer_data$flipped_aes[1])
 
       # Get original data and mapping to compute real quartiles
-      original_data <- self$get_original_data(plot)
-      mapping <- self$get_effective_mapping(plot)
-
-      # Resolve the grouping (x) and value (y) variables
-      x_var <- tryCatch(rlang::as_label(mapping$x), error = function(e) NULL)
-      y_var <- tryCatch(rlang::as_label(mapping$y), error = function(e) NULL)
-
-      if (is_horizontal) {
-        cat_var <- y_var
-        val_var <- x_var
-      } else {
-        cat_var <- x_var
-        val_var <- y_var
-      }
-
-      # Map numeric positions to category labels
-      panel_params <- built$layout$panel_params[[1]]
-      category_labels <- self$get_category_labels(
-        panel_params, is_horizontal
-      )
-
       groups <- unique(layer_data$group)
-      cat_col <- if (is_horizontal) "y" else "x"
       val_col <- if (is_horizontal) "x" else "y"
-      group_cat_positions <- vapply(groups, function(g) {
-        rows <- layer_data[layer_data$group == g, ]
-        rows[[cat_col]][1]
-      }, numeric(1))
+      labels <- self$group_labels(built, layer_data, groups, is_horizontal)
+
+      # ggplot2's own stat_boxplot output, keyed by the same group ids the
+      # violin layer uses. The columns are named for the value axis, which
+      # flips with the plot.
+      stats_data <- self$boxplot_stats(plot, built)
+      if (is.null(stats_data)) {
+        # Caller handed us a plot that was never augmented. Build the boxplot
+        # ourselves rather than approximating: the KDE grid is the density's
+        # support, so quantiles of it describe the sampling grid, not the data.
+        stats_data <- tryCatch(
+          {
+            augmented <- self$augment_plot(plot)
+            self$boxplot_stats(augmented, ggplot2::ggplot_build(augmented))
+          },
+          error = function(e) NULL
+        )
+      }
+      stat_cols <- if (is_horizontal) {
+        c(min = "xmin", q1 = "xlower", q2 = "xmiddle", q3 = "xupper", max = "xmax")
+      } else {
+        c(min = "ymin", q1 = "lower", q2 = "middle", q3 = "upper", max = "ymax")
+      }
+      has_stats <- !is.null(stats_data) &&
+        all(stat_cols %in% names(stats_data))
 
       box_data <- vector("list", length(groups))
 
       for (i in seq_along(groups)) {
         g <- groups[i]
-        cat_pos <- group_cat_positions[i]
-
-        idx <- suppressWarnings(as.integer(round(cat_pos)))
-        fill_label <- if (!is.na(idx) && idx >= 1 &&
-              idx <= length(category_labels)) {
-          as.character(category_labels[idx])
+        summary <- if (has_stats) {
+          row <- stats_data[stats_data$group == g, , drop = FALSE]
+          if (nrow(row) > 0) {
+            outliers <- if ("outliers" %in% names(row)) {
+              as.numeric(unlist(row$outliers[1]))
+            } else {
+              numeric(0)
+            }
+            outliers <- outliers[!is.na(outliers)]
+            lo <- row[[stat_cols[["min"]]]][1]
+            hi <- row[[stat_cols[["max"]]]][1]
+            list(
+              min = lo,
+              q1 = row[[stat_cols[["q1"]]]][1],
+              q2 = row[[stat_cols[["q2"]]]][1],
+              q3 = row[[stat_cols[["q3"]]]][1],
+              max = hi,
+              lower_outliers = sort(outliers[outliers < lo]),
+              upper_outliers = sort(outliers[outliers > hi])
+            )
+          } else {
+            NULL
+          }
         } else {
-          as.character(cat_pos)
+          NULL
         }
 
-        # Get values for this group from original data. Column-first
-        # indexing: df[filter, col] on a tibble returns a 1-column tibble
-        # that as.numeric() cannot coerce.
-        if (!is.null(cat_var) && !is.null(val_var) &&
-              cat_var %in% names(original_data) &&
-              val_var %in% names(original_data)) {
-          group_vals <- original_data[[val_var]][
-            as.character(original_data[[cat_var]]) == fill_label
-          ]
-          group_vals <- as.numeric(group_vals)
-          group_vals <- group_vals[!is.na(group_vals)]
-        } else {
+        if (is.null(summary)) {
+          # Nothing authoritative for this group. Report the violin's own
+          # drawn extent and leave the quartiles at its midpoint rather than
+          # inventing numbers that look like quartiles but are not.
           rows <- layer_data[layer_data$group == g, ]
-          group_vals <- rows[[val_col]]
+          vals <- suppressWarnings(as.numeric(rows[[val_col]]))
+          vals <- vals[!is.na(vals)]
+          if (length(vals) == 0) {
+            vals <- 0
+          }
+          mid <- stats::median(vals)
+          summary <- list(
+            min = min(vals), q1 = mid, q2 = mid, q3 = mid, max = max(vals),
+            lower_outliers = numeric(0), upper_outliers = numeric(0)
+          )
         }
-
-        if (length(group_vals) == 0) {
-          group_vals <- 0
-        }
-
-        qs <- stats::quantile(group_vals, probs = c(0, 0.25, 0.5, 0.75, 1))
-
-        # Compute IQR-based whiskers (Tukey fences)
-        iqr <- qs[[4]] - qs[[2]]
-        lower_fence <- qs[[2]] - 1.5 * iqr
-        upper_fence <- qs[[4]] + 1.5 * iqr
-        whisker_min <- min(group_vals[group_vals >= lower_fence])
-        whisker_max <- max(group_vals[group_vals <= upper_fence])
-
-        lower_outliers <- as.list(sort(group_vals[group_vals < lower_fence]))
-        upper_outliers <- as.list(sort(group_vals[group_vals > upper_fence]))
 
         box_data[[i]] <- list(
-          z = fill_label,
-          lowerOutliers = lower_outliers,
-          min = unname(whisker_min),
-          q1 = unname(qs[[2]]),
-          q2 = unname(qs[[3]]),
-          q3 = unname(qs[[4]]),
-          max = unname(whisker_max),
-          upperOutliers = upper_outliers
+          z = labels[i],
+          lowerOutliers = as.list(unname(summary$lower_outliers)),
+          min = unname(summary$min),
+          q1 = unname(summary$q1),
+          q2 = unname(summary$q2),
+          q3 = unname(summary$q3),
+          max = unname(summary$max),
+          upperOutliers = as.list(unname(summary$upper_outliers))
         )
       }
 
@@ -297,37 +319,19 @@ Ggplot2ViolinLayerProcessor <- R6::R6Class(
       layer_data <- built$data[[layer_index]]
       is_horizontal <- isTRUE(layer_data$flipped_aes[1])
 
-      panel_params <- built$layout$panel_params[[1]]
-      category_labels <- self$get_category_labels(
-        panel_params, is_horizontal
-      )
-
-      cat_col <- if (is_horizontal) "y" else "x"
-      val_col <- if (is_horizontal) "x" else "y"
-
       groups <- unique(layer_data$group)
-      group_cat_positions <- vapply(groups, function(g) {
-        rows <- layer_data[layer_data$group == g, ]
-        rows[[cat_col]][1]
-      }, numeric(1))
+      # Same labelling as the box layer: the two describe the same violins and
+      # must announce them under the same names.
+      labels <- self$group_labels(built, layer_data, groups, is_horizontal)
 
       kde_data <- vector("list", length(groups))
 
       for (i in seq_along(groups)) {
         g <- groups[i]
         rows <- layer_data[layer_data$group == g, ]
-        cat_pos <- group_cat_positions[i]
-
-        idx <- suppressWarnings(as.integer(round(cat_pos)))
-        cat_label <- if (!is.na(idx) && idx >= 1 &&
-              idx <= length(category_labels)) {
-          as.character(category_labels[idx])
-        } else {
-          as.character(cat_pos)
-        }
 
         kde_data[[i]] <- self$simplify_violin_kde(
-          rows, cat_label, is_horizontal, max_kde_points
+          rows, labels[i], is_horizontal, max_kde_points
         )
       }
 
@@ -720,6 +724,140 @@ Ggplot2ViolinLayerProcessor <- R6::R6Class(
         return(as.character(pp_axis$breaks))
       }
       character(0)
+    },
+
+    #' @description Break labels of whichever panel axis holds the categories
+    #'
+    #' The categorical axis is the discrete one, which is not always the axis
+    #' the data is keyed on: `coord_flip()` leaves the data x-major while
+    #' moving the category labels to the y axis, so reading the axis off
+    #' `flipped_aes` alone returns the value axis' breaks and every violin is
+    #' labelled with a number.
+    #'
+    #' @param built Built plot data
+    #' @return Character vector of labels, or NULL when neither axis is
+    #'   discrete (a continuous category axis carries its value directly)
+    discrete_axis_labels = function(built) {
+      panel_params <- built$layout$panel_params[[1]]
+      for (axis_name in c("x", "y")) {
+        pp_axis <- panel_params[[axis_name]]
+        if (is.null(pp_axis)) {
+          next
+        }
+        is_discrete <- tryCatch(
+          isTRUE(pp_axis$is_discrete()),
+          error = function(e) FALSE
+        )
+        if (!is_discrete) {
+          next
+        }
+        labels <- tryCatch(pp_axis$get_labels(), error = function(e) NULL)
+        if (is.null(labels) || length(labels) == 0) {
+          labels <- pp_axis$labels
+        }
+        if (!is.null(labels) && length(labels) > 0) {
+          return(as.character(labels))
+        }
+      }
+      NULL
+    },
+
+    #' @description Map each mapped fill colour back to the level it came from
+    #'
+    #' Dodging splits one category into several violins that differ only by
+    #' fill, and they all round to the same category position. Without the
+    #' level, they are announced under one repeated name and cannot be told
+    #' apart.
+    #'
+    #' @param built Built plot data
+    #' @return Named character vector (colour -> level), or NULL when the plot
+    #'   has no fill scale
+    fill_levels_by_colour = function(built) {
+      scale <- tryCatch(
+        built$plot$scales$get_scales("fill"),
+        error = function(e) NULL
+      )
+      if (is.null(scale)) {
+        return(NULL)
+      }
+      levels <- tryCatch(scale$get_limits(), error = function(e) NULL)
+      if (is.null(levels) || length(levels) == 0) {
+        return(NULL)
+      }
+      colours <- tryCatch(scale$map(levels), error = function(e) NULL)
+      if (is.null(colours) || length(colours) != length(levels)) {
+        return(NULL)
+      }
+      stats::setNames(as.character(levels), as.character(colours))
+    },
+
+    #' @description Announceable label for each drawn violin
+    #'
+    #' @param built Built plot data
+    #' @param layer_data Built data for the violin layer
+    #' @param groups The layer's group ids, in emission order
+    #' @param is_horizontal Whether the value axis is x
+    #' @return Character vector of labels, one per group
+    group_labels = function(built, layer_data, groups, is_horizontal) {
+      category_labels <- self$discrete_axis_labels(built)
+      fill_levels <- self$fill_levels_by_colour(built)
+      cat_col <- if (is_horizontal) "y" else "x"
+
+      vapply(groups, function(g) {
+        rows <- layer_data[layer_data$group == g, ]
+        position <- rows[[cat_col]][1]
+
+        label <- if (!is.null(category_labels)) {
+          idx <- suppressWarnings(as.integer(round(position)))
+          if (!is.na(idx) && idx >= 1 && idx <= length(category_labels)) {
+            as.character(category_labels[idx])
+          } else {
+            as.character(position)
+          }
+        } else {
+          # Continuous category axis: the position IS the value, so indexing
+          # break labels with it would read off an unrelated tick.
+          format(position, trim = TRUE)
+        }
+
+        # Only qualify when dodging actually put more than one level on the
+        # axis, so an undodged violin keeps its plain category name.
+        if (!is.null(fill_levels) && length(fill_levels) > 1) {
+          colour <- as.character(rows$fill[1])
+          if (!is.na(colour) && colour %in% names(fill_levels)) {
+            label <- paste0(label, " - ", fill_levels[[colour]])
+          }
+        }
+        label
+      }, character(1), USE.NAMES = FALSE)
+    },
+
+    #' @description Box statistics ggplot2 itself computed for each group
+    #'
+    #' The processor injects a `geom_boxplot()` so the SVG has box elements to
+    #' highlight; that layer's `stat_boxplot` output is also the authoritative
+    #' source for the numbers to announce. Reading it keyed by `group` avoids
+    #' re-deriving quartiles from the original data via a rounded axis
+    #' position and a string match on the break label -- a round trip that
+    #' silently mislabels dodged violins and finds nothing at all under
+    #' `coord_flip()`.
+    #'
+    #' @param plot The ggplot2 object
+    #' @param built Built plot data
+    #' @return data.frame of the boxplot layer's built data, or NULL
+    boxplot_stats = function(plot, built) {
+      idx <- self$find_boxplot_layer_index(plot)
+      if (is.null(idx) || idx > length(built$data)) {
+        return(NULL)
+      }
+      stats <- built$data[[idx]]
+      if (!is.data.frame(stats) || nrow(stats) == 0) {
+        return(NULL)
+      }
+      if (!"group" %in% names(stats)) {
+        return(NULL)
+      }
+      stats
     },
 
     #' @description Find the boxplot layer index in the augmented plot

--- a/R/ggplot2_violin_layer_processor.R
+++ b/R/ggplot2_violin_layer_processor.R
@@ -32,12 +32,17 @@ Ggplot2ViolinLayerProcessor <- R6::R6Class(
       }, logical(1)))
 
       if (!has_boxplot) {
-        # Never set an aesthetic the violin maps. ggplot2 derives `group` from
-        # the discrete aesthetics a layer actually carries, so pinning
-        # `fill = "white"` over an `aes(fill = ...)` drops fill from the box's
-        # grouping: a violin dodged into 12 groups gets 7 boxes, and reading
-        # statistics or selectors back by group pairs them with the wrong
-        # violins. Inheriting the aesthetic keeps the two layers in step.
+        # The box has to group exactly like the violin. ggplot2 derives
+        # `group` from the discrete aesthetics a layer carries, so a violin
+        # dodged into 12 groups whose box only sees 7 pairs statistics and
+        # selectors with the wrong violins.
+        #
+        # Two ways to lose that. Pinning `fill = "white"` over an
+        # `aes(fill = ...)` drops fill from the box's grouping, so only set a
+        # default the violin does not map. And `inherit.aes` carries the PLOT
+        # mapping only, never another layer's own `aes()` -- so a violin that
+        # maps fill on itself, `geom_violin(aes(fill = drv))`, leaves the box
+        # with nothing to dodge by. Pass the merged mapping explicitly.
         mapping <- tryCatch(
           self$get_effective_mapping(plot),
           error = function(e) list()
@@ -53,6 +58,11 @@ Ggplot2ViolinLayerProcessor <- R6::R6Class(
           # its own violin if it dodges across the violin's width.
           position = ggplot2::position_dodge(width = 0.9)
         )
+        if (length(mapped) > 0) {
+          # Carry whatever class this ggplot2 gives an aes() object; the
+          # merged list is otherwise just a list of quosures.
+          args$mapping <- structure(mapping, class = class(ggplot2::aes()))
+        }
         if (!"fill" %in% mapped) {
           args$fill <- "white"
         }
@@ -697,14 +707,35 @@ Ggplot2ViolinLayerProcessor <- R6::R6Class(
       "vert"
     },
 
-    #' Get the effective mapping (layer mapping merged with plot mapping)
+    #' @description The violin layer's mapping merged with the plot's
+    #'
+    #' Built in ggplot2's own order -- the layer's own aesthetics first, then
+    #' whatever only the plot maps -- because the order is not cosmetic.
+    #' ggplot2 numbers `group` from the interaction of a layer's discrete
+    #' columns taken in the order the mapping produced them, so a mapping
+    #' assembled the other way round gives the injected box different group
+    #' ids than the violin, and every lookup keyed on `group` then crosses
+    #' the two layers.
+    #'
+    #' @param plot The ggplot2 object
+    #' @return Named list of quosures, one per mapped aesthetic
     get_effective_mapping = function(plot) {
       layer_index <- self$get_layer_index()
       layer_mapping <- plot$layers[[layer_index]]$mapping
       plot_mapping <- plot$mapping
-      modifyList(
-        if (is.null(plot_mapping)) list() else as.list(plot_mapping),
-        if (is.null(layer_mapping)) list() else as.list(layer_mapping)
+      layer_mapping <- if (is.null(layer_mapping)) {
+        list()
+      } else {
+        as.list(layer_mapping)
+      }
+      plot_mapping <- if (is.null(plot_mapping)) {
+        list()
+      } else {
+        as.list(plot_mapping)
+      }
+      c(
+        layer_mapping,
+        plot_mapping[setdiff(names(plot_mapping), names(layer_mapping))]
       )
     },
 

--- a/R/ggplot2_violin_layer_processor.R
+++ b/R/ggplot2_violin_layer_processor.R
@@ -376,10 +376,14 @@ Ggplot2ViolinLayerProcessor <- R6::R6Class(
       left_x <- left_x[valid]
       right_x <- right_x[valid]
       widths_data <- widths_data[valid]
-      # Give zero-width tips a tiny positive width so they survive.
-      # `geom_violin(width = 0)` makes EVERY width zero, leaving nothing
-      # positive to scale from -- min() of an empty vector is Inf, and the
-      # comparison below is then NA, which aborts the whole render.
+      # Widen the zero-width tips of an otherwise normal violin, scaling the
+      # nudge from the narrowest real width so it stays proportionate.
+      #
+      # `geom_violin(width = 0)` has no real width to scale from: every width
+      # is zero, so this vector is empty, min() returns Inf with a warning and
+      # the comparison below is NA, which aborts the render. Skip widening
+      # entirely in that case -- a violin with no envelope has nothing to
+      # widen, and the extrema kept above are exactly what ggplot2 draws.
       positive_widths <- widths_data[widths_data > 0]
       if (any(widths_data <= 0) && length(positive_widths) > 0) {
         min_w <- min(positive_widths, na.rm = TRUE)

--- a/R/ggplot2_violin_layer_processor.R
+++ b/R/ggplot2_violin_layer_processor.R
@@ -376,9 +376,13 @@ Ggplot2ViolinLayerProcessor <- R6::R6Class(
       left_x <- left_x[valid]
       right_x <- right_x[valid]
       widths_data <- widths_data[valid]
-      # Give zero-width tips a tiny positive width so they survive
-      if (any(widths_data <= 0)) {
-        min_w <- min(widths_data[widths_data > 0], na.rm = TRUE)
+      # Give zero-width tips a tiny positive width so they survive.
+      # `geom_violin(width = 0)` makes EVERY width zero, leaving nothing
+      # positive to scale from -- min() of an empty vector is Inf, and the
+      # comparison below is then NA, which aborts the whole render.
+      positive_widths <- widths_data[widths_data > 0]
+      if (any(widths_data <= 0) && length(positive_widths) > 0) {
+        min_w <- min(positive_widths, na.rm = TRUE)
         widths_data[widths_data <= 0] <- min_w * 0.01
         # Also adjust left/right edges for the tip points
         tiny_hw <- min_w * 0.01 / 2

--- a/R/ggplot2_violin_layer_processor.R
+++ b/R/ggplot2_violin_layer_processor.R
@@ -739,32 +739,6 @@ Ggplot2ViolinLayerProcessor <- R6::R6Class(
       )
     },
 
-    #' Get original data used by this layer
-    get_original_data = function(plot) {
-      layer_index <- self$get_layer_index()
-      layer <- plot$layers[[layer_index]]
-      if (!is.null(layer$data) && is.data.frame(layer$data) &&
-            nrow(layer$data) > 0) {
-        return(layer$data)
-      }
-      if (is.data.frame(plot$data)) {
-        return(plot$data)
-      }
-      data.frame()
-    },
-
-    #' Get category labels from panel params
-    get_category_labels = function(panel_params, is_horizontal) {
-      pp_axis <- if (is_horizontal) panel_params$y else panel_params$x
-      if (!is.null(pp_axis$labels) && length(pp_axis$labels) > 0) {
-        return(as.character(pp_axis$labels))
-      }
-      if (!is.null(pp_axis$breaks) && length(pp_axis$breaks) > 0) {
-        return(as.character(pp_axis$breaks))
-      }
-      character(0)
-    },
-
     #' @description Break labels of whichever panel axis holds the categories
     #'
     #' The categorical axis is the discrete one, which is not always the axis

--- a/man/Ggplot2ViolinLayerProcessor.Rd
+++ b/man/Ggplot2ViolinLayerProcessor.Rd
@@ -309,9 +309,6 @@ iq, q2, max, lowerOutliers, upperOutliers.
 \subsection{Returns}{
 List of BoxSelector objects
 Determine orientation from built data
-Get the effective mapping (layer mapping merged with plot mapping)
-Get original data used by this layer
-Get category labels from panel params
 }
 }
 \if{html}{\out{<hr>}}
@@ -327,10 +324,31 @@ Get category labels from panel params
 \if{html}{\out{<a id="method-Ggplot2ViolinLayerProcessor-get_effective_mapping"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2ViolinLayerProcessor-get_effective_mapping}{}}}
 \subsection{Method \code{get_effective_mapping()}}{
+The violin layer's mapping merged with the plot's
+
+Built in ggplot2's own order -- the layer's own aesthetics first, then
+whatever only the plot maps -- because the order is not cosmetic.
+ggplot2 numbers `group` from the interaction of a layer's discrete
+columns taken in the order the mapping produced them, so a mapping
+assembled the other way round gives the injected box different group
+ids than the violin, and every lookup keyed on `group` then crosses
+the two layers.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Ggplot2ViolinLayerProcessor$get_effective_mapping(plot)}\if{html}{\out{</div>}}
 }
 
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{plot}}{The ggplot2 object}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+Named list of quosures, one per mapped aesthetic
+Get original data used by this layer
+Get category labels from panel params
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Ggplot2ViolinLayerProcessor-get_original_data"></a>}}

--- a/man/Ggplot2ViolinLayerProcessor.Rd
+++ b/man/Ggplot2ViolinLayerProcessor.Rd
@@ -37,6 +37,10 @@ CSS selectors can drive the violin_box highlight in the maidr frontend.
 \item \href{#method-Ggplot2ViolinLayerProcessor-get_effective_mapping}{\code{Ggplot2ViolinLayerProcessor$get_effective_mapping()}}
 \item \href{#method-Ggplot2ViolinLayerProcessor-get_original_data}{\code{Ggplot2ViolinLayerProcessor$get_original_data()}}
 \item \href{#method-Ggplot2ViolinLayerProcessor-get_category_labels}{\code{Ggplot2ViolinLayerProcessor$get_category_labels()}}
+\item \href{#method-Ggplot2ViolinLayerProcessor-discrete_axis_labels}{\code{Ggplot2ViolinLayerProcessor$discrete_axis_labels()}}
+\item \href{#method-Ggplot2ViolinLayerProcessor-fill_levels_by_colour}{\code{Ggplot2ViolinLayerProcessor$fill_levels_by_colour()}}
+\item \href{#method-Ggplot2ViolinLayerProcessor-group_labels}{\code{Ggplot2ViolinLayerProcessor$group_labels()}}
+\item \href{#method-Ggplot2ViolinLayerProcessor-boxplot_stats}{\code{Ggplot2ViolinLayerProcessor$boxplot_stats()}}
 \item \href{#method-Ggplot2ViolinLayerProcessor-find_boxplot_layer_index}{\code{Ggplot2ViolinLayerProcessor$find_boxplot_layer_index()}}
 \item \href{#method-Ggplot2ViolinLayerProcessor-find_panel_grob}{\code{Ggplot2ViolinLayerProcessor$find_panel_grob()}}
 \item \href{#method-Ggplot2ViolinLayerProcessor-find_grob_ids}{\code{Ggplot2ViolinLayerProcessor$find_grob_ids()}}
@@ -345,6 +349,120 @@ Get category labels from panel params
 \if{html}{\out{<div class="r">}}\preformatted{Ggplot2ViolinLayerProcessor$get_category_labels(panel_params, is_horizontal)}\if{html}{\out{</div>}}
 }
 
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Ggplot2ViolinLayerProcessor-discrete_axis_labels"></a>}}
+\if{latex}{\out{\hypertarget{method-Ggplot2ViolinLayerProcessor-discrete_axis_labels}{}}}
+\subsection{Method \code{discrete_axis_labels()}}{
+Break labels of whichever panel axis holds the categories
+
+The categorical axis is the discrete one, which is not always the axis
+the data is keyed on: `coord_flip()` leaves the data x-major while
+moving the category labels to the y axis, so reading the axis off
+`flipped_aes` alone returns the value axis' breaks and every violin is
+labelled with a number.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Ggplot2ViolinLayerProcessor$discrete_axis_labels(built)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{built}}{Built plot data}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+Character vector of labels, or NULL when neither axis is
+  discrete (a continuous category axis carries its value directly)
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Ggplot2ViolinLayerProcessor-fill_levels_by_colour"></a>}}
+\if{latex}{\out{\hypertarget{method-Ggplot2ViolinLayerProcessor-fill_levels_by_colour}{}}}
+\subsection{Method \code{fill_levels_by_colour()}}{
+Map each mapped fill colour back to the level it came from
+
+Dodging splits one category into several violins that differ only by
+fill, and they all round to the same category position. Without the
+level, they are announced under one repeated name and cannot be told
+apart.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Ggplot2ViolinLayerProcessor$fill_levels_by_colour(built)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{built}}{Built plot data}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+Named character vector (colour -> level), or NULL when the plot
+  has no fill scale
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Ggplot2ViolinLayerProcessor-group_labels"></a>}}
+\if{latex}{\out{\hypertarget{method-Ggplot2ViolinLayerProcessor-group_labels}{}}}
+\subsection{Method \code{group_labels()}}{
+Announceable label for each drawn violin
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Ggplot2ViolinLayerProcessor$group_labels(
+  built,
+  layer_data,
+  groups,
+  is_horizontal
+)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{built}}{Built plot data}
+
+\item{\code{layer_data}}{Built data for the violin layer}
+
+\item{\code{groups}}{The layer's group ids, in emission order}
+
+\item{\code{is_horizontal}}{Whether the value axis is x}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+Character vector of labels, one per group
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Ggplot2ViolinLayerProcessor-boxplot_stats"></a>}}
+\if{latex}{\out{\hypertarget{method-Ggplot2ViolinLayerProcessor-boxplot_stats}{}}}
+\subsection{Method \code{boxplot_stats()}}{
+Box statistics ggplot2 itself computed for each group
+
+The processor injects a `geom_boxplot()` so the SVG has box elements to
+highlight; that layer's `stat_boxplot` output is also the authoritative
+source for the numbers to announce. Reading it keyed by `group` avoids
+re-deriving quartiles from the original data via a rounded axis
+position and a string match on the break label -- a round trip that
+silently mislabels dodged violins and finds nothing at all under
+`coord_flip()`.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Ggplot2ViolinLayerProcessor$boxplot_stats(plot, built)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{plot}}{The ggplot2 object}
+
+\item{\code{built}}{Built plot data}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+data.frame of the boxplot layer's built data, or NULL
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Ggplot2ViolinLayerProcessor-find_boxplot_layer_index"></a>}}

--- a/man/Ggplot2ViolinLayerProcessor.Rd
+++ b/man/Ggplot2ViolinLayerProcessor.Rd
@@ -35,8 +35,6 @@ CSS selectors can drive the violin_box highlight in the maidr frontend.
 \item \href{#method-Ggplot2ViolinLayerProcessor-generate_box_selectors}{\code{Ggplot2ViolinLayerProcessor$generate_box_selectors()}}
 \item \href{#method-Ggplot2ViolinLayerProcessor-determine_orientation}{\code{Ggplot2ViolinLayerProcessor$determine_orientation()}}
 \item \href{#method-Ggplot2ViolinLayerProcessor-get_effective_mapping}{\code{Ggplot2ViolinLayerProcessor$get_effective_mapping()}}
-\item \href{#method-Ggplot2ViolinLayerProcessor-get_original_data}{\code{Ggplot2ViolinLayerProcessor$get_original_data()}}
-\item \href{#method-Ggplot2ViolinLayerProcessor-get_category_labels}{\code{Ggplot2ViolinLayerProcessor$get_category_labels()}}
 \item \href{#method-Ggplot2ViolinLayerProcessor-discrete_axis_labels}{\code{Ggplot2ViolinLayerProcessor$discrete_axis_labels()}}
 \item \href{#method-Ggplot2ViolinLayerProcessor-fill_levels_by_colour}{\code{Ggplot2ViolinLayerProcessor$fill_levels_by_colour()}}
 \item \href{#method-Ggplot2ViolinLayerProcessor-group_labels}{\code{Ggplot2ViolinLayerProcessor$group_labels()}}
@@ -346,27 +344,7 @@ the two layers.
 }
 \subsection{Returns}{
 Named list of quosures, one per mapped aesthetic
-Get original data used by this layer
-Get category labels from panel params
 }
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Ggplot2ViolinLayerProcessor-get_original_data"></a>}}
-\if{latex}{\out{\hypertarget{method-Ggplot2ViolinLayerProcessor-get_original_data}{}}}
-\subsection{Method \code{get_original_data()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Ggplot2ViolinLayerProcessor$get_original_data(plot)}\if{html}{\out{</div>}}
-}
-
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Ggplot2ViolinLayerProcessor-get_category_labels"></a>}}
-\if{latex}{\out{\hypertarget{method-Ggplot2ViolinLayerProcessor-get_category_labels}{}}}
-\subsection{Method \code{get_category_labels()}}{
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Ggplot2ViolinLayerProcessor$get_category_labels(panel_params, is_horizontal)}\if{html}{\out{</div>}}
-}
-
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Ggplot2ViolinLayerProcessor-discrete_axis_labels"></a>}}

--- a/tests/testthat/test-ggplot2-violin-layer-processor.R
+++ b/tests/testthat/test-ggplot2-violin-layer-processor.R
@@ -581,6 +581,61 @@ test_that("dodged violins get their own statistics, not the whole category's", {
   testthat::expect_false(isTRUE(all.equal(q4, qf)))
 })
 
+test_that("a violin that maps fill on itself dodges its box the same way", {
+  testthat::skip_if_not_installed("ggplot2")
+
+  # `inherit.aes` carries the PLOT mapping only, never another layer's own
+  # aes(), so a box left to inherit gets no fill here and collapses to one
+  # undodged box per class while the violin dodges into twelve.
+  box_data <- violin_box_payload(
+    ggplot2::ggplot(ggplot2::mpg, ggplot2::aes(class, hwy)) +
+      ggplot2::geom_violin(ggplot2::aes(fill = drv))
+  )
+
+  testthat::expect_equal(length(box_data), 12)
+  labels <- vapply(box_data, function(d) as.character(d$z), character(1))
+  testthat::expect_equal(anyDuplicated(labels), 0)
+
+  compact4 <- ggplot2::mpg$hwy[ggplot2::mpg$class == "compact" & ggplot2::mpg$drv == "4"]
+  suvr <- ggplot2::mpg$hwy[ggplot2::mpg$class == "suv" & ggplot2::mpg$drv == "r"]
+  q4 <- unname(stats::quantile(compact4, c(0.25, 0.5, 0.75)))
+  qs <- unname(stats::quantile(suvr, c(0.25, 0.5, 0.75)))
+
+  expect_group_quartiles(box_data, "compact - 4", q4[1], q4[2], q4[3])
+  expect_group_quartiles(box_data, "suv - r", qs[1], qs[2], qs[3])
+})
+
+test_that("the injected box carries the violin's own group ids", {
+  testthat::skip_if_not_installed("ggplot2")
+
+  # Statistics and selectors are both looked up by `group`, and ggplot2
+  # numbers groups from the interaction of a layer's discrete columns in
+  # mapping order. Build the box's mapping in a different order and the same
+  # id means a different violin -- silently, with plausible numbers.
+  processor <- Ggplot2ViolinLayerProcessor$new(list(index = 1, type = "violin"))
+  plot <- ggplot2::ggplot(ggplot2::mpg, ggplot2::aes(class, hwy)) +
+    ggplot2::geom_violin(ggplot2::aes(fill = drv))
+  built <- ggplot2::ggplot_build(processor$augment_plot(plot))
+
+  key <- function(d) {
+    first <- !duplicated(d$group)
+    out <- data.frame(
+      group = d$group[first],
+      x = round(d$x[first], 2),
+      fill = as.character(d$fill[first]),
+      stringsAsFactors = FALSE
+    )
+    out[order(out$group), ]
+  }
+  violin <- key(built$data[[1]])
+  box <- key(built$data[[2]])
+
+  testthat::expect_equal(nrow(violin), 12)
+  testthat::expect_equal(box$group, violin$group)
+  testthat::expect_equal(box$fill, violin$fill)
+  testthat::expect_equal(box$x, violin$x)
+})
+
 test_that("coord_flip violins are labelled with categories, not axis breaks", {
   testthat::skip_if_not_installed("ggplot2")
 

--- a/tests/testthat/test-ggplot2-violin-layer-processor.R
+++ b/tests/testthat/test-ggplot2-violin-layer-processor.R
@@ -532,3 +532,149 @@ test_that("the kde layer records which panel its ranges came from", {
   testthat::expect_null(single$layers[[2]]$.panel_index)
   testthat::expect_null(single$layers[[2]]$.panel_name)
 })
+
+# ==============================================================================
+# Box statistics and category labels (issue #65)
+# ==============================================================================
+
+# The numbers a screen reader announces must be the numbers on screen, so each
+# case is checked against quartiles computed independently from the raw data.
+violin_box_payload <- function(plot) {
+  processor <- Ggplot2ViolinLayerProcessor$new(list(index = 1, type = "violin"))
+  augmented <- processor$augment_plot(plot)
+  built <- ggplot2::ggplot_build(augmented)
+  processor$extract_box_data(augmented, built)
+}
+
+expect_group_quartiles <- function(box_data, key, q1, q2, q3) {
+  labels <- vapply(box_data, function(d) as.character(d$z), character(1))
+  idx <- which(labels == key)
+  testthat::expect_length(idx, 1)
+  entry <- box_data[[idx]]
+  testthat::expect_equal(entry$q1, q1)
+  testthat::expect_equal(entry$q2, q2)
+  testthat::expect_equal(entry$q3, q3)
+}
+
+test_that("dodged violins get their own statistics, not the whole category's", {
+  testthat::skip_if_not_installed("ggplot2")
+
+  box_data <- violin_box_payload(
+    ggplot2::ggplot(ggplot2::mpg, ggplot2::aes(class, hwy, fill = drv)) +
+      ggplot2::geom_violin()
+  )
+
+  # One entry per drawn violin, each separately identifiable
+  testthat::expect_equal(length(box_data), 12)
+  labels <- vapply(box_data, function(d) as.character(d$z), character(1))
+  testthat::expect_equal(anyDuplicated(labels), 0)
+
+  # compact/4 and compact/f are different distributions and must not share
+  # the category-wide numbers
+  compact4 <- ggplot2::mpg$hwy[ggplot2::mpg$class == "compact" & ggplot2::mpg$drv == "4"]
+  compactf <- ggplot2::mpg$hwy[ggplot2::mpg$class == "compact" & ggplot2::mpg$drv == "f"]
+  q4 <- unname(stats::quantile(compact4, c(0.25, 0.5, 0.75)))
+  qf <- unname(stats::quantile(compactf, c(0.25, 0.5, 0.75)))
+
+  expect_group_quartiles(box_data, "compact - 4", q4[1], q4[2], q4[3])
+  expect_group_quartiles(box_data, "compact - f", qf[1], qf[2], qf[3])
+  testthat::expect_false(isTRUE(all.equal(q4, qf)))
+})
+
+test_that("coord_flip violins are labelled with categories, not axis breaks", {
+  testthat::skip_if_not_installed("ggplot2")
+
+  box_data <- violin_box_payload(
+    ggplot2::ggplot(ggplot2::mpg, ggplot2::aes(class, hwy)) +
+      ggplot2::geom_violin() +
+      ggplot2::coord_flip()
+  )
+
+  labels <- vapply(box_data, function(d) as.character(d$z), character(1))
+  testthat::expect_equal(sort(labels), sort(levels(factor(ggplot2::mpg$class))))
+
+  # Previously every group fell back to a value of 0
+  minivan <- ggplot2::mpg$hwy[ggplot2::mpg$class == "minivan"]
+  q <- unname(stats::quantile(minivan, c(0.25, 0.5, 0.75)))
+  expect_group_quartiles(box_data, "minivan", q[1], q[2], q[3])
+})
+
+test_that("a continuous category axis labels groups with their own value", {
+  testthat::skip_if_not_installed("ggplot2")
+
+  box_data <- violin_box_payload(
+    ggplot2::ggplot(ggplot2::mpg, ggplot2::aes(cyl, hwy, group = cyl)) +
+      ggplot2::geom_violin()
+  )
+
+  labels <- vapply(box_data, function(d) as.character(d$z), character(1))
+  # The cylinder counts that exist -- not positions in the axis break list
+  testthat::expect_equal(sort(labels), c("4", "5", "6", "8"))
+
+  six <- ggplot2::mpg$hwy[ggplot2::mpg$cyl == 6]
+  q <- unname(stats::quantile(six, c(0.25, 0.5, 0.75)))
+  expect_group_quartiles(box_data, "6", q[1], q[2], q[3])
+})
+
+test_that("plain and horizontal violins keep their existing labels", {
+  testthat::skip_if_not_installed("ggplot2")
+
+  classes <- sort(levels(factor(ggplot2::mpg$class)))
+  for (plot in list(
+    ggplot2::ggplot(ggplot2::mpg, ggplot2::aes(class, hwy)) + ggplot2::geom_violin(),
+    ggplot2::ggplot(ggplot2::mpg, ggplot2::aes(hwy, class)) + ggplot2::geom_violin()
+  )) {
+    box_data <- violin_box_payload(plot)
+    labels <- vapply(box_data, function(d) as.character(d$z), character(1))
+    testthat::expect_equal(sort(labels), classes)
+
+    suv <- ggplot2::mpg$hwy[ggplot2::mpg$class == "suv"]
+    q <- unname(stats::quantile(suv, c(0.25, 0.5, 0.75)))
+    expect_group_quartiles(box_data, "suv", q[1], q[2], q[3])
+  }
+})
+
+test_that("augmentation never overrides an aesthetic the violin maps", {
+  testthat::skip_if_not_installed("ggplot2")
+
+  processor <- Ggplot2ViolinLayerProcessor$new(list(index = 1, type = "violin"))
+
+  # Pinning fill would drop it from the box's grouping, so a dodged violin
+  # would get fewer boxes than violins and they would pair up wrongly.
+  dodged <- processor$augment_plot(
+    ggplot2::ggplot(ggplot2::mpg, ggplot2::aes(class, hwy, fill = drv)) +
+      ggplot2::geom_violin()
+  )
+  built <- ggplot2::ggplot_build(dodged)
+  testthat::expect_equal(
+    length(unique(built$data[[1]]$group)),
+    length(unique(built$data[[2]]$group))
+  )
+
+  # With no fill mapped, the box keeps its white fill
+  plain <- processor$augment_plot(
+    ggplot2::ggplot(ggplot2::mpg, ggplot2::aes(class, hwy)) + ggplot2::geom_violin()
+  )
+  testthat::expect_equal(plain$layers[[2]]$aes_params$fill, "white")
+})
+
+test_that("box and kde layers announce the same group names", {
+  testthat::skip_if_not_installed("ggplot2")
+
+  processor <- Ggplot2ViolinLayerProcessor$new(list(index = 1, type = "violin"))
+  augmented <- processor$augment_plot(
+    ggplot2::ggplot(ggplot2::mpg, ggplot2::aes(class, hwy, fill = drv)) +
+      ggplot2::geom_violin()
+  )
+  built <- ggplot2::ggplot_build(augmented)
+
+  box_labels <- vapply(
+    processor$extract_box_data(augmented, built),
+    function(d) as.character(d$z), character(1)
+  )
+  kde_labels <- vapply(
+    processor$extract_kde_data(augmented, built),
+    function(points) as.character(points[[1]]$x), character(1)
+  )
+  testthat::expect_equal(kde_labels, box_labels)
+})

--- a/tests/testthat/test-violin-patchwork.R
+++ b/tests/testthat/test-violin-patchwork.R
@@ -419,9 +419,7 @@ test_that("a leaf a processor cannot handle does not abort the composition", {
     add = TRUE
   )
 
-  expect_no_error({
-    payload <- render_payload_uncached(violin_plot() | bar_plot())
-  })
+  payload <- expect_no_error(render_payload_uncached(violin_plot() | bar_plot()))
   # The healthy leaf is still described; only the failing one goes quiet.
   expect_equal(layer_types(payload$data$subplots[[1]][[2]]), "bar")
   expect_length(payload$data$subplots[[1]][[1]]$layers, 0)
@@ -437,9 +435,7 @@ test_that("a degenerate violin renders instead of aborting", {
     ggplot2::geom_violin(width = 0)
 
   expect_no_error(render_payload_uncached(degenerate))
-  expect_no_error({
-    payload <- render_payload_uncached(degenerate | bar_plot())
-  })
+  payload <- expect_no_error(render_payload_uncached(degenerate | bar_plot()))
   expect_equal(layer_types(payload$data$subplots[[1]][[2]]), "bar")
 })
 

--- a/tests/testthat/test-violin-patchwork.R
+++ b/tests/testthat/test-violin-patchwork.R
@@ -403,16 +403,44 @@ test_that("a faceted sibling does not cost the other plot its selectors", {
 test_that("a leaf a processor cannot handle does not abort the composition", {
   skip_if_no_patchwork()
 
-  # geom_violin(width = 0) errors inside the violin processor; the rest of
-  # the figure must still render and describe itself.
+  # Force the violin processor to fail for this render only. `width = 0` used
+  # to be a natural trigger; now that it is fixed, the isolation guarantee
+  # still needs exercising, so make the failure explicitly.
+  original <- Ggplot2ViolinLayerProcessor$public_methods$process
+  Ggplot2ViolinLayerProcessor$set(
+    "public", "process",
+    function(...) stop("processor blew up"),
+    overwrite = TRUE
+  )
+  on.exit(
+    Ggplot2ViolinLayerProcessor$set(
+      "public", "process", original, overwrite = TRUE
+    ),
+    add = TRUE
+  )
+
+  expect_no_error({
+    payload <- render_payload_uncached(violin_plot() | bar_plot())
+  })
+  # The healthy leaf is still described; only the failing one goes quiet.
+  expect_equal(layer_types(payload$data$subplots[[1]][[2]]), "bar")
+  expect_length(payload$data$subplots[[1]][[1]]$layers, 0)
+})
+
+test_that("a degenerate violin renders instead of aborting", {
+  skip_if_no_patchwork()
+
+  # geom_violin(width = 0) leaves every KDE width at zero, which used to make
+  # the tip-widening step compute min() of an empty vector and abort the
+  # whole render (issue #65).
   degenerate <- ggplot2::ggplot(ggplot2::mpg, ggplot2::aes(class, hwy)) +
     ggplot2::geom_violin(width = 0)
 
+  expect_no_error(render_payload_uncached(degenerate))
   expect_no_error({
-    payload <- render_payload(degenerate | bar_plot())
+    payload <- render_payload_uncached(degenerate | bar_plot())
   })
   expect_equal(layer_types(payload$data$subplots[[1]][[2]]), "bar")
-  expect_length(payload$data$subplots[[1]][[1]]$layers, 0)
 })
 
 test_that("a patchwork violin payload matches the standalone one", {


### PR DESCRIPTION
Closes #65.

Two defects from the issue, plus a third found in review.

## 1. The announced quartiles belonged to the wrong rows

`extract_box_data()` recovered a violin's category by rounding its drawn position to an axis index, reading that index out of the panel's break labels, and matching the label back against the category column as a string. Every step of that round trip has a case where it lands somewhere else.

Measured against quartiles computed independently from `mpg`:

| case | before | after |
|---|---|---|
| `aes(class, hwy, fill = drv)` | **7 labels for 12 violins**, each repeated, each carrying the whole class's numbers | 12 distinct labels (`compact - 4`, `compact - f`, …), every quartile matching |
| `+ coord_flip()` | labelled with `hwy` breaks; **every quartile 0** | correct class labels and quartiles |
| `aes(cyl, hwy)` | off-by-index, including a `7` no car in the data has | `4, 5, 6, 8`, correct quartiles |
| plain / horizontal violin | correct | unchanged |

This is the failure mode the issue calls out as the worst kind for this package: the payload parses, the highlighting works, and the numbers are simply not the ones on screen.

**The fix reads ggplot2's own `stat_boxplot` output** for the `geom_boxplot()` the processor already injects, keyed by the same `group` ids the violin layer uses. The issue suggested keying off the built data's grouping columns; going one step further to the boxplot layer means the numbers are computed by ggplot2, from the same data, under the same grouping — no re-derivation to keep in sync, and `outliers`/whiskers come along rather than being recomputed with a second Tukey pass. Labels now come from whichever panel axis is actually discrete (`is_discrete()`), which is what `coord_flip()` breaks, and are qualified with the fill level when dodging put more than one on the axis.

**Augmentation had to stop pinning `fill = "white"` over a mapped fill.** ggplot2 derives `group` from the discrete aesthetics a layer carries, so overriding it grouped the box by class alone — 7 boxes for 12 violins — which is why group-keyed lookup could not have worked on its own. The injected box now inherits any aesthetic the violin maps, and dodges at width 0.9 so a 0.1-wide box still lands inside its own violin (verified: max |dx| between box centre and violin centre is 0.0000).

Side effect worth noting: dodged `violin_box` selectors went from 7 against 12 data entries — a mismatch the frontend requires not to happen — to 12 against 12, all resolving.

## 2. `geom_violin(width = 0)` aborted the render

`simplify_violin_kde()` widens zero-width tips so they survive the density filter, scaling the nudge from the smallest positive width in the layer. With `width = 0` every width is zero, so that vector is empty: `min()` returns `Inf` with a warning and the following comparison is `NA`, which `if` will not accept.

Guarded on there being a positive width to scale from. The issue suggested falling back to the extrema-only path; that path is the same code — the extrema are already force-kept by `valid[y_min_idx] <- TRUE` before this point — so the guard reaches it by skipping the widening rather than branching to a duplicate. Layers mixing zero and positive widths still scale as before.

## 3. Found in review: the same bug via layer-level fill

A violin that maps fill on itself — `geom_violin(aes(fill = drv))` rather than at the plot level — still announced 12 groups against 7 selectors, with **every one of the 12 carrying the wrong quartiles**. Fix (1) detected the layer's fill correctly and so skipped the `fill = "white"` default, but `inherit.aes` carries the *plot* mapping only, never another layer's own `aes()`, so the box had no fill to dodge by.

Passing the mapping explicitly was necessary but not sufficient — it fixed the selector count and left 10 of 12 groups still wrong. ggplot2 numbers `group` from the interaction of a layer's discrete columns **in the order the mapping produced them**, and builds a layer's mapping as its own aesthetics first, then plot-only ones. `get_effective_mapping()` merged the other way round, so the box's group 1 was a different violin than the violin's group 1:

| merged mapping order | violin/box group ids agreeing on (x, fill) |
|---|---|
| `x, y, fill` (was) | 2 of 12 |
| `fill, x, y` (ggplot2's own) | **12 of 12** |

Since every statistic and selector lookup is keyed on `group`, that is the same "parses fine, wrong numbers" class of failure as (1). Built in ggplot2's order, layer-level fill now reports 0 of 12 wrong with 12↔12 selectors; plot-level fill is unchanged.

Also removed `get_category_labels()` and `get_original_data()`, which fix (1) left without callers. (Note for anyone grepping: `get_original_data` still appears in `R/`, but those hits are `Ggplot2CandlestickLayerProcessor`'s own same-named method — a different class, untouched.)

## Verification

- A harness parses `maidr-data` out of the rendered HTML and compares every emitted `q1/q2/q3` against `stats::quantile()` computed straight from `mpg`. All cases above pass; the plain-violin control is unchanged.
- Full `testthat` suite: 3443 passed, 0 failed, 0 errors. The 35 skips are pre-existing (missing `{tidyquant}`, Base R detection).
- `R CMD check` with tests: `Running 'testthat.R' ... OK`, `checking Rd files ... OK`, `checking for code/documentation mismatches ... OK`. The three WARNINGs in this container are environmental — an ASCII locale tripping over the pre-existing currency glyphs in `R/format_utils.R`, plus two `inst/doc` artifacts of `--no-build-vignettes`.

## Tests

Eight new blocks in `test-ggplot2-violin-layer-processor.R`, covering the dodged, `coord_flip()` and continuous-x cases the issue notes are untested today, plus a control that plain and horizontal violins keep their existing labels, a check that augmentation never overrides a mapped aesthetic, one asserting the box and kde layers announce the same group names, and — for (3) — a layer-level-fill quartile check and one pinning the cross-layer group-id correspondence directly, since that invariant is what silently broke.

One existing test changed: `test-violin-patchwork.R`'s "a leaf a processor cannot handle does not abort the composition" used `geom_violin(width = 0)` as its erroring vehicle, and fixing that defect removed its premise. It now induces the failure explicitly by replacing the processor's `process` method, so the isolation guarantee is still exercised, and a separate block asserts the degenerate violin renders.

## Not addressed

The other pre-existing gaps listed in #63 are untouched: faceted violins remain unsupported, non-violin geoms in a nested patchwork still emit selectors that do not resolve, and the patchwork path still does not thread `format_config`.