### PR TITLE
fix(knitr): clear recorded base r calls when interception is disabled

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,11 @@
 
 ## Bug Fixes
 
+* knitr: turning interception off mid-document no longer leaves recorded Base
+  R calls behind. The hook returned early when interception was disabled
+  without clearing the device, unlike the sibling branch for non-HTML output,
+  so a document that plotted, called `maidr_off()`, then called `maidr_on()`
+  again folded the earlier calls into the next render as phantom layers.
 * ggplot2: a violin plot combined with 'patchwork' is no longer silent. The
   leaf emitted a subplot with no layers at all -- no sonification, no
   braille, no highlighting for that panel -- because the processor skipped

--- a/R/knitr_support.R
+++ b/R/knitr_support.R
@@ -304,8 +304,12 @@ create_maidr_widget_internal <- function(plot = NULL) {
 maidr_plot_hook <- function(x, options) {
   device_id <- grDevices::dev.cur()
 
-  # Honour maidr_off(): behave exactly like the original hook
+  # Honour maidr_off(): behave exactly like the original hook. Drop anything
+  # already recorded on this device first - otherwise calls captured before
+  # interception was disabled survive, and a later maidr_on() folds them into
+  # the next render as phantom layers.
   if (!is_base_r_enabled()) {
+    clear_device_storage(device_id)
     return(call_original_plot_hook(x, options))
   }
 

--- a/tests/testthat/test-knitr-support.R
+++ b/tests/testthat/test-knitr-support.R
@@ -11,6 +11,7 @@ save_knitr_env <- function() {
 
   state <- list(
     options = options("maidr.auto_show", "maidr.base_r", "maidr.ggplot2"),
+    patching_active = maidr:::is_patching_active(),
     plot_hook = NULL,
     original_plot_hook = knitr_state$original_plot_hook,
     enabled = knitr_state$enabled
@@ -24,6 +25,16 @@ save_knitr_env <- function() {
 }
 
 restore_knitr_env <- function(state) {
+  # Go back through maidr_on()/maidr_off() rather than writing the flag
+  # directly: they install and remove the Base R wrappers as well as setting
+  # it, and a flag that disagrees with which wrappers are installed is worse
+  # than either state on its own.
+  if (isTRUE(state$patching_active)) {
+    maidr::maidr_on()
+  } else {
+    maidr::maidr_off()
+  }
+
   if (requireNamespace("knitr", quietly = TRUE) && !is.null(state$plot_hook)) {
     knitr::knit_hooks$set(plot = state$plot_hook)
   }
@@ -31,6 +42,7 @@ restore_knitr_env <- function(state) {
   knitr_state <- maidr:::.maidr_knitr_state
   knitr_state$original_plot_hook <- state$original_plot_hook
   knitr_state$enabled <- state$enabled
+  # Last, so the saved values win over whatever maidr_on()/maidr_off() set.
   options(state$options)
   maidr:::clear_all_device_storage()
 
@@ -103,4 +115,25 @@ test_that("toggling maidr_off()/maidr_on() does not leak phantom layers", {
 
   testthat::expect_false("barplot" %in% recorded)
   testthat::expect_true("hist" %in% recorded)
+})
+
+test_that("the test helpers leave global patching state as they found it", {
+  testthat::skip_if_not_installed("knitr")
+
+  # These tests call maidr_on()/maidr_off(), which install and remove the Base
+  # R wrappers globally. Without this the first test above -- which ends with
+  # interception off -- would leave it off for whatever runs next, making the
+  # suite quietly order-dependent.
+  for (start_on in c(TRUE, FALSE)) {
+    if (start_on) maidr::maidr_on() else maidr::maidr_off()
+    before <- maidr:::is_patching_active()
+
+    env_state <- save_knitr_env()
+    if (start_on) maidr::maidr_off() else maidr::maidr_on()
+    restore_knitr_env(env_state)
+
+    testthat::expect_identical(maidr:::is_patching_active(), before)
+  }
+
+  maidr::maidr_on()
 })

--- a/tests/testthat/test-knitr-support.R
+++ b/tests/testthat/test-knitr-support.R
@@ -1,0 +1,106 @@
+# Tests for the knitr integration in R/knitr_support.R
+
+# ==============================================================================
+# Setup and Teardown
+# ==============================================================================
+
+# maidr_on()/maidr_off() mutate global state (options, Base R patching, knitr
+# hooks). Snapshot everything we touch so the rest of the suite is unaffected.
+save_knitr_env <- function() {
+  knitr_state <- maidr:::.maidr_knitr_state
+
+  state <- list(
+    options = options("maidr.auto_show", "maidr.base_r", "maidr.ggplot2"),
+    plot_hook = NULL,
+    original_plot_hook = knitr_state$original_plot_hook,
+    enabled = knitr_state$enabled
+  )
+
+  if (requireNamespace("knitr", quietly = TRUE)) {
+    state$plot_hook <- knitr::knit_hooks$get("plot")
+  }
+
+  state
+}
+
+restore_knitr_env <- function(state) {
+  if (requireNamespace("knitr", quietly = TRUE) && !is.null(state$plot_hook)) {
+    knitr::knit_hooks$set(plot = state$plot_hook)
+  }
+
+  knitr_state <- maidr:::.maidr_knitr_state
+  knitr_state$original_plot_hook <- state$original_plot_hook
+  knitr_state$enabled <- state$enabled
+  options(state$options)
+  maidr:::clear_all_device_storage()
+
+  invisible(NULL)
+}
+
+# ==============================================================================
+# maidr_plot_hook Tests
+# ==============================================================================
+
+test_that("maidr_plot_hook clears device storage when interception is off", {
+  testthat::skip_if_not_installed("knitr")
+
+  env_state <- save_knitr_env()
+  on.exit(restore_knitr_env(env_state), add = TRUE)
+
+  maidr::maidr_on()
+  maidr:::clear_all_device_storage()
+
+  grDevices::pdf(NULL)
+  device_id <- grDevices::dev.cur()
+  on.exit(
+    tryCatch(grDevices::dev.off(device_id), error = function(e) NULL),
+    add = TRUE
+  )
+
+  barplot(c(10, 20, 30), names.arg = c("A", "B", "C"))
+  testthat::expect_true(maidr:::has_device_calls(device_id))
+
+  # maidr_off() disables interception; the hook must behave like the original
+  # hook AND drop what was already recorded, rather than leaving it behind.
+  maidr::maidr_off()
+  testthat::expect_false(maidr:::is_base_r_enabled())
+
+  maidr:::maidr_plot_hook("figure-1.png", list())
+
+  testthat::expect_false(maidr:::has_device_calls(device_id))
+  testthat::expect_length(maidr:::get_device_calls(device_id), 0)
+})
+
+test_that("toggling maidr_off()/maidr_on() does not leak phantom layers", {
+  testthat::skip_if_not_installed("knitr")
+
+  env_state <- save_knitr_env()
+  on.exit(restore_knitr_env(env_state), add = TRUE)
+
+  maidr::maidr_on()
+  maidr:::clear_all_device_storage()
+
+  grDevices::pdf(NULL)
+  device_id <- grDevices::dev.cur()
+  on.exit(
+    tryCatch(grDevices::dev.off(device_id), error = function(e) NULL),
+    add = TRUE
+  )
+
+  # Chunk 1: recorded while interception is on.
+  barplot(c(10, 20, 30), names.arg = c("A", "B", "C"))
+
+  # Chunk 2: rendered after maidr_off() - the stale barplot must not survive.
+  maidr::maidr_off()
+  maidr:::maidr_plot_hook("figure-1.png", list())
+
+  # Chunk 3: interception back on, a brand new plot.
+  maidr::maidr_on()
+  hist(c(1, 2, 2, 3, 3, 3, 4, 4, 5))
+
+  calls <- maidr:::get_device_calls(device_id)
+  recorded <- vapply(calls, function(entry) entry$function_name, character(1))
+
+  testthat::expect_false("barplot" %in% recorded)
+  testthat::expect_true("hist" %in% recorded)
+})


### PR DESCRIPTION
Closes #57.

`maidr_plot_hook()` returned early when interception was disabled without clearing the device, unlike the sibling branch immediately below it:

```r
if (!is_base_r_enabled()) {
  return(call_original_plot_hook(x, options))   # no clear
}
if (!is_html_output()) {
  clear_device_storage(device_id)               # clears
  return(call_original_plot_hook(x, options))
}
```

So a document that recorded Base R plots, then turned interception off, left those calls on the device. Turning it back on folded them into the next render as phantom layers.

Reproduced before changing anything, driving the hook directly on a `pdf(NULL)` device:

```
calls after barplot:                1
is_base_r_enabled:                  FALSE
calls AFTER hook while disabled:    1     <- stale
```

and the consequence — `maidr_on(); barplot(); maidr_off(); hook(); maidr_on(); hist()`:

```
total calls on device: 2
function names:        barplot, hist      <- barplot is a phantom layer
```

After the fix those read `0` and `hist`.

`device_id` is already in scope — `maidr_plot_hook()` assigns it on its first line, before the disabled check — so the fix is the one line the sibling branch already has.

## Scope

The branch is only reachable when the hook is still installed while interception is off: setting `options(maidr.base_r = FALSE)` directly, or `maidr_off()` running when `.maidr_knitr_state$original_plot_hook` is `NULL` so there is nothing to restore the hook to. That narrows who hits it, but not what happens when they do. The regression test drives the hook directly, so it pins the branch's behaviour regardless of which route reaches it.

## Verification

`tests/testthat/test-knitr-support.R` is new. Confirmed it is a real regression test rather than a vacuous one by reverting the fix and re-running — **3 failures appear** (`has_device_calls` TRUE, `get_device_calls` length 1, `"barplot" %in% recorded` TRUE) and all three disappear with it.

Addressing Copilot's review: the test helpers snapshotted knitr hooks and options but not Base R patching state, even though the helper's own comment claimed otherwise — and `maidr_on()`/`maidr_off()` install and remove the wrappers globally. The first test ends with interception off, so it really did leave it off; nothing broke only because the second test happens to end with `maidr_on()`. Reordering the file, or adding a test that ends off, would have made the suite quietly order-dependent.

The restore now routes back through `maidr_on()`/`maidr_off()` rather than writing the flag directly — they install and remove the wrappers as well as setting it, and a flag disagreeing with which wrappers are installed is worse than either state alone — with saved options applied last so they win over what those calls set. A new test pins that the helpers round-trip from both starting states; removing the restore produces **2 failures**.

Full suite on this branch: **3451 passed, 0 failed, 0 errors, 35 skipped** (all pre-existing — missing `{tidyquant}`, Base R detection).