### PR TITLE
fix(base-r): label an unnamed heatmap with the indices it draws

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,19 @@
 
 ## Bug Fixes
 
+* Base R: `heatmap()` of a matrix with no `dimnames` announces the row and
+  column identities it actually draws. `heatmap()` clusters the rows and
+  columns and then labels the reordered matrix with the *original* indices,
+  `(1L:nr)[rowInd]`; maidr instead filled unnamed axes with a plain 1..n
+  position sequence, so a default `heatmap(m)` announced "row 5" while
+  sonifying the values of original row 2. Only the labels were affected — the
+  values have been drawn from the same ordering since dendrogram support
+  landed, which left the payload internally inconsistent as well as wrong
+  against the figure. Unnamed axes now take their labels from that ordering,
+  on both the row and the column axis, and `revC` (which every `symm = TRUE`
+  call turns on) reverses labels and values together as before. Matrices that
+  carry `dimnames` are unchanged, as are `Rowv = NA, Colv = NA` heatmaps and
+  `image()`, none of which reorder anything, so 1..n is what they draw.
 * ggplot2: a faceted stacked bar whose facet column contains `NA` exports
   again. ggplot2 draws a real extra panel for the missing value, but the
   per-panel subset picked its rows with `==`, which answers `NA` for exactly

--- a/R/base_r_heatmap_layer_processor.R
+++ b/R/base_r_heatmap_layer_processor.R
@@ -63,6 +63,7 @@ BaseRHeatmapLayerProcessor <- R6::R6Class(
       # so the top-down grid is the reverse of the matrix. heatmap()'s revC
       # flips the drawing back, and then the matrix already reads top-down.
       reverse_rows <- TRUE
+      ordering <- NULL
 
       if (identical(function_name, "heatmap")) {
         # heatmap() reorders rows/columns by dendrogram (default Rowv/Colv)
@@ -87,11 +88,24 @@ BaseRHeatmapLayerProcessor <- R6::R6Class(
       row_names <- rownames(heat_matrix)
       col_names <- colnames(heat_matrix)
 
+      # An unnamed matrix keeps no dimnames through the reorder, so fall back
+      # the way heatmap() itself does: it labels the reordered matrix with
+      # `(1L:nr)[rowInd]`, i.e. the ORIGINAL indices in drawn order, not with
+      # 1..n positions. Only when no ordering was recovered -- or for image(),
+      # which never reorders -- is a plain 1..n sequence the drawn label.
       if (is.null(row_names)) {
-        row_names <- as.character(seq_len(nrow(heat_matrix)))
+        row_names <- if (is.null(ordering)) {
+          as.character(seq_len(nrow(heat_matrix)))
+        } else {
+          as.character(ordering$rowInd)
+        }
       }
       if (is.null(col_names)) {
-        col_names <- as.character(seq_len(ncol(heat_matrix)))
+        col_names <- if (is.null(ordering)) {
+          as.character(seq_len(ncol(heat_matrix)))
+        } else {
+          as.character(ordering$colInd)
+        }
       }
 
       # points is a 2D array where points[row][col] = value

--- a/tests/testthat/test-base-r-heatmap-layer-processor.R
+++ b/tests/testthat/test-base-r-heatmap-layer-processor.R
@@ -579,3 +579,215 @@ test_that("a rendered revC heatmap lists rows in drawn top-to-bottom order", {
 
   testthat::expect_equal(unlist(layer$data$y), drawn)
 })
+
+# ==============================================================================
+# Unnamed matrices: heatmap() labels the reordered matrix with the ORIGINAL
+# indices, `(1L:nr)[rowInd]`, because it takes labRow after `x <- x[rowInd,
+# colInd]` has already dropped the (absent) dimnames. maidr used to fall back
+# to a plain 1..n position sequence there, so an unnamed matrix announced a
+# systematically permuted identity while sonifying the right values.
+# ==============================================================================
+
+# Unnamed, and clustered into a non-identity ROW order (colInd stays 1..4).
+heatmap_unnamed_matrix <- function() {
+  matrix(
+    c(
+      10, 11, 12, 13,
+      90, 91, 92, 93,
+      50, 51, 52, 53,
+      20, 21, 22, 23,
+      70, 71, 72, 73
+    ),
+    nrow = 5, ncol = 4, byrow = TRUE
+  )
+}
+
+# Unnamed, and clustered into a non-identity order on BOTH axes.
+heatmap_unnamed_matrix_2d <- function() {
+  matrix(
+    c(
+      10, 40, 30, 20,
+      90, 60, 70, 80,
+      50, 20, 30, 40,
+      20, 80, 70, 30,
+      70, 10, 15, 60
+    ),
+    nrow = 5, ncol = 4, byrow = TRUE
+  )
+}
+
+# The ordering heatmap() itself uses, taken on a throwaway device so the
+# expectations are not hard-coded to one clustering implementation.
+heatmap_true_ordering <- function(m, ...) {
+  null_pdf <- tempfile(fileext = ".pdf")
+  grDevices::pdf(null_pdf)
+  on.exit(
+    {
+      grDevices::dev.off()
+      unlink(null_pdf)
+    },
+    add = TRUE
+  )
+  stats::heatmap(m, ...)
+}
+
+test_that("an unnamed reordered heatmap labels rows with the original indices", {
+  m <- heatmap_unnamed_matrix()
+  ordering <- heatmap_true_ordering(m, scale = "none")
+
+  info <- heatmap_layer_info(m, scale = "none")
+  processor <- maidr:::BaseRHeatmapLayerProcessor$new(info)
+  data <- processor$extract_data(info)
+
+  # No revC here, so drawn top-to-bottom is the reverse of rowInd.
+  testthat::expect_equal(
+    unlist(data$y),
+    rev(as.character(ordering$rowInd))
+  )
+  # The whole point: this is NOT the plain positional sequence.
+  testthat::expect_false(
+    identical(unlist(data$y), rev(as.character(seq_len(nrow(m)))))
+  )
+  # The values stay what they already were: drawn row 1 is original row
+  # rowInd[nrow], because the grid reads top-down.
+  testthat::expect_equal(
+    unlist(data$points[[1]]),
+    unname(m[ordering$rowInd[nrow(m)], ordering$colInd])
+  )
+})
+
+test_that("an unnamed heatmap labels both axes from the ordering it draws", {
+  m <- heatmap_unnamed_matrix_2d()
+  ordering <- heatmap_true_ordering(m, scale = "none")
+
+  # Guard the fixture: this matrix must reorder its COLUMNS too, otherwise
+  # the x-axis half of this test proves nothing.
+  testthat::expect_false(identical(ordering$colInd, seq_len(ncol(m))))
+
+  info <- heatmap_layer_info(m, scale = "none")
+  processor <- maidr:::BaseRHeatmapLayerProcessor$new(info)
+  data <- processor$extract_data(info)
+
+  testthat::expect_equal(unlist(data$x), as.character(ordering$colInd))
+  testthat::expect_equal(unlist(data$y), rev(as.character(ordering$rowInd)))
+})
+
+test_that("an unnamed symm heatmap labels rows top-down in rowInd order", {
+  # symm = TRUE makes Colv default to "Rowv", so revC applies and the drawn
+  # rows already read top-down -- labels must NOT be reversed here.
+  m <- matrix(
+    c(
+      0, 9, 1, 8,
+      9, 0, 7, 2,
+      1, 7, 0, 6,
+      8, 2, 6, 0
+    ),
+    nrow = 4, ncol = 4, byrow = TRUE
+  )
+  ordering <- heatmap_true_ordering(m, symm = TRUE, scale = "none")
+  testthat::expect_false(identical(ordering$rowInd, seq_len(nrow(m))))
+
+  info <- heatmap_layer_info(m, symm = TRUE, scale = "none")
+  processor <- maidr:::BaseRHeatmapLayerProcessor$new(info)
+  data <- processor$extract_data(info)
+
+  testthat::expect_equal(unlist(data$y), as.character(ordering$rowInd))
+  testthat::expect_equal(unlist(data$x), as.character(ordering$colInd))
+})
+
+test_that("an unnamed unreordered heatmap keeps its 1..n labels", {
+  m <- heatmap_unnamed_matrix()
+  info <- heatmap_layer_info(m, Rowv = NA, Colv = NA, scale = "none")
+  processor <- maidr:::BaseRHeatmapLayerProcessor$new(info)
+
+  data <- processor$extract_data(info)
+
+  # Rowv/Colv = NA means rowInd/colInd are the identity, so the labels are
+  # the plain sequence -- reversed on y, because revC does not apply.
+  testthat::expect_equal(unlist(data$y), c("5", "4", "3", "2", "1"))
+  testthat::expect_equal(unlist(data$x), c("1", "2", "3", "4"))
+})
+
+test_that("a named heatmap still carries its dimnames through unchanged", {
+  m <- heatmap_unnamed_matrix()
+  rownames(m) <- paste0("R", seq_len(nrow(m)))
+  colnames(m) <- paste0("C", seq_len(ncol(m)))
+  ordering <- heatmap_true_ordering(m, scale = "none")
+
+  info <- heatmap_layer_info(m, scale = "none")
+  processor <- maidr:::BaseRHeatmapLayerProcessor$new(info)
+  data <- processor$extract_data(info)
+
+  testthat::expect_equal(unlist(data$y), rev(rownames(m)[ordering$rowInd]))
+  testthat::expect_equal(unlist(data$x), colnames(m)[ordering$colInd])
+})
+
+test_that("image() of an unnamed matrix keeps plain positional labels", {
+  # image() does no reordering, so 1..n is genuinely what it draws.
+  m <- heatmap_unnamed_matrix()
+  info <- list(
+    index = 1,
+    function_name = "image",
+    plot_call = list(function_name = "image", args = list(x = m))
+  )
+  processor <- maidr:::BaseRHeatmapLayerProcessor$new(info)
+  data <- processor$extract_data(info)
+
+  # image() transposes: matrix rows run along x, columns along y.
+  testthat::expect_equal(unlist(data$x), as.character(seq_len(nrow(m))))
+  testthat::expect_equal(unlist(data$y), rev(as.character(seq_len(ncol(m)))))
+})
+
+test_that("a rendered unnamed heatmap lists the row labels it draws", {
+  testthat::skip_if_not_installed("xml2")
+  testthat::skip_if_not_installed("jsonlite")
+
+  m <- heatmap_unnamed_matrix()
+
+  maidr:::clear_all_device_storage()
+  grDevices::pdf(NULL)
+  heatmap(m, scale = "none")
+  file <- tempfile(fileext = ".html")
+  on.exit(
+    {
+      unlink(file)
+      maidr:::clear_all_device_storage()
+    },
+    add = TRUE
+  )
+  suppressWarnings(save_html(file = file))
+  grDevices::dev.off()
+
+  html <- paste(readLines(file, warn = FALSE), collapse = "\n")
+  raw <- regmatches(
+    html, gregexpr('maidr-data="([^"]*)"', html, perl = TRUE)
+  )[[1]]
+  testthat::expect_gt(length(raw), 0)
+
+  json <- sub('"$', "", sub('^maidr-data="', "", raw[1]))
+  json <- gsub("&quot;", '"', json, fixed = TRUE)
+  json <- gsub("&lt;", "<", json, fixed = TRUE)
+  json <- gsub("&gt;", ">", json, fixed = TRUE)
+  json <- gsub("&amp;", "&", json, fixed = TRUE)
+  payload <- jsonlite::fromJSON(json, simplifyVector = FALSE)
+  layer <- payload$subplots[[1]][[1]]$layers[[1]]
+
+  # Row labels as drawn: axis(4) text nodes, read visually top to bottom.
+  # gridSVG wraps the whole tree in translate(0, h) scale(1, -1), so a
+  # LARGER y is higher up the page.
+  doc <- xml2::read_html(html)
+  nodes <- xml2::xml_find_all(
+    doc,
+    "//*[contains(@id,'right-axis-labels')][local-name()='text']"
+  )
+  testthat::expect_equal(length(nodes), 5L)
+  label_y <- vapply(nodes, function(nd) {
+    tf <- xml2::xml_attr(xml2::xml_parent(xml2::xml_parent(nd)), "transform")
+    as.numeric(regmatches(tf, gregexpr("-?[0-9.]+", tf))[[1]])[2]
+  }, numeric(1))
+  drawn <- vapply(nodes, xml2::xml_text, character(1))[order(-label_y)]
+
+  testthat::expect_equal(unlist(layer$data$y), drawn)
+  # Guard: the drawing really is reordered, so this is not a trivial pass.
+  testthat::expect_false(identical(drawn, c("5", "4", "3", "2", "1")))
+})


### PR DESCRIPTION
Closes #99.

`stats::heatmap()` clusters the rows and columns and then labels the reordered matrix with the **original** indices — `labRow <- labRow[rowInd] %||% rownames(x) %||% (1L:nr)[rowInd]`, taken after `x <- x[rowInd, colInd]`, drawn with `axis(4, iy, ...)` where `iy` is `nr:1` under `revC` else `1:nr`. maidr filled an unnamed axis with a plain `seq_len()` position sequence instead, so a default `heatmap(m)` announced "row 5" while sonifying the values of original row 2.

`ordering` is hoisted out of the `heatmap` branch so the label fallback can see it; when `rownames()`/`colnames()` is NULL the labels come from `as.character(ordering$rowInd)` / `as.character(ordering$colInd)`. `seq_len()` stays for the two cases where it is what actually gets drawn: no ordering recovered, and `image()`. `rowInd` is a permutation of `1:nr`, so it is inherently the pre-reorder dimension, and it is captured before the `heat_matrix` subset. 18 lines.

**Not a regression.** The `seq_len()` fallback predates the dendrogram-ordering work; before that the values were unreordered too. What changed is that the values became correct while the labels stayed positional, leaving the payload internally inconsistent as well as wrong against the drawing. NEWS says it that way.

## Emitted vs drawn

Labels read out of the exported SVG in Chromium with `svg text` sorted by measured `getBoundingClientRect()` — not document order — and the plot region derived from the `image-rect` cells so the right-axis and bottom-axis labels are separated geometrically rather than by guessing.

| case | axis | before | after | SVG drawn |
|---|---|---|---|---|
| unnamed, rows reordered | y | `5,4,3,2,1` ✗ | `2,5,3,4,1` ✓ | `2,5,3,4,1` |
| unnamed, **both** reordered | y | `5,4,3,2,1` ✗ | `2,5,3,4,1` ✓ | `2,5,3,4,1` |
| | x | `1,2,3,4` ✗ | `2,3,4,1` ✓ | `2,3,4,1` |
| named *(control)* | y | `R2,R5,R3,R4,R1` ✓ | unchanged | `R2,R5,R3,R4,R1` |
| named, both reordered *(control)* | x | `C2,C3,C4,C1` ✓ | unchanged | `C2,C3,C4,C1` |
| `image()` *(control)* | x / y | `1..5` / `4,3,2,1` | unchanged | continuous axis |
| `Rowv = NA, Colv = NA` | y | `5,4,3,2,1` ✓ | unchanged | `5,4,3,2,1` |
| `symm = TRUE` | y **and** x | `1,2,3,4` ✗ | `3,1,4,2` ✓ | `3,1,4,2` |

Emitted **values** are byte-identical across all seven cases before and after; only labels moved.

I checked this independently against `stats::heatmap()`'s own output rather than only against the fix: `rowInd = 1,4,3,5,2`, which reversed for top-down is `2,5,3,4,1` — exactly what is now emitted.

One note on `symm`: the obvious 4×4 symmetric fixture clusters to the identity, which would have made that row a vacuous pass. The fixture was swapped for one that clusters to `3,1,4,2` so it actually bites — and it turned out to be wrong on *both* axes there, since `revC` applies and the labels were un-reversed.

## Verification

**Bite check**, `R/base_r_heatmap_layer_processor.R` reverted to `origin/main` with the tests kept: `FAIL 7 | PASS 102`, across 4 of the 7 new blocks (row-only, both-axes, `symm`, and the rendered end-to-end case). The three control blocks keep passing, which is what makes them controls. I re-ran this independently and reproduced 7.

**Full suite:** `FAIL 0 | WARN 2 | SKIP 31 | PASS 4369` with `main` merged in. Baseline measured directly on `origin/main` in a throwaway worktree rather than taken from an older note.

roxygen ran and rewrote only the three perennially-stale pages, all reverted. lintr: **no lints** on either touched file. New tests use only `testthat::`, `xml2::`, `jsonlite::`, `stats::`, `grDevices::` — nothing added to DESCRIPTION, no `withr`. The selector grid is unchanged and never empty, so #89 stays satisfied.

## The two side leads from #60, re-checked here

Both confirmed **still present and untouched** — neither trivially better nor worse:

- **Device leak in `compute_heatmap_ordering()`.** Probed with two pdf devices open and the current one not the lowest-numbered: `dev.cur()` goes `3 → 2` on main and on this branch, identically. This change calls the function no more often than before; it just keeps the value it already returned.
- **Per-cell selector grid size.** Built from the `points` dimensions, which are unchanged, so the grid is identical. Page-size delta across cases was 0–3 bytes, entirely the label text.

## Found here, not fixed

`heatmap()`'s `labRow=` / `labCol=` arguments are ignored entirely — maidr reads dimnames and now the ordering, but never the user-supplied label vectors, so an explicit `labRow = c(...)` is silently dropped. Separate from #99's unnamed fallback; worth its own issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHiQLtv3om84NnECwsL8Z9)_