### PR TITLE
test(ggplot2): pin the segmented bar selector and series order contract

### DIFF
--- a/R/ggplot2_dodged_bar_layer_processor.R
+++ b/R/ggplot2_dodged_bar_layer_processor.R
@@ -195,6 +195,42 @@ Ggplot2DodgedBarLayerProcessor <- R6::R6Class(
         })
       })
     },
+    # ONE flat CSS selector matching every rect in the layer is the contract
+    # maidr.js expects for segmented bars. It is deliberate, not an oversight:
+    # do not "fix" it by emitting one selector per series.
+    #
+    # In the bundled frontend (inst/htmlwidgets/lib/maidr-*/maidr.js) the
+    # dodged, stacked and normalized trace types are all built by the same
+    # class:
+    #
+    #   case DODGED: case NORMALIZED: case STACKED: return new <Segmented>(layer)
+    #
+    # Its constructor runs `this.highlightValues = this.mapToSvgElements(
+    # layer.selectors)`, and `selectAllElements` is just
+    # `Array.from(document.querySelectorAll(sel))` - one flat node list in SVG
+    # document order. The class then RE-GROUPS that list itself instead of
+    # zipping it against the flattened payload (de-minified, rect branch):
+    #
+    #   for (let col = 0, k = 0; col < barValues[0].length; col++)
+    #     if (domMapping?.groupDirection === "forward")
+    #       for (let s = 0; s < barValues.length; s++)      out[s][col] = nodes[k++];
+    #     else
+    #       for (let s = barValues.length - 1; s >= 0; s--) out[s][col] = nodes[k++];
+    #
+    # So the DOM walk is X-MAJOR (one whole column at a time) while `data`
+    # stays SERIES-MAJOR, and because this layer emits no `domMapping` the
+    # per-column direction defaults to "reverse": the first rect of a column
+    # is handed to the LAST data series, the last rect to the first series.
+    #
+    # `reorder_layer_data()` above is what makes that hold for dodged bars.
+    # It sorts the plot data by x ascending and fill DESCENDING, so ggplot2
+    # draws each column's rects right-to-left and the reverse regrouping
+    # lands them back on the ascending-fill series this processor emits.
+    # Concretely, for x = a,b,c and fills u = 10,20,30 / v = 55,65,75 the
+    # emitted flattening is 10,20,30,55,65,75 while the rects come out
+    # 55,10,65,20,75,30; the regrouping reunites data[0] = u with the u rects.
+    #
+    # Pinned by tests/testthat/test-segmented-bar-selector-contract.R.
     generate_selectors = function(plot, gt = NULL, panel_ctx = NULL) {
       if (is.null(gt)) {
         gt <- ggplot2::ggplotGrob(plot)

--- a/R/ggplot2_stacked_bar_layer_processor.R
+++ b/R/ggplot2_stacked_bar_layer_processor.R
@@ -211,6 +211,11 @@ Ggplot2StackedBarProcessor <- R6::R6Class(
         # order. So data[last] maps to DOM rect[0] (top segment) and data[0]
         # maps to the last DOM rect (bottom segment).
         # Therefore: data[0] = bottom fill level, data[last] = top fill level.
+        # Verified against the rendered SVG: gridSVG wraps the plot in a
+        # `translate(0, height) scale(1, -1)` group, so a rect's `y`
+        # attribute grows with its data value. Within one column the rect
+        # with the largest `y` (the top segment) is emitted first, and it is
+        # the last data series that receives it.
         fill_max_y <- tapply(built_data_layer$ymax, built_data_layer$fill, max)
         ordered_colors <- names(sort(fill_max_y, decreasing = FALSE))
 
@@ -254,6 +259,40 @@ Ggplot2StackedBarProcessor <- R6::R6Class(
         })
       }
     },
+    # ONE flat CSS selector matching every rect in the layer is the contract
+    # maidr.js expects for segmented bars. It is deliberate, not an oversight:
+    # do not "fix" it by emitting one selector per series.
+    #
+    # In the bundled frontend (inst/htmlwidgets/lib/maidr-*/maidr.js) the
+    # stacked, dodged and normalized trace types are all built by the same
+    # class:
+    #
+    #   case DODGED: case NORMALIZED: case STACKED: return new <Segmented>(layer)
+    #
+    # Its constructor runs `this.highlightValues = this.mapToSvgElements(
+    # layer.selectors)`, and `selectAllElements` is just
+    # `Array.from(document.querySelectorAll(sel))` - one flat node list in SVG
+    # document order. The class then RE-GROUPS that list itself instead of
+    # zipping it against the flattened payload (de-minified, rect branch):
+    #
+    #   for (let col = 0, k = 0; col < barValues[0].length; col++)
+    #     if (domMapping?.groupDirection === "forward")
+    #       for (let s = 0; s < barValues.length; s++)      out[s][col] = nodes[k++];
+    #     else
+    #       for (let s = barValues.length - 1; s >= 0; s--) out[s][col] = nodes[k++];
+    #
+    # So the DOM walk is X-MAJOR (one whole column at a time) while `data`
+    # stays SERIES-MAJOR, and because this layer emits no `domMapping` the
+    # per-column direction defaults to "reverse": the first rect of a column
+    # is handed to the LAST data series, the last rect to the first series.
+    #
+    # That is why flattening `data` and lining it up against document order
+    # looks wrong - the frontend never does that. Concretely, for x = a,b,c
+    # and fills u = 10,20,30 / v = 55,65,75, the emitted flattening is
+    # 55,65,75,10,20,30 while the rects come out 10,55,20,65,30,75; the
+    # regrouping above reunites data[0] = v with the v rects.
+    #
+    # Pinned by tests/testthat/test-segmented-bar-selector-contract.R.
     generate_selectors = function(plot, gt = NULL, panel_ctx = NULL) {
       if (is.null(gt)) {
         return(list())

--- a/tests/testthat/test-segmented-bar-selector-contract.R
+++ b/tests/testthat/test-segmented-bar-selector-contract.R
@@ -124,7 +124,12 @@ test_that("a stacked bar layer emits one flat selector for every rect", {
   testthat::expect_equal(rendered$layer$type, "stacked_bar")
 })
 
-test_that("stacked bar data stays series-major, top fill level first", {
+# The two orders below run opposite ways, which is the whole point of this
+# file: `data` starts at the BOTTOM of the stack while each column's rects
+# are drawn TOP first. ggplot2 puts v at the bottom here (ymin 0 to 55) and
+# u above it (55 to 65), and the processor sorts series by ascending stack
+# height, so data[[1]] is v. The reverse regrouping is what reunites the two.
+test_that("stacked bar data stays series-major, bottom fill level first", {
   skip_if_no_render()
   rendered <- render_segmented_bar("stack", "stack")
   layer <- rendered$layer

--- a/tests/testthat/test-segmented-bar-selector-contract.R
+++ b/tests/testthat/test-segmented-bar-selector-contract.R
@@ -1,0 +1,215 @@
+# Stacked and dodged bars emit ONE flat CSS selector for the whole layer while
+# `data` stays series-major (issue #54).
+#
+# Flattened side by side the two look mismatched, because SVG document order is
+# x-major. They are not: the bundled maidr.js builds stacked, dodged and
+# normalized traces from a single class whose `mapToSvgElements` re-groups the
+# flat `querySelectorAll` node list one column at a time, walking each column's
+# series in REVERSE when the layer carries no `domMapping`:
+#
+#   for (let col = 0, k = 0; col < barValues[0].length; col++)
+#     if (domMapping?.groupDirection === "forward")
+#       for (let s = 0; s < barValues.length; s++)      out[s][col] = nodes[k++];
+#     else
+#       for (let s = barValues.length - 1; s >= 0; s--) out[s][col] = nodes[k++];
+#
+# These tests re-run that regrouping in R against the rects actually exported,
+# so a change to either the emitted series order or the rect draw order fails
+# here instead of silently announcing the wrong bars.
+
+skip_if_no_render <- function() {
+  testthat::skip_if_not_installed("ggplot2")
+  testthat::skip_if_not_installed("xml2")
+  testthat::skip_if_not_installed("jsonlite")
+}
+
+# x = a,b,c crossed with fills u = 10,20,30 and v = 55,65,75. Every value is
+# distinct, so a rect's pixel height identifies which datum drew it.
+segmented_bar_frame <- function() {
+  data.frame(
+    cat = rep(c("a", "b", "c"), times = 2),
+    grp = rep(c("u", "v"), each = 3),
+    val = c(10, 20, 30, 55, 65, 75),
+    stringsAsFactors = FALSE
+  )
+}
+
+segmented_bar_cache <- new.env(parent = emptyenv())
+
+# Render through the real pipeline and return the layer payload alongside the
+# value each matched rect represents, in SVG document order.
+render_segmented_bar <- function(position, key) {
+  if (!is.null(segmented_bar_cache[[key]])) {
+    return(segmented_bar_cache[[key]])
+  }
+
+  plot <- ggplot2::ggplot(
+    segmented_bar_frame(),
+    ggplot2::aes(x = cat, y = val, fill = grp)
+  ) + ggplot2::geom_col(position = position)
+
+  file <- tempfile(fileext = ".html")
+  on.exit(unlink(file), add = TRUE)
+  suppressWarnings(save_html(plot, file))
+  html <- paste(readLines(file, warn = FALSE), collapse = "\n")
+
+  raw <- regmatches(html, regexpr('maidr-data="[^"]*"', html))
+  testthat::expect_length(raw, 1)
+  json <- sub('"$', "", sub('^maidr-data="', "", raw))
+  json <- gsub("&quot;", '"', json, fixed = TRUE)
+  json <- gsub("&lt;", "<", json, fixed = TRUE)
+  json <- gsub("&gt;", ">", json, fixed = TRUE)
+  json <- gsub("&amp;", "&", json, fixed = TRUE)
+
+  payload <- jsonlite::fromJSON(json, simplifyVector = FALSE)
+  layer <- payload$subplots[[1]][[1]]$layers[[1]]
+
+  selector <- unlist(layer$selectors, use.names = FALSE)[1]
+  id <- gsub("\\\\", "", sub(" rect$", "", sub("^#", "", selector)))
+
+  doc <- xml2::read_html(html)
+  rects <- xml2::xml_find_all(doc, sprintf("//*[@id='%s']//rect", id))
+  heights <- as.numeric(xml2::xml_attr(rects, "height"))
+
+  # Rect heights are proportional to the values that drew them; the tallest
+  # rect is the largest value, which pins the pixels-per-unit scale.
+  values <- unlist(lapply(layer$data, function(series) {
+    vapply(series, function(point) as.numeric(point$y), numeric(1))
+  }))
+  dom_values <- heights / (max(heights) / max(values))
+
+  out <- list(layer = layer, selector = selector, dom_values = dom_values)
+  assign(key, out, envir = segmented_bar_cache)
+  out
+}
+
+# The `mapToSvgElements` rect branch of the bundled maidr.js, in R.
+regroup_like_maidr_js <- function(layer, dom_values) {
+  bar_values <- lapply(layer$data, function(series) {
+    vapply(series, function(point) as.numeric(point$y), numeric(1))
+  })
+  forward <- identical(layer$domMapping$groupDirection, "forward")
+
+  grouped <- vector("list", length(bar_values))
+  k <- 1L
+  for (col in seq_along(bar_values[[1]])) {
+    series_order <- if (forward) {
+      seq_along(bar_values)
+    } else {
+      rev(seq_along(bar_values))
+    }
+    for (s in series_order) {
+      grouped[[s]] <- c(grouped[[s]], dom_values[k])
+      k <- k + 1L
+    }
+  }
+  grouped
+}
+
+series_values <- function(layer, index) {
+  vapply(layer$data[[index]], function(point) as.numeric(point$y), numeric(1))
+}
+
+series_fill <- function(layer, index) {
+  as.character(layer$data[[index]][[1]]$z)
+}
+
+test_that("a stacked bar layer emits one flat selector for every rect", {
+  skip_if_no_render()
+  rendered <- render_segmented_bar("stack", "stack")
+
+  testthat::expect_length(rendered$layer$selectors, 1)
+  testthat::expect_match(rendered$selector, "^#geom_rect\\\\\\..* rect$")
+  testthat::expect_null(rendered$layer$domMapping)
+  testthat::expect_equal(rendered$layer$type, "stacked_bar")
+})
+
+test_that("stacked bar data stays series-major, top fill level first", {
+  skip_if_no_render()
+  rendered <- render_segmented_bar("stack", "stack")
+  layer <- rendered$layer
+
+  testthat::expect_length(layer$data, 2)
+  testthat::expect_equal(series_fill(layer, 1), "v")
+  testthat::expect_equal(series_values(layer, 1), c(55, 65, 75))
+  testthat::expect_equal(series_fill(layer, 2), "u")
+  testthat::expect_equal(series_values(layer, 2), c(10, 20, 30))
+})
+
+test_that("stacked rects are exported x-major, top segment first per column", {
+  skip_if_no_render()
+  rendered <- render_segmented_bar("stack", "stack")
+
+  # Deliberately NOT the emitted flattening (55,65,75,10,20,30).
+  testthat::expect_equal(rendered$dom_values, c(10, 55, 20, 65, 30, 75),
+                         tolerance = 1e-3)
+})
+
+test_that("maidr.js regrouping reunites stacked series with their own rects", {
+  skip_if_no_render()
+  rendered <- render_segmented_bar("stack", "stack")
+  grouped <- regroup_like_maidr_js(rendered$layer, rendered$dom_values)
+
+  testthat::expect_equal(grouped[[1]], series_values(rendered$layer, 1),
+                         tolerance = 1e-3)
+  testthat::expect_equal(grouped[[2]], series_values(rendered$layer, 2),
+                         tolerance = 1e-3)
+})
+
+test_that("a dodged bar layer emits one flat selector for every rect", {
+  skip_if_no_render()
+  rendered <- render_segmented_bar("dodge", "dodge")
+
+  testthat::expect_length(rendered$layer$selectors, 1)
+  testthat::expect_match(rendered$selector, "^#geom_rect\\\\\\..* rect$")
+  testthat::expect_null(rendered$layer$domMapping)
+  testthat::expect_equal(rendered$layer$type, "dodged_bar")
+})
+
+test_that("dodged bar data stays series-major, fills ascending", {
+  skip_if_no_render()
+  rendered <- render_segmented_bar("dodge", "dodge")
+  layer <- rendered$layer
+
+  testthat::expect_length(layer$data, 2)
+  testthat::expect_equal(series_fill(layer, 1), "u")
+  testthat::expect_equal(series_values(layer, 1), c(10, 20, 30))
+  testthat::expect_equal(series_fill(layer, 2), "v")
+  testthat::expect_equal(series_values(layer, 2), c(55, 65, 75))
+})
+
+test_that("dodged rects are exported x-major, fills descending per column", {
+  skip_if_no_render()
+  rendered <- render_segmented_bar("dodge", "dodge")
+
+  # reorder_layer_data() sorts fill descending so ggplot2 draws each column
+  # right-to-left, which is what the reverse regrouping expects.
+  testthat::expect_equal(rendered$dom_values, c(55, 10, 65, 20, 75, 30),
+                         tolerance = 1e-3)
+})
+
+test_that("maidr.js regrouping reunites dodged series with their own rects", {
+  skip_if_no_render()
+  rendered <- render_segmented_bar("dodge", "dodge")
+  grouped <- regroup_like_maidr_js(rendered$layer, rendered$dom_values)
+
+  testthat::expect_equal(grouped[[1]], series_values(rendered$layer, 1),
+                         tolerance = 1e-3)
+  testthat::expect_equal(grouped[[2]], series_values(rendered$layer, 2),
+                         tolerance = 1e-3)
+})
+
+test_that("a naive flatten-and-zip would disagree with the regrouping", {
+  skip_if_no_render()
+
+  # Guards the premise of the tests above: if emitted order and document
+  # order ever coincided, the regrouping assertions would pass vacuously and
+  # stop protecting anything.
+  for (key in c("stack", "dodge")) {
+    rendered <- render_segmented_bar(key, key)
+    flattened <- unlist(lapply(rendered$layer$data, function(series) {
+      vapply(series, function(point) as.numeric(point$y), numeric(1))
+    }))
+    testthat::expect_false(isTRUE(all.equal(flattened, rendered$dom_values)))
+  }
+})


### PR DESCRIPTION
Closes #54.

## Answer: the contract is correct as-is. Do not "fix" the R side.

The issue asked whether the bundled `maidr.js` flattens-and-zips the emitted `data` against the matched node list — in which case the R side would be emitting the wrong order — or re-groups the nodes itself, in which case the current emission is right and changing it would break every stacked and dodged chart.

**It re-groups.** Stacked, dodged and normalized traces are all built by one class, whose `mapToSvgElements` walks the flat `querySelectorAll` result one column at a time:

```js
for (let col = 0, k = 0; col < barValues[0].length; col++)
  if (domMapping?.groupDirection === "forward")
    for (let s = 0; s < barValues.length; s++)      out[s][col] = nodes[k++];
  else
    for (let s = barValues.length - 1; s >= 0; s--) out[s][col] = nodes[k++];
```

So the DOM walk is **x-major** while `data` stays **series-major**, and because these layers emit no `domMapping` the per-column direction defaults to `"reverse"` — the first rect of a column goes to the *last* data series. The two orders were never meant to line up when flattened.

This is exactly the "already correct" branch the issue anticipated, and the requested remedy applies: a comment in each processor recording *why*, so the next reviewer does not re-litigate it.

## What changed

No behaviour change. This PR is comments plus tests.

- `R/ggplot2_stacked_bar_layer_processor.R` and `R/ggplot2_dodged_bar_layer_processor.R` each gain a block above `generate_selectors()` explaining the contract, quoting the de-minified frontend regrouping, and stating the concrete orders for the issue's own test figure. Both end with "do not fix it by emitting one selector per series."
- The stacked processor's existing ordering comment gains the SVG evidence behind it: gridSVG wraps the plot in `translate(0, height) scale(1, -1)`, so a rect's `y` attribute grows with its data value, which is why the top segment is emitted first.
- `tests/testthat/test-segmented-bar-selector-contract.R` (new) makes the implicit cross-repo contract executable.

No `NEWS.md` entry: nothing user-facing changed, and that section is for bug fixes.

## How the tests work

They render through the real pipeline, pull the `maidr-data` payload out of the HTML, then read the rect `height` attributes out of the exported SVG and convert them back to data values. That gives the true document order rather than an assumed one. The maidr.js regrouping is then re-implemented in R and applied to those DOM values, asserting each series is reunited with its own rects.

Using the issue's own figure (`a, b, c` × `u = 10, 20, 30` / `v = 55, 65, 75`), the tests pin:

| | emitted, flattened | DOM order |
|---|---|---|
| `position = "stack"` | `55, 65, 75, 10, 20, 30` | `10, 55, 20, 65, 30, 75` |
| `position = "dodge"` | `10, 20, 30, 55, 65, 75` | `55, 10, 65, 20, 75, 30` |

and that regrouping those DOM values reproduces the emitted series exactly.

The last test is an anti-vacuity guard: it asserts the flattened emission and the document order **disagree**. If they ever coincided, the regrouping assertions would pass for the wrong reason and stop protecting anything.

## Verification

Full suite on this branch: `[ FAIL 0 | WARN 2 | SKIP 35 | PASS 3515 ]`.

There is no fix to revert here, so the usual revert-and-confirm-it-fails check does not apply — the anti-vacuity test above is what stands in for it. The assertions are on concrete rendered values (`10, 55, 20, 65, 30, 75`, not "did not error"), so a change to either the emitted series order or the rect draw order fails this file rather than silently announcing the wrong bars.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHiQLtv3om84NnECwsL8Z9)_