### PR TITLE
docs: interpret the markdown the roxygen comments were already written in

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,5 +54,6 @@ Suggests:
     zoo,
     xts
 Config/testthat/edition: 3
+Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 VignetteBuilder: knitr

--- a/R/base_r_heatmap_layer_processor.R
+++ b/R/base_r_heatmap_layer_processor.R
@@ -369,7 +369,7 @@ heatmap_applies_revc <- function(args) {
 #'
 #' `heatmap()` gives an explicit `labRow=`/`labCol=` priority over the
 #' matrix's own dimnames, and subscripts it by the same ordering it applies to
-#' the data: `labRow[rowInd] \%||\% rownames(x) \%||\% (1L:nr)[rowInd]`. Reading
+#' the data: `labRow[rowInd] %||% rownames(x) %||% (1L:nr)[rowInd]`. Reading
 #' the labels off the reordered matrix therefore announced the dimnames -- or,
 #' for an unnamed matrix, bare indices -- while the axis showed the caller's
 #' strings.

--- a/R/base_r_pie_layer_processor.R
+++ b/R/base_r_pie_layer_processor.R
@@ -119,7 +119,7 @@ BaseRPieLayerProcessor <- R6::R6Class(
     #' @description Generate one selector per wedge, index-aligned to the data
     #' @param layer_info Layer information
     #' @param gt Grob tree to search
-    #' @param extracted_data Points from [extract_data()], used for the count
+    #' @param extracted_data Points from `extract_data()`, used for the count
     #' @return List of CSS selector strings, one per slice
     generate_selectors = function(layer_info, gt = NULL, extracted_data = NULL) {
       n_slices <- length(extracted_data)

--- a/R/format_utils.R
+++ b/R/format_utils.R
@@ -293,7 +293,7 @@ prefix_to_currency_code <- function(prefix) {
 #'
 #' Converts R strftime format strings to JavaScript Intl.DateTimeFormat options.
 #'
-#' @param format R date format string (e.g., "\%Y-\%m-\%d")
+#' @param format R date format string (e.g., "%Y-%m-%d")
 #' @return List of Intl.DateTimeFormat options
 #' @keywords internal
 r_date_format_to_intl_options <- function(format) {

--- a/R/svg_utils.R
+++ b/R/svg_utils.R
@@ -652,7 +652,7 @@ extract_rect_index_from_id <- function(grob_id) {
 #' Reposition chartSeries date-range bracket header to prevent clipping
 #'
 #' `quantmod::chartSeries()` renders a bracketed date-range header
-#' (e.g. "[2024-01-12/2024-01-15]") via base R `title()` with `par(adj=1)`.
+#' (e.g. `"[2024-01-12/2024-01-15]"`) via base R `title()` with `par(adj=1)`.
 #' For short timeseries the text width exceeds the available right margin
 #' and the closing bracket is clipped at the SVG viewBox edge. This is
 #' upstream quantmod issue #129 (open since 2016, no fix). See
@@ -1282,7 +1282,7 @@ create_standalone_html <- function(svg_content, use_cdn = NULL) {
 #' This isolates each plot in its own document/JavaScript context.
 #'
 #' @param svg_content Character vector of SVG content with maidr-data attribute
-#' @param width Width of the iframe (default: "100\%")
+#' @param width Width of the iframe (default: "100%")
 #' @param height Height of the iframe (default: "450px")
 #' @param plot_id Unique identifier for the plot
 #' @param use_cdn Logical. If `TRUE`, use CDN. If `FALSE`, use bundled files.
@@ -1351,7 +1351,7 @@ maidr_iframe_resize_script <- function() {
 #' Unlike create_maidr_iframe, this does not include MAIDR.js dependencies.
 #'
 #' @param html_content Character string of HTML content (with img tag)
-#' @param width Width of the iframe (default: "100\%")
+#' @param width Width of the iframe (default: "100%")
 #' @param height Height of the iframe (default: "450px")
 #' @param plot_id Unique identifier for the plot
 #' @return Character string of iframe HTML

--- a/man/BaseRAdapter.Rd
+++ b/man/BaseRAdapter.Rd
@@ -84,7 +84,7 @@ Detect the type of a single layer from Base R plot calls
 }
 \subsection{Returns}{
 String indicating the layer type (e.g., "bar", "dodged_bar",
-  "stacked_bar", "smooth", "line", "point")
+"stacked_bar", "smooth", "line", "point")
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/BaseRCandlestickLayerProcessor.Rd
+++ b/man/BaseRCandlestickLayerProcessor.Rd
@@ -10,19 +10,19 @@ Base R Candlestick Layer Processor
 }
 \details{
 Processes Base R candlestick chart layers produced by
-`quantmod::chartSeries(x, type = "candlesticks")`.
+\code{quantmod::chartSeries(x, type = "candlesticks")}.
 
-Each xts row becomes a single navigable `CandlestickPoint` with
-`value`, `open`, `high`, `low`, `close`, computed `trend`
-(Bull / Bear / Neutral), `volatility` (high - low) and optional
-`volume` (when `quantmod::has.Vo()` is `TRUE`).
+Each xts row becomes a single navigable \code{CandlestickPoint} with
+\code{value}, \code{open}, \code{high}, \code{low}, \code{close}, computed \code{trend}
+(Bull / Bear / Neutral), \code{volatility} (high - low) and optional
+\code{volume} (when \code{quantmod::has.Vo()} is \code{TRUE}).
 
 Selectors are derived from the gridSVG export of the chartSeries
-grob (captured via `ggplotify::as.grob()`). chartSeries draws candle
-bodies via a single vectorized `rect()` call (each candle body is one
-SVG `<rect>` child of `graphics-plot-<N>-rect-*`) and upper/lower
-wicks via `segments()` calls (one SVG `<polyline>` per wick under
-`graphics-plot-<N>-segments-*`).
+grob (captured via \code{ggplotify::as.grob()}). chartSeries draws candle
+bodies via a single vectorized \code{rect()} call (each candle body is one
+SVG \verb{<rect>} child of \verb{graphics-plot-<N>-rect-*}) and upper/lower
+wicks via \code{segments()} calls (one SVG \verb{<polyline>} per wick under
+\verb{graphics-plot-<N>-segments-*}).
 }
 \keyword{internal}
 \section{Super class}{
@@ -106,7 +106,7 @@ Build a "bar" layer carrying volume data
 Generate selectors for the addVo() volume bar panel
 
 chartSeries(TA = "addVo()") creates a second plotting window. In
-the gridSVG export that maps to a second `graphics-plot-<N>` group
+the gridSVG export that maps to a second \verb{graphics-plot-<N>} group
 (typically N = 2). Returns a per-bar selector list so each volume
 bar can be individually highlighted on navigation; matches the
 bar layer contract used by the Base R barplot processor.
@@ -145,29 +145,30 @@ List of CandlestickPoint dicts
 \subsection{Method \code{generate_selectors()}}{
 Generate CSS selectors for the candlestick layer
 
-Returns ONE `CandlestickSelector` object (matching the maidr JS
-frontend contract in `src/model/candlestick.ts::mapToSvgElements`).
+Returns ONE \code{CandlestickSelector} object (matching the maidr JS
+frontend contract in \code{src/model/candlestick.ts::mapToSvgElements}).
 The returned object has these named character-vector keys:
-  - `body`     length-N vector, one per-candle body-rect selector
-  - `wickHigh` length-N vector, one per-candle upper-wick selector
-               (omitted if only one segments group is present)
-  - `wickLow`  length-N vector, one per-candle lower-wick selector
-               (omitted if only one segments group is present)
-  - `wick`     length-N vector, used as fallback when there is only
-               one segments group (the frontend falls back to
-               `wick` when `wickHigh` / `wickLow` are absent).
+\itemize{
+\item \code{body}     length-N vector, one per-candle body-rect selector
+\item \code{wickHigh} length-N vector, one per-candle upper-wick selector
+(omitted if only one segments group is present)
+\item \code{wickLow}  length-N vector, one per-candle lower-wick selector
+(omitted if only one segments group is present)
+\item \code{wick}     length-N vector, used as fallback when there is only
+one segments group (the frontend falls back to
+\code{wick} when \code{wickHigh} / \code{wickLow} are absent).
+}
 
-gridSVG emits a child id `<group-id>.1.<i>` for each primitive in
+gridSVG emits a child id \verb{<group-id>.1.<i>} for each primitive in
 a vectorized draw call. The frontend iterates each string array
-(`collectElements(arr)`) and picks the i-th element via
-`getElementAt(*, i)`, so per-candle selectors are required for
+(\code{collectElements(arr)}) and picks the i-th element via
+\verb{getElementAt(*, i)}, so per-candle selectors are required for
 single-candle highlighting on arrow-key navigation.
 
 IMPORTANT: do NOT return an array of objects (e.g.
-`[[body, wick], ...]`). The frontend's `Array.isArray()` branch
-would then take `selectors[0]` (the first dict) and pass it to
-`querySelectorAll`, yielding a JS `SyntaxError: '[object Object]'
-is not a valid selector`. The boxplot pattern of per-item dicts
+\verb{[[body, wick], ...]}). The frontend's \code{Array.isArray()} branch
+would then take \code{selectors[0]} (the first dict) and pass it to
+\code{querySelectorAll}, yielding a JS \verb{SyntaxError: '[object Object]' is not a valid selector}. The boxplot pattern of per-item dicts
 does NOT apply here because each chart model has its own contract.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{BaseRCandlestickLayerProcessor$generate_selectors(
@@ -189,8 +190,8 @@ does NOT apply here because each chart model has its own contract.
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-Named list (single CandlestickSelector) or `list()` when
-  grobs cannot be located.
+Named list (single CandlestickSelector) or \code{list()} when
+grobs cannot be located.
 }
 }
 \if{html}{\out{<hr>}}
@@ -245,7 +246,7 @@ Sort grob ids by trailing integer suffix
 \if{html}{\out{<a id="method-BaseRCandlestickLayerProcessor-find_grob_by_name"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRCandlestickLayerProcessor-find_grob_by_name}{}}}
 \subsection{Method \code{find_grob_by_name()}}{
-Find the grob node whose name matches `id`
+Find the grob node whose name matches \code{id}
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{BaseRCandlestickLayerProcessor$find_grob_by_name(g, id)}\if{html}{\out{</div>}}
 }

--- a/man/BaseRPieLayerProcessor.Rd
+++ b/man/BaseRPieLayerProcessor.Rd
@@ -9,9 +9,9 @@ Base R Pie Chart Layer Processor
 Base R Pie Chart Layer Processor
 }
 \details{
-Processes Base R `pie()` layers based on recorded plot calls. A pie layer is
-1-D and flat: one point per slice, carrying the slice label as `x` and the
-slice magnitude as `y`. Percentages are derived by the frontend from those
+Processes Base R \code{pie()} layers based on recorded plot calls. A pie layer is
+1-D and flat: one point per slice, carrying the slice label as \code{x} and the
+slice magnitude as \code{y}. Percentages are derived by the frontend from those
 magnitudes, so none are emitted here.
 }
 \keyword{internal}
@@ -123,7 +123,7 @@ Extract one point per slice from the recorded call
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-Flat list of `list(x = <label>, y = <value>)` points
+Flat list of \verb{list(x = <label>, y = <value>)} points
 }
 }
 \if{html}{\out{<hr>}}
@@ -132,8 +132,8 @@ Flat list of `list(x = <label>, y = <value>)` points
 \subsection{Method \code{resolve_slice_labels()}}{
 Resolve the per-slice labels the way pie() does
 
-`labels` defaults to `names(x)`, and falls back to the slice position
-when the input is unnamed. `pie(labels = NA)` draws neither label nor
+\code{labels} defaults to \code{names(x)}, and falls back to the slice position
+when the input is unnamed. \code{pie(labels = NA)} draws neither label nor
 leader line, but the wedges are still there and still navigable, so
 those slices are announced by position rather than as "NA".
 \subsection{Usage}{
@@ -143,7 +143,7 @@ those slices are announced by position rather than as "NA".
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{values}}{The recorded `x` argument (names still attached)}
+\item{\code{values}}{The recorded \code{x} argument (names still attached)}
 
 \item{\code{args}}{Recorded argument list from the pie() call}
 }
@@ -173,7 +173,7 @@ Generate one selector per wedge, index-aligned to the data
 
 \item{\code{gt}}{Grob tree to search}
 
-\item{\code{extracted_data}}{Points from [extract_data()], used for the count}
+\item{\code{extracted_data}}{Points from \code{extract_data()}, used for the count}
 }
 \if{html}{\out{</div>}}
 }
@@ -210,7 +210,7 @@ Character vector of grob names
 Extract the axis titles for this layer
 
 x names what the slice labels mean, y what their magnitudes measure.
-`pie()` records neither unless the author wrote one, and a pie always
+\code{pie()} records neither unless the author wrote one, and a pie always
 holds labelled categories against their magnitudes, so the defaults
 say that much rather than leaving the axes nameless.
 \subsection{Usage}{

--- a/man/BaseRPlotOrchestrator.Rd
+++ b/man/BaseRPlotOrchestrator.Rd
@@ -355,7 +355,7 @@ Panels rendered without accessible data
 
 \subsection{Returns}{
 Integer vector of 1-based panel numbers, empty when the whole
-  figure renders normally or falls back as a whole
+figure renders normally or falls back as a whole
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/BaseRSmoothLayerProcessor.Rd
+++ b/man/BaseRSmoothLayerProcessor.Rd
@@ -5,9 +5,11 @@
 \title{Base R Smooth/Density Layer Processor}
 \description{
 Processes Base R smooth curves including:
-- Density plots: plot(density()) or lines(density())
-- Loess smooth: lines(loess.smooth()) or lines(predict(loess))
-- Smooth splines: lines(smooth.spline())
+\itemize{
+\item Density plots: plot(density()) or lines(density())
+\item Loess smooth: lines(loess.smooth()) or lines(predict(loess))
+\item Smooth splines: lines(smooth.spline())
+}
 }
 \keyword{internal}
 \section{Super class}{

--- a/man/BaseRStackedBarLayerProcessor.Rd
+++ b/man/BaseRStackedBarLayerProcessor.Rd
@@ -6,7 +6,7 @@
 \description{
 Processes Base R stacked bar plot layers intercepted via the patching
 system. Assumes sorting by x (columns) and then z (rows) has already been
-applied by the `SortingPatcher`.
+applied by the \code{SortingPatcher}.
 }
 \keyword{internal}
 \section{Super class}{

--- a/man/Ggplot2BarLayerProcessor.Rd
+++ b/man/Ggplot2BarLayerProcessor.Rd
@@ -100,10 +100,10 @@ Processes bar plot layers with complete logic included
 \subsection{Method \code{format_x_value()}}{
 Format an x-axis value as character.
 
-Date / POSIXct / POSIXlt values are formatted via `format()` so that a
-`Date` column emits ISO date strings ("2024-01-02") rather than the
+Date / POSIXct / POSIXlt values are formatted via \code{format()} so that a
+\code{Date} column emits ISO date strings ("2024-01-02") rather than the
 default scale-tick labels ("Jan 02"). All other types use
-`as.character()`. Mirrors `Ggplot2CandlestickProcessor$format_x_value()`
+\code{as.character()}. Mirrors \code{Ggplot2CandlestickProcessor$format_x_value()}
 so candle and bar layers from the same Date column align string-wise.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Ggplot2BarLayerProcessor$format_x_value(x)}\if{html}{\out{</div>}}
@@ -125,7 +125,7 @@ makes indexing the break labels with them legitimate.
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{panel_params}}{This panel's entry from `built$layout$panel_params`}
+\item{\code{panel_params}}{This panel's entry from \code{built$layout$panel_params}}
 
 \item{\code{x_pos}}{Built x positions for this panel}
 
@@ -167,9 +167,9 @@ Recover user-facing x values for a non-discrete scale.
 
 Built positions on a continuous, Date or datetime scale already are
 the values, but a Date arrives as a day count. Matching them back to
-the mapped column restores the original typing so `format_x_value()`
+the mapped column restores the original typing so \code{format_x_value()}
 can emit "2024-01-02" rather than "19724". Mirrors the same recovery
-in `Ggplot2LineLayerProcessor`.
+in \code{Ggplot2LineLayerProcessor}.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Ggplot2BarLayerProcessor$map_continuous_x(x_pos, plot, layer_index)}\if{html}{\out{</div>}}
 }

--- a/man/Ggplot2CandlestickProcessor.Rd
+++ b/man/Ggplot2CandlestickProcessor.Rd
@@ -9,24 +9,26 @@ Candlestick Layer Processor
 Candlestick Layer Processor
 }
 \details{
-Processes candlestick chart layers produced by `tidyquant::geom_candlestick()`.
+Processes candlestick chart layers produced by \code{tidyquant::geom_candlestick()}.
 
-tidyquant's `geom_candlestick()` expands into TWO ggplot layers:
-  1. A `GeomLinerangeBC` (BC = barchart) layer drawing the high-low wicks.
-  2. A `GeomRectCS` (CS = candlestick) layer drawing the open-close bodies.
+tidyquant's \code{geom_candlestick()} expands into TWO ggplot layers:
+\enumerate{
+\item A \code{GeomLinerangeBC} (BC = barchart) layer drawing the high-low wicks.
+\item A \code{GeomRectCS} (CS = candlestick) layer drawing the open-close bodies.
+}
 
-The adapter tags the wick layer as `"skip"` so the orchestrator does not
+The adapter tags the wick layer as \code{"skip"} so the orchestrator does not
 create a separate maidr layer for it. This processor handles only the
 second (body) layer, but reads back into the wick layer's grobs to
 produce wick CSS selectors.
 
-Output type: `"candlestick"`. Each data point is a `CandlestickPoint`
-with `value`, `open`, `high`, `low`, `close`, optional `volume`,
-computed `trend` (Bull / Bear / Neutral) and `volatility` (high - low).
+Output type: \code{"candlestick"}. Each data point is a \code{CandlestickPoint}
+with \code{value}, \code{open}, \code{high}, \code{low}, \code{close}, optional \code{volume},
+computed \code{trend} (Bull / Bear / Neutral) and \code{volatility} (high - low).
 
-Selectors are emitted as a single `CandlestickSelector` object whose
-`body` and `wick` fields are arrays of per-candle CSS selectors using
-`:nth-of-type` against the rect/line elements of the gridSVG-exported
+Selectors are emitted as a single \code{CandlestickSelector} object whose
+\code{body} and \code{wick} fields are arrays of per-candle CSS selectors using
+\verb{:nth-of-type} against the rect/line elements of the gridSVG-exported
 tidyquant grobs.
 }
 \keyword{internal}
@@ -142,10 +144,10 @@ List of CandlestickPoint dicts
 \subsection{Method \code{generate_selectors()}}{
 Generate candlestick CSS selectors
 
-Returns a single `CandlestickSelector` object with `body` and `wick`
+Returns a single \code{CandlestickSelector} object with \code{body} and \code{wick}
 as single CSS group selectors (one per element kind, not per candle).
 The maidr JS layer uses these to grab all candle elements at once and
-then auto-derives `open`/`close` from body rect edges based on trend.
+then auto-derives \code{open}/\code{close} from body rect edges based on trend.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Ggplot2CandlestickProcessor$generate_selectors(
   plot,
@@ -169,8 +171,8 @@ then auto-derives `open`/`close` from body rect edges based on trend.
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-Named list with `body` and (optionally) `wick` single-string
-  selectors, or empty list if grobs cannot be located.
+Named list with \code{body} and (optionally) \code{wick} single-string
+selectors, or empty list if grobs cannot be located.
 }
 }
 \if{html}{\out{<hr>}}
@@ -181,8 +183,8 @@ Extract axes labels for candlestick layer
 
 Candlestick layer mappings are typically NULL (top-level mapping
 carries x/open/high/low/close). The base implementation only inspects
-`layer_mapping$x` and `layer_mapping$y`, which yields blank labels.
-Here we additionally fall back to `plot$mapping$x` and synthesize a
+\code{layer_mapping$x} and \code{layer_mapping$y}, which yields blank labels.
+Here we additionally fall back to \code{plot$mapping$x} and synthesize a
 "Price" y-label since OHLC has no single y mapping.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Ggplot2CandlestickProcessor$extract_layer_axes(plot, layout)}\if{html}{\out{</div>}}
@@ -205,7 +207,7 @@ list(x = list(label = ...), y = list(label = ...))
 \if{html}{\out{<a id="method-Ggplot2CandlestickProcessor-resolve_col"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2CandlestickProcessor-resolve_col}{}}}
 \subsection{Method \code{resolve_col()}}{
-Resolve a mapping quosure to a column name in `data`
+Resolve a mapping quosure to a column name in \code{data}
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Ggplot2CandlestickProcessor$resolve_col(mapping_expr, data)}\if{html}{\out{</div>}}
 }
@@ -278,7 +280,7 @@ The panel gTree, or NULL when it cannot be resolved
 \if{html}{\out{<a id="method-Ggplot2CandlestickProcessor-find_first_child_name"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2CandlestickProcessor-find_first_child_name}{}}}
 \subsection{Method \code{find_first_child_name()}}{
-Find the first descendant whose name matches `pattern`
+Find the first descendant whose name matches \code{pattern}
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Ggplot2CandlestickProcessor$find_first_child_name(grob, pattern)}\if{html}{\out{</div>}}
 }

--- a/man/Ggplot2DodgedBarLayerProcessor.Rd
+++ b/man/Ggplot2DodgedBarLayerProcessor.Rd
@@ -74,12 +74,12 @@ Processes dodged bar plot layers with complete logic included
 \if{latex}{\out{\hypertarget{method-Ggplot2DodgedBarLayerProcessor-resolve_aes_values}{}}}
 \subsection{Method \code{resolve_aes_values()}}{
 Resolve this layer's x/y/fill aesthetics to VALUES.
-  `rlang::as_label()` produces a display string, which doubles as a
-  column name only for bare-column mappings. Evaluating the quosure
-  against the data also covers expression aesthetics such as
-  `aes(fill = factor(cyl))`, which are idiomatic ggplot2 and which
-  the column-name treatment turned into `data[["factor(cyl)"]]`,
-  i.e. NULL.
+\code{rlang::as_label()} produces a display string, which doubles as a
+column name only for bare-column mappings. Evaluating the quosure
+against the data also covers expression aesthetics such as
+\code{aes(fill = factor(cyl))}, which are idiomatic ggplot2 and which
+the column-name treatment turned into \code{data[["factor(cyl)"]]},
+i.e. NULL.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Ggplot2DodgedBarLayerProcessor$resolve_aes_values(plot, data)}\if{html}{\out{</div>}}
 }
@@ -94,7 +94,7 @@ Resolve this layer's x/y/fill aesthetics to VALUES.
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-List with `x`, `y` and `fill` vectors (any may be NULL)
+List with \code{x}, \code{y} and \code{fill} vectors (any may be NULL)
 }
 }
 \if{html}{\out{<hr>}}
@@ -102,12 +102,12 @@ List with `x`, `y` and `fill` vectors (any may be NULL)
 \if{latex}{\out{\hypertarget{method-Ggplot2DodgedBarLayerProcessor-discrete_level_order}{}}}
 \subsection{Method \code{discrete_level_order()}}{
 Order the distinct values of an aesthetic the way ggplot2
-  lays them out, so the emitted columns line up with the drawn ones.
-  A factor follows its own level order, minus the levels nothing was
-  drawn for; anything else sorts in its own type's order. Sorting the
-  values AS TEXT, which is what this used to do, reordered the columns
-  twice over: against a factor whose levels are not alphabetical, and
-  against a number, where it puts 10 before 2.
+lays them out, so the emitted columns line up with the drawn ones.
+A factor follows its own level order, minus the levels nothing was
+drawn for; anything else sorts in its own type's order. Sorting the
+values AS TEXT, which is what this used to do, reordered the columns
+twice over: against a factor whose levels are not alphabetical, and
+against a number, where it puts 10 before 2.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Ggplot2DodgedBarLayerProcessor$discrete_level_order(values)}\if{html}{\out{</div>}}
 }

--- a/man/Ggplot2LineLayerProcessor.Rd
+++ b/man/Ggplot2LineLayerProcessor.Rd
@@ -5,8 +5,10 @@
 \title{Final Line Layer Processor - Uses Actual SVG Structure}
 \description{
 Processes line plot layers using the actual gridSVG structure discovered:
-- Lines: GRID.polyline.61.1.1, GRID.polyline.61.1.2, GRID.polyline.61.1.3
-- Points: geom_point.points.63.1.1 through geom_point.points.63.1.24 (grouped by series)
+\itemize{
+\item Lines: GRID.polyline.61.1.1, GRID.polyline.61.1.2, GRID.polyline.61.1.3
+\item Points: geom_point.points.63.1.1 through geom_point.points.63.1.24 (grouped by series)
+}
 }
 \keyword{internal}
 \section{Super class}{
@@ -187,8 +189,8 @@ A line has no fill, so only the colour aesthetic is probed.
 }
 \subsection{Returns}{
 list with \code{aes} (aesthetic spelling variants, or NULL when
-  nothing is mapped) and \code{column} (the mapped column name, or
-  "group" as a fallback)
+nothing is mapped) and \code{column} (the mapped column name, or
+"group" as a fallback)
 }
 }
 \if{html}{\out{<hr>}}
@@ -196,16 +198,16 @@ list with \code{aes} (aesthetic spelling variants, or NULL when
 \if{latex}{\out{\hypertarget{method-Ggplot2LineLayerProcessor-extract_layer_axes}{}}}
 \subsection{Method \code{extract_layer_axes()}}{
 Extract axes labels for line layers, with a special case for
-moving-average geoms (e.g. `tidyquant::geom_ma`).
+moving-average geoms (e.g. \code{tidyquant::geom_ma}).
 
-By default the parent `LayerProcessor$extract_layer_axes()` reads the
+By default the parent \code{LayerProcessor$extract_layer_axes()} reads the
 y-label from the layer's aesthetic mapping. For a moving-average
-overlay typically written as `geom_ma(aes(y = close), ma_fun = SMA, ...)`,
-this yields the literal input-column name `"close"`, which is misleading:
+overlay typically written as \code{geom_ma(aes(y = close), ma_fun = SMA, ...)},
+this yields the literal input-column name \code{"close"}, which is misleading:
 the value being plotted (and announced during navigation) is the moving
-average of `close`, not `close` itself. We detect `GeomMA` (the class of
+average of \code{close}, not \code{close} itself. We detect \code{GeomMA} (the class of
 tidyquant's geom_ma layer) and override the y-label accordingly. Plain
-`geom_line` / `geom_smooth` overlays are untouched.
+\code{geom_line} / \code{geom_smooth} overlays are untouched.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Ggplot2LineLayerProcessor$extract_layer_axes(plot, layout)}\if{html}{\out{</div>}}
 }
@@ -345,11 +347,11 @@ Numeric vector the same length as \code{values}
 \subsection{Method \code{format_x_value()}}{
 Format an x-axis value as character.
 
-Date / POSIXct / POSIXlt values are formatted via `format()` so that a
-`Date` column emits ISO date strings (e.g. "2024-01-02") rather than
+Date / POSIXct / POSIXlt values are formatted via \code{format()} so that a
+\code{Date} column emits ISO date strings (e.g. "2024-01-02") rather than
 the underlying numeric days-since-epoch representation produced by
-`ggplot_build()`. All other types use `as.character()`. Mirrors
-`Ggplot2BarLayerProcessor$format_x_value()` so bar and line layers
+\code{ggplot_build()}. All other types use \code{as.character()}. Mirrors
+\code{Ggplot2BarLayerProcessor$format_x_value()} so bar and line layers
 from the same Date column align string-wise.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Ggplot2LineLayerProcessor$format_x_value(x)}\if{html}{\out{</div>}}
@@ -362,11 +364,11 @@ from the same Date column align string-wise.
 \subsection{Method \code{get_original_x_column()}}{
 Recover the original (untransformed) x column for a layer.
 
-`ggplot_build()` transforms Date / POSIXct columns into numeric
-days-since-epoch on `built$data[[i]]$x`. To emit ISO strings we need
-the original column from `plot$data` (or the layer's own `data`).
+\code{ggplot_build()} transforms Date / POSIXct columns into numeric
+days-since-epoch on \code{built$data[[i]]$x}. To emit ISO strings we need
+the original column from \code{plot$data} (or the layer's own \code{data}).
 
-Returns the per-row vector of x values aligned to `built_data` if a
+Returns the per-row vector of x values aligned to \code{built_data} if a
 simple column reference is found and the lengths match, otherwise
 NULL.
 \subsection{Usage}{
@@ -540,7 +542,7 @@ Selectors for the curves inside this layer's own grob.
 }
 \subsection{Returns}{
 List of selectors, or NULL when the grob does not line up
-  with the series
+with the series
 }
 }
 \if{html}{\out{<hr>}}
@@ -691,7 +693,7 @@ List with single selector
 \if{html}{\out{<a id="method-Ggplot2LineLayerProcessor-line_layer_position"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2LineLayerProcessor-line_layer_position}{}}}
 \subsection{Method \code{line_layer_position()}}{
-Position (1-based) of this layer among line-typed layers in `plot`.
+Position (1-based) of this layer among line-typed layers in \code{plot}.
 Returns NULL if the registry-based detection fails.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Ggplot2LineLayerProcessor$line_layer_position(plot)}\if{html}{\out{</div>}}

--- a/man/Ggplot2PieLayerProcessor.Rd
+++ b/man/Ggplot2PieLayerProcessor.Rd
@@ -112,6 +112,21 @@ The magnitude is the segment's own extent, not the stacked \code{y}:
 \code{ymax - ymin} is what the wedge actually subtends, and it is the
 one expression that works for both \code{geom_col()} (stat identity)
 and \code{geom_bar()} (stat count).
+
+The extent is unsigned, though, and a negative datum is stacked
+\emph{below} the baseline: ggplot2 builds \code{v = -40} as
+\code{ymin = -40, ymax = 0}, so the extent is 40 and the sign is gone.
+Reporting that would announce a slice the author entered as -40 as
+\code{40}, and compute its share against a total that swallowed it --
+confidently wrong, and indistinguishable from real data.
+
+So the sign is restored from which side of the baseline the segment
+sits on. The renderer treats a negative slice as a gap, announcing it
+as missing rather than letting it corrupt every other slice's
+percentage; laundering it here would leave that defence nothing to
+catch. Whether a producer should reject such a value outright is a
+separate question -- see xability/maidr#771 -- but no answer to it is
+served by destroying the sign first.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Ggplot2PieLayerProcessor$extract_data(plot, built = NULL, panel_id = NULL)}\if{html}{\out{</div>}}
 }
@@ -178,7 +193,7 @@ row shares group -1 or 1), so no aesthetic names its wedges.
 }
 \subsection{Returns}{
 list with \code{aes} (aesthetic name, or NULL) and
-  \code{column} (the mapped column name)
+\code{column} (the mapped column name)
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/Ggplot2ViolinLayerProcessor.Rd
+++ b/man/Ggplot2ViolinLayerProcessor.Rd
@@ -10,10 +10,10 @@ Violin Layer Processor
 }
 \details{
 Processes violin layers (geom_violin) to extract density curve (KDE) data
-and box-summary statistics, producing two maidr layers: `violin_kde` and
-`violin_box`.
+and box-summary statistics, producing two maidr layers: \code{violin_kde} and
+\code{violin_box}.
 
-The processor injects a thin `geom_boxplot(width = 0.1)` into the plot
+The processor injects a thin \code{geom_boxplot(width = 0.1)} into the plot
 before rendering so that the SVG contains visible box elements whose
 CSS selectors can drive the violin_box highlight in the maidr frontend.
 }
@@ -93,7 +93,7 @@ Inject geom_boxplot into the plot for visual box + selectors
 Augmented ggplot2 object with boxplot layer added
 Process the violin layer
 
-Returns a list with `multi_layer = TRUE` and two maidr layers:
+Returns a list with \code{multi_layer = TRUE} and two maidr layers:
 violin_box (with BoxSelector objects) and violin_kde.
 }
 }
@@ -166,9 +166,9 @@ Extract KDE density-curve data per violin group
 
 Uses ggplot2's built violin data (violinwidth, x, y, width columns)
 to compute left/right violin edges, applies RDP simplification to
-~30 points per violin, and includes the `width` field needed by the
-maidr frontend.  The `svg_x`/`svg_y` coordinates are injected later
-by `create_enhanced_svg()` after the grid device is drawn.
+~30 points per violin, and includes the \code{width} field needed by the
+maidr frontend.  The \code{svg_x}/\code{svg_y} coordinates are injected later
+by \code{create_enhanced_svg()} after the grid device is drawn.
 }
 }
 \if{html}{\out{<hr>}}
@@ -326,10 +326,10 @@ The violin layer's mapping merged with the plot's
 
 Built in ggplot2's own order -- the layer's own aesthetics first, then
 whatever only the plot maps -- because the order is not cosmetic.
-ggplot2 numbers `group` from the interaction of a layer's discrete
+ggplot2 numbers \code{group} from the interaction of a layer's discrete
 columns taken in the order the mapping produced them, so a mapping
 assembled the other way round gives the injected box different group
-ids than the violin, and every lookup keyed on `group` then crosses
+ids than the violin, and every lookup keyed on \code{group} then crosses
 the two layers.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Ggplot2ViolinLayerProcessor$get_effective_mapping(plot)}\if{html}{\out{</div>}}
@@ -353,9 +353,9 @@ Named list of quosures, one per mapped aesthetic
 Break labels of whichever panel axis holds the categories
 
 The categorical axis is the discrete one, which is not always the axis
-the data is keyed on: `coord_flip()` leaves the data x-major while
+the data is keyed on: \code{coord_flip()} leaves the data x-major while
 moving the category labels to the y axis, so reading the axis off
-`flipped_aes` alone returns the value axis' breaks and every violin is
+\code{flipped_aes} alone returns the value axis' breaks and every violin is
 labelled with a number.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Ggplot2ViolinLayerProcessor$discrete_axis_labels(built)}\if{html}{\out{</div>}}
@@ -370,7 +370,7 @@ labelled with a number.
 }
 \subsection{Returns}{
 Character vector of labels, or NULL when neither axis is
-  discrete (a continuous category axis carries its value directly)
+discrete (a continuous category axis carries its value directly)
 }
 }
 \if{html}{\out{<hr>}}
@@ -396,7 +396,7 @@ apart.
 }
 \subsection{Returns}{
 Named character vector (colour -> level), or NULL when the plot
-  has no fill scale
+has no fill scale
 }
 }
 \if{html}{\out{<hr>}}
@@ -436,13 +436,13 @@ Character vector of labels, one per group
 \subsection{Method \code{boxplot_stats()}}{
 Box statistics ggplot2 itself computed for each group
 
-The processor injects a `geom_boxplot()` so the SVG has box elements to
-highlight; that layer's `stat_boxplot` output is also the authoritative
-source for the numbers to announce. Reading it keyed by `group` avoids
+The processor injects a \code{geom_boxplot()} so the SVG has box elements to
+highlight; that layer's \code{stat_boxplot} output is also the authoritative
+source for the numbers to announce. Reading it keyed by \code{group} avoids
 re-deriving quartiles from the original data via a rounded axis
 position and a string match on the break label -- a round trip that
 silently mislabels dodged violins and finds nothing at all under
-`coord_flip()`.
+\code{coord_flip()}.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Ggplot2ViolinLayerProcessor$boxplot_stats(plot, built)}\if{html}{\out{</div>}}
 }

--- a/man/adjust_chartseries_bracket.Rd
+++ b/man/adjust_chartseries_bracket.Rd
@@ -14,31 +14,31 @@ candlestick layers)}
 }
 \value{
 Modified SVG content (character vector). If any guard fails,
-  returns `svg_content` unchanged.
+returns \code{svg_content} unchanged.
 }
 \description{
-`quantmod::chartSeries()` renders a bracketed date-range header
-(e.g. "[2024-01-12/2024-01-15]") via base R `title()` with `par(adj=1)`.
+\code{quantmod::chartSeries()} renders a bracketed date-range header
+(e.g. \code{"[2024-01-12/2024-01-15]"}) via base R \code{title()} with \code{par(adj=1)}.
 For short timeseries the text width exceeds the available right margin
 and the closing bracket is clipped at the SVG viewBox edge. This is
 upstream quantmod issue #129 (open since 2016, no fix). See
-`chartSeries.chob.R` lines 205-209 for the hardcoded placement.
+\code{chartSeries.chob.R} lines 205-209 for the hardcoded placement.
 }
 \details{
-Earlier we tried CSS `overflow: visible`, but that re-exposes
-chartSeries' intentionally negative-y volume `<rect>`s which rely on
-the SVG root's default `overflow: hidden` for clipping. Further canvas
-enlargement is impractical: the header is anchored at ~91% of canvas
+Earlier we tried CSS \code{overflow: visible}, but that re-exposes
+chartSeries' intentionally negative-y volume \verb{<rect>}s which rely on
+the SVG root's default \code{overflow: hidden} for clipping. Further canvas
+enlargement is impractical: the header is anchored at ~91\% of canvas
 width regardless of total width, so even 24-inch canvases would still
 leave the header riding the right edge.
 
 This helper performs surgical SVG post-processing on the exported
 gridSVG output: it locates the bracket text element by content pattern,
-switches its `text-anchor` to `end`, and snaps its `x` coordinate to
-95% of the viewBox width. The text then right-aligns within the
+switches its \code{text-anchor} to \code{end}, and snaps its \code{x} coordinate to
+95\% of the viewBox width. The text then right-aligns within the
 viewBox regardless of header length.
 
-Safety: this is a no-op when `maidr_data` contains no candlestick
+Safety: this is a no-op when \code{maidr_data} contains no candlestick
 layers (ggplot candlestick / non-candlestick plots), when xml2 is
 unavailable, when the SVG fails to parse, when the viewBox cannot be
 read, or when no element matches the bracket pattern.

--- a/man/adjust_chartseries_bracket_doc.Rd
+++ b/man/adjust_chartseries_bracket_doc.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/svg_utils.R
 \name{adjust_chartseries_bracket_doc}
 \alias{adjust_chartseries_bracket_doc}
-\title{Document-level implementation of [adjust_chartseries_bracket()]}
+\title{Document-level implementation of \code{\link[=adjust_chartseries_bracket]{adjust_chartseries_bracket()}}}
 \usage{
 adjust_chartseries_bracket_doc(svg_doc)
 }
@@ -13,6 +13,6 @@ adjust_chartseries_bracket_doc(svg_doc)
 TRUE if the document was modified
 }
 \description{
-Mutates `svg_doc` in place.
+Mutates \code{svg_doc} in place.
 }
 \keyword{internal}

--- a/man/attach_series_group_axis.Rd
+++ b/man/attach_series_group_axis.Rd
@@ -32,7 +32,7 @@ The axes list, with z added when the layer is grouped
 }
 \description{
 A grouped layer emits a per-series \code{z} value (the group's name), and
-MAIDR announces it as "<z label> is <z value>". Without a z label the
+MAIDR announces it as "\if{html}{\out{<z label>}} is \if{html}{\out{<z value>}}". Without a z label the
 frontend falls back to the generic word "Group", losing the legend title the
 plot actually shows. Single-series layers emit no z value at all, so they
 get no z label either.

--- a/man/augment_leaf_plot.Rd
+++ b/man/augment_leaf_plot.Rd
@@ -14,9 +14,9 @@ The augmented ggplot (the input unchanged when nothing augments)
 }
 \description{
 Some processors need extra geoms in the rendered SVG to hang selectors on
--- violin injects a thin `geom_boxplot()` so the box-summary layer has
+-- violin injects a thin \code{geom_boxplot()} so the box-summary layer has
 something to highlight. The single-plot path does this in
-`Ggplot2PlotOrchestrator$process_layers()`; leaves of a patchwork need the
+\code{Ggplot2PlotOrchestrator$process_layers()}; leaves of a patchwork need the
 same treatment before the composition is rendered.
 }
 \keyword{internal}

--- a/man/augment_patchwork_leaves.Rd
+++ b/man/augment_patchwork_leaves.Rd
@@ -13,9 +13,9 @@ augment_patchwork_leaves(node)
 The same structure with each leaf augmented
 }
 \description{
-Mirrors [extract_patchwork_leaves()]'s traversal so the augmented tree has
+Mirrors \code{\link[=extract_patchwork_leaves]{extract_patchwork_leaves()}}'s traversal so the augmented tree has
 the same leaf order. The result must be used for BOTH
-`patchwork::patchworkGrob()` and [process_patchwork_plot_data()]: grob names
+\code{patchwork::patchworkGrob()} and \code{\link[=process_patchwork_plot_data]{process_patchwork_plot_data()}}: grob names
 come from a global counter, so selectors computed against one build cannot
 resolve against another.
 }

--- a/man/base-r-wrappers.Rd
+++ b/man/base-r-wrappers.Rd
@@ -119,21 +119,21 @@ Same as the original Base R function (invisibly when applicable).
 MAIDR wraps standard Base R graphics functions to intercept plot calls
 and enable accessible, interactive visualizations. When the maidr package
 is loaded, these wrappers automatically replace the standard functions
-on the search path, recording plot data so that [show()] can render
+on the search path, recording plot data so that \code{\link[=show]{show()}} can render
 accessible versions.
 
 The wrappers are transparent: they call the original graphics functions
-and return the same results. When patching is disabled (via [maidr_off()]),
+and return the same results. When patching is disabled (via \code{\link[=maidr_off]{maidr_off()}}),
 they pass through directly to the originals with no overhead.
 }
 \details{
 These stub definitions are overwritten during package loading by the
-actual wrapper implementations created in [initialize_base_r_patching()].
+actual wrapper implementations created in \code{\link[=initialize_base_r_patching]{initialize_base_r_patching()}}.
 They exist here solely to generate the necessary NAMESPACE exports
 via roxygen2.
 }
 \seealso{
-[show()] for displaying accessible plots, [maidr_on()],
-  [maidr_off()] for controlling patching
+\code{\link[=show]{show()}} for displaying accessible plots, \code{\link[=maidr_on]{maidr_on()}},
+\code{\link[=maidr_off]{maidr_off()}} for controlling patching
 }
 \keyword{internal}

--- a/man/base_r_axis_labels.Rd
+++ b/man/base_r_axis_labels.Rd
@@ -5,10 +5,10 @@
 \title{Base R Axis-Title Defaults}
 \description{
 Base R's high-level plotting functions derive their axis titles inside the
-call (`hist()` names the y axis "Frequency", `boxplot.formula()` reads both
-titles off the formula) instead of recording them, and `barplot()` and
-`pie()` draw no title at all. Either way the recorded call carries no
-`xlab=`/`ylab=`, so a processor that only reads those arguments announces a
+call (\code{hist()} names the y axis "Frequency", \code{boxplot.formula()} reads both
+titles off the formula) instead of recording them, and \code{barplot()} and
+\code{pie()} draw no title at all. Either way the recorded call carries no
+\verb{xlab=}/\verb{ylab=}, so a processor that only reads those arguments announces a
 nameless axis.
 }
 \details{

--- a/man/base_r_categorical_axes.Rd
+++ b/man/base_r_categorical_axes.Rd
@@ -16,7 +16,7 @@ which swaps which visual axis holds the categories}
 Canonical axes list
 }
 \description{
-`barplot()`, `boxplot()` and `pie()` all plot one categorical axis against
+\code{barplot()}, \code{boxplot()} and \code{pie()} all plot one categorical axis against
 one measured axis, and none of them writes a title unless the author does.
 Naming those axes for what they hold -- "Category" against "Value" -- says
 what the numbers mean, where the renderer's positional "X"/"Y" fallback

--- a/man/build_axes.Rd
+++ b/man/build_axes.Rd
@@ -15,7 +15,7 @@ build_axes(x = NULL, y = NULL, z = NULL)
 }
 \value{
 A canonical axes list with only non-NULL axes set. Named even when
-  empty, so it serializes as the JSON object `{}` rather than as `[]`.
+empty, so it serializes as the JSON object \code{{}} rather than as \verb{[]}.
 }
 \description{
 Convenience constructor for a per-axis axes list. Drops NULL and empty

--- a/man/build_axis_config.Rd
+++ b/man/build_axis_config.Rd
@@ -21,6 +21,6 @@ A named list (AxisConfig), possibly empty
 \description{
 Drops the fields that are absent, so an axis only carries what its caller
 could establish. Returns a named empty list when nothing could be: passed
-to [build_axes()], that drops the axis key entirely.
+to \code{\link[=build_axes]{build_axes()}}, that drops the axis key entirely.
 }
 \keyword{internal}

--- a/man/cancel_auto_show.Rd
+++ b/man/cancel_auto_show.Rd
@@ -7,7 +7,7 @@
 cancel_auto_show()
 }
 \description{
-Removes by NAME rather than by the index `addTaskCallback()` returned:
+Removes by NAME rather than by the index \code{addTaskCallback()} returned:
 that index is a position in R's callback list, and any other package
 adding or removing a callback in the meantime shifts it. Removing a
 stale index silently deletes an unrelated package's callback.

--- a/man/collect_gtable_panels.Rd
+++ b/man/collect_gtable_panels.Rd
@@ -24,18 +24,18 @@ collect_gtable_panels(
 List of panel entries (name, grob, t, l, t_key, l_key, vp_path)
 }
 \description{
-Nested layouts like `(p1 | p2) / p3` place the inner row's panels inside a
+Nested layouts like \code{(p1 | p2) / p3} place the inner row's panels inside a
 CHILD gtable ("patchwork-table-N"), so scanning only the top-level layout
 drops them. Panels are collected in DISCOVERY order, which follows
 patchwork's plot-addition order and therefore matches
-[extract_patchwork_leaves()].
+\code{\link[=extract_patchwork_leaves]{extract_patchwork_leaves()}}.
 }
 \details{
 Each entry also carries the grid viewport path needed to navigate to that
 panel after the gtable has been drawn. gtable names a cell's viewport
-`<name>.<t>-<r>-<b>-<l>` and wraps a nested gtable's children in a
+\verb{<name>.<t>-<r>-<b>-<l>} and wraps a nested gtable's children in a
 "layout" viewport, so the path down to a nested panel is
-`c("<child>.t-r-b-l", "layout", "<panel>.t-r-b-l")`. Panel names are NOT
+\code{c("<child>.t-r-b-l", "layout", "<panel>.t-r-b-l")}. Panel names are NOT
 unique across a nested composition (both halves of a 2x2 contain a
 "panel-1"), which is why callers address panels by position in this list
 rather than by name.

--- a/man/compute_panel_slots.Rd
+++ b/man/compute_panel_slots.Rd
@@ -18,11 +18,11 @@ Integer vector (one entry per group): panel slot or NA
 Maps plot groups to panel slots (1-based, in drawing order) for a
 multi-panel configuration:
 \itemize{
-  \item Groups drawn BEFORE the layout call are not part of the grid
-    (the next high-level plot starts a fresh page), so they get NA.
-  \item When more groups than panels were drawn, R flows onto a new
-    page; only the final (visible) page is exported, so groups on
-    earlier pages get NA.
+\item Groups drawn BEFORE the layout call are not part of the grid
+(the next high-level plot starts a fresh page), so they get NA.
+\item When more groups than panels were drawn, R flows onto a new
+page; only the final (visible) page is exported, so groups on
+earlier pages get NA.
 }
 }
 \keyword{internal}

--- a/man/count_leaf_panels.Rd
+++ b/man/count_leaf_panels.Rd
@@ -14,7 +14,7 @@ Integer count, 0 for a wrapped leaf
 }
 \description{
 One for an ordinary leaf; one per facet cell for a faceted one; none for a
-leaf patchwork has wrapped. Used to walk `find_patchwork_panels()` in step
+leaf patchwork has wrapped. Used to walk \code{find_patchwork_panels()} in step
 with the leaf list -- a leaf that contributes no panel must not consume
 one, or every leaf after it is described over somebody else's panel.
 }

--- a/man/create_html_document.Rd
+++ b/man/create_html_document.Rd
@@ -9,8 +9,8 @@ create_html_document(svg_content, use_cdn = NULL)
 \arguments{
 \item{svg_content}{Character vector of SVG content}
 
-\item{use_cdn}{Logical. If `TRUE`, use CDN. If `FALSE`, use bundled files.
-If `NULL` (default), auto-detect based on internet availability.}
+\item{use_cdn}{Logical. If \code{TRUE}, use CDN. If \code{FALSE}, use bundled files.
+If \code{NULL} (default), auto-detect based on internet availability.}
 }
 \value{
 An htmltools HTML document object

--- a/man/create_maidr_html.Rd
+++ b/man/create_maidr_html.Rd
@@ -15,8 +15,8 @@ create_maidr_html(
 \arguments{
 \item{plot}{A ggplot2 object}
 
-\item{use_cdn}{Logical. If `TRUE`, use CDN. If `FALSE`, use bundled files.
-If `NULL` (default), auto-detect based on internet availability.}
+\item{use_cdn}{Logical. If \code{TRUE}, use CDN. If \code{FALSE}, use bundled files.
+If \code{NULL} (default), auto-detect based on internet availability.}
 
 \item{shiny}{If TRUE, returns just the SVG content instead of full HTML document}
 

--- a/man/create_maidr_iframe.Rd
+++ b/man/create_maidr_iframe.Rd
@@ -21,8 +21,8 @@ create_maidr_iframe(
 
 \item{plot_id}{Unique identifier for the plot}
 
-\item{use_cdn}{Logical. If `TRUE`, use CDN. If `FALSE`, use bundled files.
-If `NULL` (default), auto-detect based on internet availability.}
+\item{use_cdn}{Logical. If \code{TRUE}, use CDN. If \code{FALSE}, use bundled files.
+If \code{NULL} (default), auto-detect based on internet availability.}
 }
 \value{
 Character string of iframe HTML

--- a/man/create_standalone_html.Rd
+++ b/man/create_standalone_html.Rd
@@ -9,8 +9,8 @@ create_standalone_html(svg_content, use_cdn = NULL)
 \arguments{
 \item{svg_content}{Character vector of SVG content with maidr-data attribute}
 
-\item{use_cdn}{Logical. If `TRUE`, use CDN. If `FALSE`, use bundled files.
-If `NULL` (default), auto-detect based on internet availability.}
+\item{use_cdn}{Logical. If \code{TRUE}, use CDN. If \code{FALSE}, use bundled files.
+If \code{NULL} (default), auto-detect based on internet availability.}
 }
 \value{
 Character string of complete HTML document

--- a/man/curve_default_labels.Rd
+++ b/man/curve_default_labels.Rd
@@ -10,18 +10,18 @@ curve_default_labels(recorded_args)
 \item{recorded_args}{Recorded (unevaluated) argument list of the call}
 }
 \value{
-List with `x` and `y` label strings
+List with \code{x} and \code{y} label strings
 }
 \description{
 curve() computes its default labels internally and does not return them:
-the x label is `xname` ("x" unless the caller overrides it) and the y
+the x label is \code{xname} ("x" unless the caller overrides it) and the y
 label is the deparsed expression, with a bare function name rewritten as
-`fname(xname)`. Reading them off the recorded call keeps the announced
+\code{fname(xname)}. Reading them off the recorded call keeps the announced
 axes matching the drawn ones; without them a visibly labelled plot would
 be announced with two empty axis titles.
 }
 \details{
-An explicit `xlab`/`ylab` in the call wins over these defaults; the line
+An explicit \code{xlab}/\code{ylab} in the call wins over these defaults; the line
 processor applies that precedence.
 }
 \keyword{internal}

--- a/man/curve_recorded_values.Rd
+++ b/man/curve_recorded_values.Rd
@@ -12,8 +12,8 @@ curve_recorded_values(recorded_args, result)
 \item{result}{The value curve() returned}
 }
 \value{
-A list with `x`, `y` and `labels`, or NULL when the returned
-  value is not a usable pair of coordinate vectors
+A list with \code{x}, \code{y} and \code{labels}, or NULL when the returned
+value is not a usable pair of coordinate vectors
 }
 \description{
 curve() returns, invisibly, the exact x/y vectors it just drew. Keeping
@@ -23,17 +23,17 @@ evaluated once, at the moment it was made, in the frame that made it.
 \details{
 The alternative -- re-deriving the points when the figure is emitted --
 means running user code a second time, later, in a rebuilt frame. That
-is the failure mode #59 fixed for `for` loops, where every panel
+is the failure mode #59 fixed for \code{for} loops, where every panel
 replayed the last iteration's bindings; snapshot_call_env() narrows the
 window but cannot close it, and the recorded call alone is not enough
-anyway: `from`/`to` arrive unevaluated too (`to = 2 * pi` is recorded as
+anyway: \code{from}/\code{to} arrive unevaluated too (\code{to = 2 * pi} is recorded as
 a call), so emit time would have to redo curve()'s own seq/log/xname
 handling on top of evaluating the expression. Reading back what was
 drawn is neither. The SVG still comes from replaying the call, so a
 deliberately non-deterministic expression can draw a second, different
 curve -- that is true of every recorded call and is not made worse here.
 
-The values are stored under a `.maidr_` name, so clean_maidr_args()
+The values are stored under a \code{.maidr_} name, so clean_maidr_args()
 drops them before the call is replayed.
 }
 \keyword{internal}

--- a/man/dispatched_definition.Rd
+++ b/man/dispatched_definition.Rd
@@ -17,9 +17,9 @@ dispatched_definition(function_name, definition, args)
 A function to match against, or NULL when none can be resolved
 }
 \description{
-`hist` is the motivating case from #98: the generic is `hist(x, ...)`, so
-matching against it leaves a positional `breaks` inside the dots. The
+\code{hist} is the motivating case from #98: the generic is \code{hist(x, ...)}, so
+matching against it leaves a positional \code{breaks} inside the dots. The
 method carries the formals that matter, and picking it by the first
-argument's class is the same choice `UseMethod()` made when the call ran.
+argument's class is the same choice \code{UseMethod()} made when the call ran.
 }
 \keyword{internal}

--- a/man/dot-maidr_chartseries_ta_warned.Rd
+++ b/man/dot-maidr_chartseries_ta_warned.Rd
@@ -11,7 +11,7 @@ An object of class \code{environment} of length 1.
 .maidr_chartseries_ta_warned
 }
 \description{
-Environment used to suppress repeat chartSeries `TA` advisory warnings
+Environment used to suppress repeat chartSeries \code{TA} advisory warnings
 within a single session.
 }
 \keyword{internal}

--- a/man/drop_empty_selectors.Rd
+++ b/man/drop_empty_selectors.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/svg_utils.R
 \name{drop_empty_selectors}
 \alias{drop_empty_selectors}
-\title{Drop `selectors` entries that carry no selector}
+\title{Drop \code{selectors} entries that carry no selector}
 \usage{
 drop_empty_selectors(node)
 }
@@ -10,20 +10,20 @@ drop_empty_selectors(node)
 \item{node}{A maidr-data node (list, or a leaf)}
 }
 \value{
-The node with empty `selectors` entries removed
+The node with empty \code{selectors} entries removed
 }
 \description{
 A layer that resolved no highlight target must say so by OMITTING the key,
-never by sending an empty list. The frontend hands `layer.selectors`
-straight to `document.querySelectorAll()`, and an empty array stringifies
-to `""`, which is a `SyntaxError` -- thrown inside the trace constructor,
+never by sending an empty list. The frontend hands \code{layer.selectors}
+straight to \code{document.querySelectorAll()}, and an empty array stringifies
+to \code{""}, which is a \code{SyntaxError} -- thrown inside the trace constructor,
 so the whole figure fails to initialise: no announcement, no sonification,
 no braille, no keyboard entry, on a chart that still looks fine. An absent
 key is falsy and takes the frontend's own "no selectors" path instead.
 }
 \details{
 Applied here rather than in each processor because every payload passes
-through this one point, and `list()` is the honest return value for a
+through this one point, and \code{list()} is the honest return value for a
 processor whose grob lookup found nothing.
 }
 \keyword{internal}

--- a/man/embed_volume_into_candle_data.Rd
+++ b/man/embed_volume_into_candle_data.Rd
@@ -8,12 +8,14 @@ embed_volume_into_candle_data(candle_layer, bar_layer)
 }
 \description{
 Strategy:
-  1. If both layers have the same number of points, embed positionally.
-     This is the canonical case: patchwork stacks two panels driven by
-     the same date column, so the i-th candle and the i-th bar refer to
-     the same trading day even if the bar layer's x is formatted
-     differently from the candle's `value`.
-  2. Otherwise, fall back to string-matching the candle's `value` field
-     against the bar layer's `x` field.
+\enumerate{
+\item If both layers have the same number of points, embed positionally.
+This is the canonical case: patchwork stacks two panels driven by
+the same date column, so the i-th candle and the i-th bar refer to
+the same trading day even if the bar layer's x is formatted
+differently from the candle's \code{value}.
+\item Otherwise, fall back to string-matching the candle's \code{value} field
+against the bar layer's \code{x} field.
+}
 }
 \keyword{internal}

--- a/man/extract_body_grob_id.Rd
+++ b/man/extract_body_grob_id.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/svg_utils.R
 \name{extract_body_grob_id}
 \alias{extract_body_grob_id}
-\title{Extract the body `<g>` id from a candlestick `body` selector}
+\title{Extract the body \verb{<g>} id from a candlestick \code{body} selector}
 \usage{
 extract_body_grob_id(body_selector)
 }

--- a/man/extract_format_config.Rd
+++ b/man/extract_format_config.Rd
@@ -11,7 +11,7 @@ extract_format_config(built)
 }
 \value{
 A list with \code{x} and/or \code{y} format configurations,
-  or NULL if no format config is found
+or NULL if no format config is found
 }
 \description{
 Extracts MAIDR format configuration from the scale objects in a built

--- a/man/extract_patchwork_leaves.Rd
+++ b/man/extract_patchwork_leaves.Rd
@@ -13,7 +13,7 @@ extract_patchwork_leaves(node)
 List of leaf ggplot objects
 }
 \description{
-The order matches panel discovery order in [find_patchwork_panels()]
+The order matches panel discovery order in \code{\link[=find_patchwork_panels]{find_patchwork_panels()}}
 (patches first, then the plot carried by the patchwork object itself),
 which is how leaves are paired with panels.
 }

--- a/man/facet_group_rows.Rd
+++ b/man/facet_group_rows.Rd
@@ -9,24 +9,24 @@ facet_group_rows(values, group)
 \arguments{
 \item{values}{The facet column of the layer's data}
 
-\item{group}{The panel's own facet group, possibly `NA`}
+\item{group}{The panel's own facet group, possibly \code{NA}}
 }
 \value{
-A logical vector, one element per row, never `NA`
+A logical vector, one element per row, never \code{NA}
 }
 \description{
-The obvious `values == group` is wrong the moment the facet column holds
-an `NA`: `==` answers `NA` for that row, and `[` turns an `NA` index into
-a fabricated all-`NA` row. One missing facet value therefore injects junk
-rows into EVERY panel's subset, not only the panel the `NA` belongs to.
+The obvious \code{values == group} is wrong the moment the facet column holds
+an \code{NA}: \code{==} answers \code{NA} for that row, and \code{[} turns an \code{NA} index into
+a fabricated all-\code{NA} row. One missing facet value therefore injects junk
+rows into EVERY panel's subset, not only the panel the \code{NA} belongs to.
 }
 \details{
-`NA` is a panel, not an absence. ggplot2 lays out a real panel for it and
+\code{NA} is a panel, not an absence. ggplot2 lays out a real panel for it and
 draws "NA" on its strip, so the matching rows have to be selected for that
-panel rather than dropped everywhere. `%in%` handles the ordinary levels
-(it scores an `NA` value as `FALSE` instead of `NA`), and `is.na()` picks
-out the `NA` panel's own rows. A facet column that literally contains the
-string "NA" stays distinct from a missing value: `as.character()` leaves
-the former as `"NA"` and the latter as `NA_character_`.
+panel rather than dropped everywhere. \code{\%in\%} handles the ordinary levels
+(it scores an \code{NA} value as \code{FALSE} instead of \code{NA}), and \code{is.na()} picks
+out the \code{NA} panel's own rows. A facet column that literally contains the
+string "NA" stays distinct from a missing value: \code{as.character()} leaves
+the former as \code{"NA"} and the latter as \code{NA_character_}.
 }
 \keyword{internal}

--- a/man/find_graphics_plot_grob.Rd
+++ b/man/find_graphics_plot_grob.Rd
@@ -23,5 +23,5 @@ Find grob by element type pattern
 }
 \details{
 Searches recursively through a grob tree to find a grob whose name matches
-the pattern: graphics-plot-<number>-<element_type>-<number>
+the pattern: graphics-plot-\if{html}{\out{<number>}}-<element_type>-\if{html}{\out{<number>}}
 }

--- a/man/find_gtable_panel_grob.Rd
+++ b/man/find_gtable_panel_grob.Rd
@@ -17,8 +17,8 @@ The panel gTree, or NULL when it cannot be resolved
 \description{
 Without a panel context this keeps the single-plot behaviour: the cell
 literally named "panel". With one, the panel is addressed by
-`panel_ctx$panel_index` into [collect_gtable_panels()], whose order matches
-[find_patchwork_panels()]. Name matching is only a fallback because
+\code{panel_ctx$panel_index} into \code{\link[=collect_gtable_panels]{collect_gtable_panels()}}, whose order matches
+\code{\link[=find_patchwork_panels]{find_patchwork_panels()}}. Name matching is only a fallback because
 patchwork reuses panel names across nesting levels.
 }
 \keyword{internal}

--- a/man/find_patchwork_panels.Rd
+++ b/man/find_patchwork_panels.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/ggplot2_patchwork_utils.R
 \name{find_patchwork_panels}
 \alias{find_patchwork_panels}
-\title{Discover panels via gtable layout rows named '^panel-<num>' or '^panel-<row>-<col>'
+\title{Discover panels via gtable layout rows named '^panel-\if{html}{\out{<num>}}' or '^panel-\if{html}{\out{<row>}}-\if{html}{\out{<col>}}'
 Returns a data.frame with panel_index, name, t, l, row, col}
 \usage{
 find_patchwork_panels(gtable)
@@ -14,6 +14,6 @@ find_patchwork_panels(gtable)
 Data frame with panel information
 }
 \description{
-Discover panels via gtable layout rows named '^panel-<num>' or '^panel-<row>-<col>'
+Discover panels via gtable layout rows named '^panel-\if{html}{\out{<num>}}' or '^panel-\if{html}{\out{<row>}}-\if{html}{\out{<col>}}'
 Returns a data.frame with panel_index, name, t, l, row, col
 }

--- a/man/heatmap_applies_revc.Rd
+++ b/man/heatmap_applies_revc.Rd
@@ -10,13 +10,13 @@ heatmap_applies_revc(args)
 \item{args}{Recorded heatmap() arguments}
 }
 \value{
-TRUE when `revC` applies, i.e. the drawn rows read top-down
+TRUE when \code{revC} applies, i.e. the drawn rows read top-down
 }
 \description{
-`heatmap()` normally puts reordered row 1 at the bottom of the y axis, but
-its `revC` argument flips the drawing so row 1 lands at the top. `revC` is
-not part of the ordering `heatmap()` returns, and it defaults to
-`identical(Colv, "Rowv")` -- which is TRUE for every `symm = TRUE` call,
-since `Colv` itself defaults to `"Rowv"` there.
+\code{heatmap()} normally puts reordered row 1 at the bottom of the y axis, but
+its \code{revC} argument flips the drawing so row 1 lands at the top. \code{revC} is
+not part of the ordering \code{heatmap()} returns, and it defaults to
+\code{identical(Colv, "Rowv")} -- which is TRUE for every \code{symm = TRUE} call,
+since \code{Colv} itself defaults to \code{"Rowv"} there.
 }
 \keyword{internal}

--- a/man/heatmap_caller_labels.Rd
+++ b/man/heatmap_caller_labels.Rd
@@ -7,30 +7,30 @@
 heatmap_caller_labels(labels, ordering)
 }
 \arguments{
-\item{labels}{The recorded `labRow=` or `labCol=` argument, or NULL}
+\item{labels}{The recorded \verb{labRow=} or \verb{labCol=} argument, or NULL}
 
-\item{ordering}{The matching `rowInd`/`colInd`. Never NULL: when no
+\item{ordering}{The matching \code{rowInd}/\code{colInd}. Never NULL: when no
 ordering was recovered the caller passes the identity, because
-`heatmap()` applies a subscript either way}
+\code{heatmap()} applies a subscript either way}
 }
 \value{
 Character vector in drawn order, or NULL when the caller supplied
-  no labels for this axis
+no labels for this axis
 }
 \description{
-`heatmap()` gives an explicit `labRow=`/`labCol=` priority over the
+\code{heatmap()} gives an explicit \verb{labRow=}/\verb{labCol=} priority over the
 matrix's own dimnames, and subscripts it by the same ordering it applies to
-the data: `labRow[rowInd] \%||\% rownames(x) \%||\% (1L:nr)[rowInd]`. Reading
+the data: \code{labRow[rowInd] \%||\% rownames(x) \%||\% (1L:nr)[rowInd]}. Reading
 the labels off the reordered matrix therefore announced the dimnames -- or,
 for an unnamed matrix, bare indices -- while the axis showed the caller's
 strings.
 }
 \details{
-A short or `NA`-carrying vector is passed through rather than rejected:
-`labRow[rowInd]` yields `NA` for the positions it cannot fill, and grid
+A short or \code{NA}-carrying vector is passed through rather than rejected:
+\code{labRow[rowInd]} yields \code{NA} for the positions it cannot fill, and grid
 draws that as the glyphs "NA", so mirroring it keeps the announcement equal
 to the picture. Subscripting is also what holds the result to one label per
 row: a caller who supplies too many gets the surplus dropped, exactly as
-`heatmap()` drops it.
+\code{heatmap()} drops it.
 }
 \keyword{internal}

--- a/man/inject_candlestick_open_close.Rd
+++ b/man/inject_candlestick_open_close.Rd
@@ -10,26 +10,26 @@ inject_candlestick_open_close(svg_content, maidr_data)
 \item{svg_content}{Character vector of SVG lines}
 
 \item{maidr_data}{The maidr-data structure (read-only; used to look up
-per-candle `trend`)}
+per-candle \code{trend})}
 }
 \value{
 Modified SVG content (character vector). If parsing fails or no
-  candlestick layers are present, returns `svg_content` unchanged.
+candlestick layers are present, returns \code{svg_content} unchanged.
 }
 \description{
-tidyquant's `geom_candlestick()` draws each candle's body as a single
-`<rect>`. Upstream maidr JS auto-derives `open` and `close` highlight
+tidyquant's \code{geom_candlestick()} draws each candle's body as a single
+\verb{<rect>}. Upstream maidr JS auto-derives \code{open} and \code{close} highlight
 positions from the rect's bounding-box edges, but its heuristic assumes
 a natural SVG y-axis (y increasing downward). gridSVG exports content
-inside a `translate(0, h) scale(1, -1)` group, so y is flipped. The
+inside a \verb{translate(0, h) scale(1, -1)} group, so y is flipped. The
 upstream heuristic therefore swaps open and close on every candle.
 }
 \details{
-We sidestep the heuristic by emitting two sibling `<g>` containers (one
-for opens, one for closes), each holding N invisible `<line>` elements
+We sidestep the heuristic by emitting two sibling \verb{<g>} containers (one
+for opens, one for closes), each holding N invisible \verb{<line>} elements
 positioned at the correct edge of the corresponding body rect (computed
-from the per-candle `trend`). The candlestick processor emits explicit
-`selectors.open` / `selectors.close` referencing these groups, so JS
+from the per-candle \code{trend}). The candlestick processor emits explicit
+\code{selectors.open} / \code{selectors.close} referencing these groups, so JS
 uses our placed elements directly and skips its own derivation.
 }
 \keyword{internal}

--- a/man/inject_candlestick_open_close_doc.Rd
+++ b/man/inject_candlestick_open_close_doc.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/svg_utils.R
 \name{inject_candlestick_open_close_doc}
 \alias{inject_candlestick_open_close_doc}
-\title{Document-level implementation of [inject_candlestick_open_close()]}
+\title{Document-level implementation of \code{\link[=inject_candlestick_open_close]{inject_candlestick_open_close()}}}
 \usage{
 inject_candlestick_open_close_doc(svg_doc, maidr_data)
 }
@@ -15,6 +15,6 @@ inject_candlestick_open_close_doc(svg_doc, maidr_data)
 TRUE if the document was modified
 }
 \description{
-Mutates `svg_doc` in place (xml2 documents are references).
+Mutates \code{svg_doc} in place (xml2 documents are references).
 }
 \keyword{internal}

--- a/man/inject_violin_kde_svg_coords.Rd
+++ b/man/inject_violin_kde_svg_coords.Rd
@@ -15,19 +15,19 @@ inject_violin_kde_svg_coords(gt, maidr_data)
 Updated maidr_data with svg_x/svg_y injected
 }
 \description{
-After `grid.draw(gt)` has been called on a PDF device, this function
+After \code{grid.draw(gt)} has been called on a PDF device, this function
 navigates to the panel viewport, maps data coordinates to SVG points,
-and injects `svg_x`/`svg_y` into each ViolinKdePoint.  Temporary
-metadata fields (`.panel_x_range`, `.panel_y_range`, `.is_horizontal`,
-`.panel_index`, `.panel_name`, `data_left_x`, `data_right_x`, `data_y`) are
+and injects \code{svg_x}/\code{svg_y} into each ViolinKdePoint.  Temporary
+metadata fields (\code{.panel_x_range}, \code{.panel_y_range}, \code{.is_horizontal},
+\code{.panel_index}, \code{.panel_name}, \code{data_left_x}, \code{data_right_x}, \code{data_y}) are
 stripped from the output.
 }
 \details{
 Each violin_kde layer is mapped through the viewport of the panel it was
 extracted from, so a violin inside a patchwork gets its own panel's
 coordinates rather than the first panel's. Nested compositions repeat panel
-names across levels, so the layer's `.panel_index` (its position in
-[collect_gtable_panels()], which matches [find_patchwork_panels()]) is the
+names across levels, so the layer's \code{.panel_index} (its position in
+\code{\link[=collect_gtable_panels]{collect_gtable_panels()}}, which matches \code{\link[=find_patchwork_panels]{find_patchwork_panels()}}) is the
 primary key and the name is only a fallback.
 }
 \keyword{internal}

--- a/man/is_wrapped_leaf.Rd
+++ b/man/is_wrapped_leaf.Rd
@@ -13,7 +13,7 @@ is_wrapped_leaf(leaf_plot)
 Logical
 }
 \description{
-`inset_element()`, `free()` and `wrap_elements()` each prepend their own
+\code{inset_element()}, \code{free()} and \code{wrap_elements()} each prepend their own
 class and place the plot in a gtable cell whose name is not a plain
 "panel-N", so panel discovery never sees it. Test for the wrapper rather
 than naming them, so one added later behaves the same.

--- a/man/maidr-options.Rd
+++ b/man/maidr-options.Rd
@@ -9,16 +9,16 @@ Configure MAIDR interception and display behavior using R's options system.
 \section{Available Options}{
 
 \describe{
-  \item{\code{maidr.auto_show}}{Logical. Master switch for all MAIDR interception.
-    When FALSE, all plotting functions behave as standard R. Default: TRUE.}
-  \item{\code{maidr.base_r}}{Logical. Enable Base R plot interception.
-    When TRUE, Base R plots are captured and displayed in the MAIDR viewer.
-    Default: TRUE.}
-  \item{\code{maidr.ggplot2}}{Logical. Enable ggplot2 auto-display.
-    When TRUE, ggplot2 objects are automatically rendered in the MAIDR viewer
-    instead of the standard graphics device. Default: TRUE.}
-  \item{\code{maidr.startup_message}}{Logical. Show startup message when
-    package is loaded. Default: TRUE.}
+\item{\code{maidr.auto_show}}{Logical. Master switch for all MAIDR interception.
+When FALSE, all plotting functions behave as standard R. Default: TRUE.}
+\item{\code{maidr.base_r}}{Logical. Enable Base R plot interception.
+When TRUE, Base R plots are captured and displayed in the MAIDR viewer.
+Default: TRUE.}
+\item{\code{maidr.ggplot2}}{Logical. Enable ggplot2 auto-display.
+When TRUE, ggplot2 objects are automatically rendered in the MAIDR viewer
+instead of the standard graphics device. Default: TRUE.}
+\item{\code{maidr.startup_message}}{Logical. Show startup message when
+package is loaded. Default: TRUE.}
 }
 }
 

--- a/man/maidr-package.Rd
+++ b/man/maidr-package.Rd
@@ -16,13 +16,13 @@ understand data visualizations through multiple sensory modalities.
 \section{Main Functions}{
 
 \itemize{
-  \item \code{\link{show}}: Display an interactive MAIDR plot in the browser or RStudio Viewer
-  \item \code{\link{save_html}}: Save a plot as a standalone HTML file
-  \item \code{\link{run_example}}: Run interactive example plots
-  \item \code{\link{maidr_on}}: Enable automatic MAIDR interception in RMarkdown
-  \item \code{\link{maidr_off}}: Disable automatic MAIDR interception
-  \item \code{\link{render_maidr}}: Render MAIDR plots in Shiny applications
-  \item \code{\link{maidr_output}}: Create MAIDR output container for Shiny UI
+\item \code{\link{show}}: Display an interactive MAIDR plot in the browser or RStudio Viewer
+\item \code{\link{save_html}}: Save a plot as a standalone HTML file
+\item \code{\link{run_example}}: Run interactive example plots
+\item \code{\link{maidr_on}}: Enable automatic MAIDR interception in RMarkdown
+\item \code{\link{maidr_off}}: Disable automatic MAIDR interception
+\item \code{\link{render_maidr}}: Render MAIDR plots in Shiny applications
+\item \code{\link{maidr_output}}: Create MAIDR output container for Shiny UI
 }
 }
 
@@ -33,40 +33,40 @@ Base R plotting systems:
 
 \strong{ggplot2 plots:}
 \itemize{
-  \item Bar charts (simple, grouped, stacked) - \code{geom_bar()}, \code{geom_col()}
-  \item Pie charts - \code{geom_col()} / \code{geom_bar()} with \code{coord_polar("y")}
-  \item Histograms - \code{geom_histogram()}
-  \item Scatter plots - \code{geom_point()}
-  \item Line plots - \code{geom_line()}
-  \item Box plots - \code{geom_boxplot()}
-  \item Violin plots - \code{geom_violin()}
-  \item Heat maps - \code{geom_tile()}
-  \item Density/smooth curves - \code{geom_density()}, \code{geom_smooth()}
-  \item Faceted plots - \code{facet_wrap()}, \code{facet_grid()}
-  \item Multi-panel layouts (via 'patchwork' package)
-  \item Multi-layered plot combinations
+\item Bar charts (simple, grouped, stacked) - \code{geom_bar()}, \code{geom_col()}
+\item Pie charts - \code{geom_col()} / \code{geom_bar()} with \code{coord_polar("y")}
+\item Histograms - \code{geom_histogram()}
+\item Scatter plots - \code{geom_point()}
+\item Line plots - \code{geom_line()}
+\item Box plots - \code{geom_boxplot()}
+\item Violin plots - \code{geom_violin()}
+\item Heat maps - \code{geom_tile()}
+\item Density/smooth curves - \code{geom_density()}, \code{geom_smooth()}
+\item Faceted plots - \code{facet_wrap()}, \code{facet_grid()}
+\item Multi-panel layouts (via 'patchwork' package)
+\item Multi-layered plot combinations
 }
 
 \strong{Base R plots:}
 \itemize{
-  \item Bar plots (simple, grouped, stacked) - \code{barplot()}
-  \item Pie charts - \code{pie()}
-  \item Histograms - \code{hist()}
-  \item Scatter and line plots - \code{plot()}, \code{points()}, \code{lines()}
-  \item Box plots - \code{boxplot()}
-  \item Heat maps - \code{image()}, \code{heatmap()}
-  \item Multi-panel layouts - \code{par(mfrow)}, \code{par(mfcol)}
+\item Bar plots (simple, grouped, stacked) - \code{barplot()}
+\item Pie charts - \code{pie()}
+\item Histograms - \code{hist()}
+\item Scatter and line plots - \code{plot()}, \code{points()}, \code{lines()}
+\item Box plots - \code{boxplot()}
+\item Heat maps - \code{image()}, \code{heatmap()}
+\item Multi-panel layouts - \code{par(mfrow)}, \code{par(mfcol)}
 }
 }
 
 \section{Accessibility Features}{
 
 \itemize{
-  \item \strong{Keyboard Navigation}: Use arrow keys to explore data points
-  \item \strong{Screen Reader Support}: ARIA labels and live regions for announcements
-  \item \strong{Sonification}: Audio representation of data patterns
-  \item \strong{Text Summaries}: Automatic statistical descriptions
-  \item \strong{Grid Navigation}: Efficient exploration of scatter plots
+\item \strong{Keyboard Navigation}: Use arrow keys to explore data points
+\item \strong{Screen Reader Support}: ARIA labels and live regions for announcements
+\item \strong{Sonification}: Audio representation of data patterns
+\item \strong{Text Summaries}: Automatic statistical descriptions
+\item \strong{Grid Navigation}: Efficient exploration of scatter plots
 }
 }
 
@@ -74,10 +74,10 @@ Base R plotting systems:
 
 The package integrates seamlessly with:
 \itemize{
-  \item \strong{RStudio}: Direct display in the Viewer pane
-  \item \strong{RMarkdown/Quarto}: Automatic rendering with \code{maidr_on()}
-  \item \strong{Shiny}: Interactive plots in Shiny apps via \code{render_maidr()}
-  \item \strong{Standalone HTML}: Export plots for sharing with \code{save_html()}
+\item \strong{RStudio}: Direct display in the Viewer pane
+\item \strong{RMarkdown/Quarto}: Automatic rendering with \code{maidr_on()}
+\item \strong{Shiny}: Interactive plots in Shiny apps via \code{render_maidr()}
+\item \strong{Standalone HTML}: Export plots for sharing with \code{save_html()}
 }
 }
 
@@ -114,11 +114,11 @@ show()
 \section{Learn More}{
 
 \itemize{
-  \item Package website: \url{https://r.maidr.ai/}
-  \item MAIDR project: \url{https://maidr.ai/}
-  \item GitHub repository: \url{https://github.com/xability/r-maidr}
-  \item Get started: \code{vignette("getting-started", package = "maidr")}
-  \item Shiny integration: \code{vignette("shiny-integration", package = "maidr")}
+\item Package website: \url{https://r.maidr.ai/}
+\item MAIDR project: \url{https://maidr.ai/}
+\item GitHub repository: \url{https://github.com/xability/r-maidr}
+\item Get started: \code{vignette("getting-started", package = "maidr")}
+\item Shiny integration: \code{vignette("shiny-integration", package = "maidr")}
 }
 }
 

--- a/man/maidr_cdn_url.Rd
+++ b/man/maidr_cdn_url.Rd
@@ -12,7 +12,7 @@ CDN URL string
 \description{
 Pinned to the same version as the bundled assets: the maidr-data JSON
 emitted by this package is written against that frontend version, so an
-unpinned `@latest` CDN could silently break rendering when upstream
+unpinned \verb{@latest} CDN could silently break rendering when upstream
 releases a breaking change.
 }
 \keyword{internal}

--- a/man/maidr_get_fallback.Rd
+++ b/man/maidr_get_fallback.Rd
@@ -8,11 +8,11 @@ maidr_get_fallback()
 }
 \value{
 A list with the current fallback settings:
-  \itemize{
-    \item \code{enabled}: Logical indicating if fallback is enabled
-    \item \code{format}: Character string of the image format
-    \item \code{warning}: Logical indicating if warnings are shown
-  }
+\itemize{
+\item \code{enabled}: Logical indicating if fallback is enabled
+\item \code{format}: Character string of the image format
+\item \code{warning}: Logical indicating if warnings are shown
+}
 }
 \description{
 Retrieves the current fallback configuration for MAIDR.
@@ -24,5 +24,5 @@ print(settings)
 
 }
 \seealso{
-[maidr_set_fallback()] to configure settings
+\code{\link[=maidr_set_fallback]{maidr_set_fallback()}} to configure settings
 }

--- a/man/maidr_html_dependencies.Rd
+++ b/man/maidr_html_dependencies.Rd
@@ -7,7 +7,7 @@
 maidr_html_dependencies(use_cdn = NULL)
 }
 \arguments{
-\item{use_cdn}{Logical. If `TRUE`, use CDN. If `FALSE` or `NULL` (default),
+\item{use_cdn}{Logical. If \code{TRUE}, use CDN. If \code{FALSE} or \code{NULL} (default),
 use bundled files.}
 }
 \value{
@@ -15,25 +15,27 @@ A list containing one htmlDependency object
 }
 \description{
 Creates the HTML dependency for the MAIDR JavaScript bundle.
-Behavior is controlled by the `use_cdn` parameter:
-- If `TRUE`: Use CDN (requires internet)
-- If `FALSE` (default): Use local bundled files (works offline)
-- If `NULL`: Same as `FALSE` — use local bundled files
+Behavior is controlled by the \code{use_cdn} parameter:
+\itemize{
+\item If \code{TRUE}: Use CDN (requires internet)
+\item If \code{FALSE} (default): Use local bundled files (works offline)
+\item If \code{NULL}: Same as \code{FALSE} — use local bundled files
+}
 }
 \details{
 We default to local bundled assets for deterministic rendering. Previously
-we auto-detected via `curl::has_internet()`; when internet was available
+we auto-detected via \code{curl::has_internet()}; when internet was available
 the CDN path was selected, which combined with a (now-fixed) malformed
-nested-`<html>` HTML scaffold caused base R chart SVGs to render squished
+nested-\verb{<html>} HTML scaffold caused base R chart SVGs to render squished
 in the upper-left of the viewport. Local assets match the ggplot path that
 has always rendered correctly. Users who want CDN can still pass
-`use_cdn = TRUE` explicitly.
+\code{use_cdn = TRUE} explicitly.
 
 No stylesheet is declared. MAIDR styles its interface at runtime, and
-since maidr 3.75.1 the published `maidr.css` is a placeholder with no
-rules in it. The one stylesheet that does carry rules, `maidr-math.css`
-(KaTeX, for LaTeX in AI chat responses), is fetched by `maidr.js` itself,
+since maidr 3.75.1 the published \code{maidr.css} is a placeholder with no
+rules in it. The one stylesheet that does carry rules, \code{maidr-math.css}
+(KaTeX, for LaTeX in AI chat responses), is fetched by \code{maidr.js} itself,
 resolved against the URL it was loaded from -- the CDN directory, or the
-`lib/` folder htmltools copies the bundle into.
+\verb{lib/} folder htmltools copies the bundle into.
 }
 \keyword{internal}

--- a/man/maidr_inline_asset_tags.Rd
+++ b/man/maidr_inline_asset_tags.Rd
@@ -2,19 +2,19 @@
 % Please edit documentation in R/html_dependencies.R
 \name{maidr_inline_asset_tags}
 \alias{maidr_inline_asset_tags}
-\title{Get `<style>`/`<script>` tags with the bundled assets inlined}
+\title{Get \verb{<style>}/\verb{<script>} tags with the bundled assets inlined}
 \usage{
 maidr_inline_asset_tags()
 }
 \value{
-A named list with `css_tag` and `js_tag` strings
+A named list with \code{css_tag} and \code{js_tag} strings
 }
 \description{
 Reads the bundled maidr.js/maidr-math.css once per session and caches the
 assembled tags.
 }
 \details{
-KaTeX is inlined rather than left to `maidr.js` to fetch, because these
+KaTeX is inlined rather than left to \code{maidr.js} to fetch, because these
 tags go into a standalone document whose script is inline: it has no URL
 of its own, so the runtime has nothing to resolve the stylesheet against.
 }

--- a/man/maidr_local_assets.Rd
+++ b/man/maidr_local_assets.Rd
@@ -11,8 +11,8 @@ A named list with 'js' and 'math_css' file paths
 }
 \description{
 Returns the file paths to the locally bundled MAIDR JavaScript and KaTeX
-stylesheet. The stylesheet is `maidr-math.css`, with its base64 web fonts
-stripped by `.github/scripts/fetch-maidr-bundle.sh` to keep the installed
+stylesheet. The stylesheet is \code{maidr-math.css}, with its base64 web fonts
+stripped by \code{.github/scripts/fetch-maidr-bundle.sh} to keep the installed
 package under CRAN's size limit; KaTeX's layout rules are intact and only
 the glyphs fall back to system fonts.
 }

--- a/man/maidr_off.Rd
+++ b/man/maidr_off.Rd
@@ -15,5 +15,5 @@ After calling this, Base R plots display in the standard graphics window
 and ggplot2 objects render with the default ggplot2 method.
 }
 \seealso{
-[maidr_on()] to enable MAIDR rendering
+\code{\link[=maidr_on]{maidr_on()}} to enable MAIDR rendering
 }

--- a/man/maidr_on.Rd
+++ b/man/maidr_on.Rd
@@ -31,5 +31,5 @@ barplot(table(mtcars$cyl))
 }
 }
 \seealso{
-[maidr_off()] to disable MAIDR rendering
+\code{\link[=maidr_off]{maidr_off()}} to disable MAIDR rendering
 }

--- a/man/maidr_responsive_dependency.Rd
+++ b/man/maidr_responsive_dependency.Rd
@@ -10,13 +10,13 @@ maidr_responsive_dependency()
 A single htmltools::htmlDependency() object
 }
 \description{
-Returns an htmltools::htmlDependency() whose `head` payload injects a
+Returns an htmltools::htmlDependency() whose \code{head} payload injects a
 viewport meta tag, a minimal CSS reset, and rules that make the embedded
 SVG fill (or proportionally fit) the browser viewport. This is purely a
 presentational layer; the SVG content, selectors, viewBox, and embedded
-`maidr-data` attribute are untouched and the maidr JS frontend behaves
-identically. We use a dependency (rather than an inline `<style>` tag in
-the body) so the meta and style land in the document `<head>` produced by
-`htmltools::save_html()`.
+\code{maidr-data} attribute are untouched and the maidr JS frontend behaves
+identically. We use a dependency (rather than an inline \verb{<style>} tag in
+the body) so the meta and style land in the document \verb{<head>} produced by
+\code{htmltools::save_html()}.
 }
 \keyword{internal}

--- a/man/maidr_set_fallback.Rd
+++ b/man/maidr_set_fallback.Rd
@@ -49,5 +49,5 @@ maidr_set_fallback(enabled = TRUE, format = "png", warning = TRUE)
 
 }
 \seealso{
-[maidr_get_fallback()] to retrieve current settings
+\code{\link[=maidr_get_fallback]{maidr_get_fallback()}} to retrieve current settings
 }

--- a/man/maidr_widget.Rd
+++ b/man/maidr_widget.Rd
@@ -19,9 +19,9 @@ maidr_widget(
 \item{use_cdn}{Logical. Controls where MAIDR.js is loaded from, matching
 \code{show()} and \code{save_html()}:
 \itemize{
-  \item \code{TRUE}: Use CDN (requires internet)
-  \item \code{FALSE}: Use local bundled files (works offline)
-  \item \code{NULL} (default): Auto-detect based on internet availability
+\item \code{TRUE}: Use CDN (requires internet)
+\item \code{FALSE}: Use local bundled files (works offline)
+\item \code{NULL} (default): Auto-detect based on internet availability
 }
 This differs from \code{maidr_html_dependencies()}, where \code{NULL}
 means bundled. The widget renders through \code{create_maidr_iframe()}

--- a/man/map_visual_to_dom_panel.Rd
+++ b/man/map_visual_to_dom_panel.Rd
@@ -20,10 +20,10 @@ and DOM element generation order (column-major) in gridSVG.
 }
 \details{
 Visual layout (row-major):
- 1  2
- 3  4
+1  2
+3  4
 
 DOM order (column-major):
- 1  3
- 2  4
+1  3
+2  4
 }

--- a/man/match_recorded_args.Rd
+++ b/man/match_recorded_args.Rd
@@ -14,28 +14,29 @@ match_recorded_args(function_name, definition, args)
 \item{args}{Recorded argument list of evaluated values}
 }
 \value{
-`args` with the names R matched, in the recorded order
+\code{args} with the names R matched, in the recorded order
 }
 \description{
-A wrapper declared `function(...)` sees only the names the user typed, so
-`hist(x, 20)` records an unnamed `20` and every processor asking for
-`args[["breaks"]]` comes up empty. Running the recorded arguments through
-`match.call()` against the definition R actually dispatched to restores
+A wrapper declared \verb{function(...)} sees only the names the user typed, so
+\code{hist(x, 20)} records an unnamed \code{20} and every processor asking for
+\code{args[["breaks"]]} comes up empty. Running the recorded arguments through
+\code{match.call()} against the definition R actually dispatched to restores
 the names R itself assigned, once, for every processor.
 }
 \details{
 Two properties are preserved deliberately:
-
-* **Order.** `match.call()` reorders arguments into formal order; the
-  recorded list keeps the user's order and only gains names. Replay does
-  `do.call()`, which honours names regardless of position, while
-  `apply_barplot_sorting()` and friends still find the height in slot 1.
-* **The dispatch argument stays exactly as written.** S3 dispatch happens
-  on the first argument of the *generic*, and methods are free to rename
-  it: `plot.formula()` calls it `formula`, not `x`. Naming a positional
-  first argument would therefore break replay in one direction or the
-  other (`plot(x = mpg ~ wt)` never reaches `plot.formula()`, and
-  `plot(formula = ...)` never satisfies the generic). Leaving it untouched
-  makes the replayed call dispatch byte-identically to the user's.
+\itemize{
+\item \strong{Order.} \code{match.call()} reorders arguments into formal order; the
+recorded list keeps the user's order and only gains names. Replay does
+\code{do.call()}, which honours names regardless of position, while
+\code{apply_barplot_sorting()} and friends still find the height in slot 1.
+\item \strong{The dispatch argument stays exactly as written.} S3 dispatch happens
+on the first argument of the \emph{generic}, and methods are free to rename
+it: \code{plot.formula()} calls it \code{formula}, not \code{x}. Naming a positional
+first argument would therefore break replay in one direction or the
+other (\code{plot(x = mpg ~ wt)} never reaches \code{plot.formula()}, and
+\code{plot(formula = ...)} never satisfies the generic). Leaving it untouched
+makes the replayed call dispatch byte-identically to the user's.
+}
 }
 \keyword{internal}

--- a/man/merge_line_layers.Rd
+++ b/man/merge_line_layers.Rd
@@ -7,17 +7,17 @@
 merge_line_layers(line_layers)
 }
 \description{
-Each input line layer's `data` is a list-of-series (typically length-1 for
+Each input line layer's \code{data} is a list-of-series (typically length-1 for
 a single GeomLine/GeomMA). We concatenate all series across all layers.
 }
 \details{
 Selector handling: each input layer now resolves to its OWN polyline grob
 and emits one selector per curve it drew, so the inputs no longer overlap.
 The dedupe-and-trim below is kept as a backstop, not as the mechanism: it
-used to be load-bearing, because the generator discovered *all* polyline
+used to be load-bearing, because the generator discovered \emph{all} polyline
 grobs in the panel and handed every one of N line layers the same length-N
 set. What still has to hold after merging is the frontend precondition
-`selectors.length === data.length` — one selector per merged series —
+\verb{selectors.length === data.length} — one selector per merged series —
 which is why the trim below stays. There is deliberately no pad: a short
 list fails that precondition and the frontend drops the layer's highlight
 rather than aiming it at the wrong curve.

--- a/man/muffle_promise_restart.Rd
+++ b/man/muffle_promise_restart.Rd
@@ -10,7 +10,7 @@ muffle_promise_restart(expr)
 \item{expr}{Expression to evaluate (lazily, inside the handler)}
 }
 \value{
-The value of `expr`
+The value of \code{expr}
 }
 \description{
 When a call fails part-way through forcing an argument, that argument's

--- a/man/no_base_r_plots_message.Rd
+++ b/man/no_base_r_plots_message.Rd
@@ -12,6 +12,6 @@ The error message string.
 \description{
 Names the quantmod masking case when it applies: the bare
 "create a plot first" wording is actively misleading there, because the
-user *did* draw a chart — it just went to quantmod unrecorded.
+user \emph{did} draw a chart — it just went to quantmod unrecorded.
 }
 \keyword{internal}

--- a/man/panel_has_layer_of_type.Rd
+++ b/man/panel_has_layer_of_type.Rd
@@ -7,7 +7,7 @@
 panel_has_layer_of_type(panel, type)
 }
 \arguments{
-\item{panel}{A processed patchwork panel (with `$layers`)}
+\item{panel}{A processed patchwork panel (with \verb{$layers})}
 
 \item{type}{Layer type string ("candlestick", "bar", "line", ...)}
 }

--- a/man/panel_layer_of_type.Rd
+++ b/man/panel_layer_of_type.Rd
@@ -2,11 +2,11 @@
 % Please edit documentation in R/ggplot2_patchwork_utils.R
 \name{panel_layer_of_type}
 \alias{panel_layer_of_type}
-\title{Return the (first) layer in `panel` whose type matches `type`}
+\title{Return the (first) layer in \code{panel} whose type matches \code{type}}
 \usage{
 panel_layer_of_type(panel, type)
 }
 \description{
-Return the (first) layer in `panel` whose type matches `type`
+Return the (first) layer in \code{panel} whose type matches \code{type}
 }
 \keyword{internal}

--- a/man/panel_slot_positions.Rd
+++ b/man/panel_slot_positions.Rd
@@ -13,13 +13,13 @@ panel_slot_positions(slot, panel_config)
 }
 \value{
 List of integer vectors c(row, col); empty list if the slot
-  occupies no cell
+occupies no cell
 }
 \description{
-A `layout()` matrix may name the same panel in several cells; R draws that
+A \code{layout()} matrix may name the same panel in several cells; R draws that
 panel once, spanning all of them. Returning every matching cell (in reading
 order) lets the caller advertise the panel in each cell it actually covers,
-so a spanned region is not mistaken for empty space. An `mfrow`/`mfcol`
+so a spanned region is not mistaken for empty space. An \code{mfrow}/\code{mfcol}
 grid cannot span, so it always yields exactly one cell.
 }
 \keyword{internal}

--- a/man/process_patchwork_panel.Rd
+++ b/man/process_patchwork_panel.Rd
@@ -31,7 +31,7 @@ process_patchwork_panel(
 \item{gtable}{Gtable object}
 
 \item{n_original_layers}{Number of layers the user actually wrote. Defaults
-to every layer of `leaf_plot`; pass the un-augmented count so injected
+to every layer of \code{leaf_plot}; pass the un-augmented count so injected
 geoms (violin's boxplot) do not emit a maidr layer of their own.}
 }
 \value{

--- a/man/quantmod_mask_advice.Rd
+++ b/man/quantmod_mask_advice.Rd
@@ -10,7 +10,7 @@ quantmod_mask_advice()
 A single advice string.
 }
 \description{
-Shared by `.onAttach`, the quantmod attach hook and the
+Shared by \code{.onAttach}, the quantmod attach hook and the
 "No Base R plots detected" errors so the wording stays in one place.
 }
 \keyword{internal}

--- a/man/quantmod_masks_maidr.Rd
+++ b/man/quantmod_masks_maidr.Rd
@@ -7,18 +7,18 @@
 quantmod_masks_maidr()
 }
 \value{
-`TRUE` when both packages are attached and quantmod comes first.
+\code{TRUE} when both packages are attached and quantmod comes first.
 }
 \description{
-`library(quantmod)` after `library(maidr)` puts `package:quantmod` in
-front of `package:maidr`, so an unqualified `chartSeries()` binds to
+\code{library(quantmod)} after \code{library(maidr)} puts \code{package:quantmod} in
+front of \code{package:maidr}, so an unqualified \code{chartSeries()} binds to
 quantmod's own function and maidr's recording wrapper is never entered.
 }
 \details{
 maidr deliberately does not reach into quantmod's namespace to win this
 race: overwriting a foreign package's binding would also redirect
-quantmod's *internal* `chartSeries()` calls through maidr's `...`-
-forwarding wrapper, which corrupts the `match.call(expand.dots = TRUE)`
+quantmod's \emph{internal} \code{chartSeries()} calls through maidr's \code{...}-
+forwarding wrapper, which corrupts the \code{match.call(expand.dots = TRUE)}
 that quantmod relies on. maidr reports the condition instead.
 }
 \keyword{internal}

--- a/man/recorded_axis_label.Rd
+++ b/man/recorded_axis_label.Rd
@@ -9,17 +9,17 @@ recorded_axis_label(args, name, default = NULL)
 \arguments{
 \item{args}{Recorded argument list, or NULL}
 
-\item{name}{Argument to read: `"xlab"` or `"ylab"`}
+\item{name}{Argument to read: \code{"xlab"} or \code{"ylab"}}
 
 \item{default}{What this chart type can honestly say when the author said
 nothing. Pass NULL when it can say nothing: an absent label leaves the
 generic to the renderer, which is where that decision belongs.}
 }
 \value{
-Character scalar, or `default`
+Character scalar, or \code{default}
 }
 \description{
-The author's own `xlab=`/`ylab=` always wins. An empty string counts as
+The author's own \verb{xlab=}/\verb{ylab=} always wins. An empty string counts as
 unsupplied: Base R draws no title for it, so falling through to the chart
 type's default announces more than the blank would, and the renderer would
 otherwise substitute its generic "X"/"Y" anyway. This is how the

--- a/man/register_ggplot2_print_method.Rd
+++ b/man/register_ggplot2_print_method.Rd
@@ -8,6 +8,6 @@ register_ggplot2_print_method()
 }
 \description{
 Stores the original ggplot2 print method and registers MAIDR's version.
-Called during `.onLoad()`.
+Called during \code{.onLoad()}.
 }
 \keyword{internal}

--- a/man/repair_na_text_justification.Rd
+++ b/man/repair_na_text_justification.Rd
@@ -10,24 +10,24 @@ repair_na_text_justification(grob)
 \item{grob}{A grob, gTree, gList, or gtable (or NULL)}
 }
 \value{
-The same tree with NA `hjust`/`vjust` on text grobs set to 0.5
+The same tree with NA \code{hjust}/\code{vjust} on text grobs set to 0.5
 }
 \description{
-`gridGraphics::grid.echo()` translates some base graphics text into grid
-text grobs that leave `vjust` (and, in principle, `hjust`) as NA and defer
-to the grob's `just` field instead. gridSVG 1.7.7 passes the raw value to
-`gridSVG:::justTovjust()`, which branches on it directly and fails with
-"missing value where TRUE/FALSE needed", aborting `gridSVG::grid.export()`
-from `devGrob.text`. `graphics::pie()` is the case that bites: it labels
+\code{gridGraphics::grid.echo()} translates some base graphics text into grid
+text grobs that leave \code{vjust} (and, in principle, \code{hjust}) as NA and defer
+to the grob's \code{just} field instead. gridSVG 1.7.7 passes the raw value to
+\code{gridSVG:::justTovjust()}, which branches on it directly and fails with
+"missing value where TRUE/FALSE needed", aborting \code{gridSVG::grid.export()}
+from \code{devGrob.text}. \code{graphics::pie()} is the case that bites: it labels
 every wedge, so before this repair no base R pie chart could be exported at
-all -- `pie(..., labels = NA)`, which draws no text, exported fine, which is
-what pins the failure on these grobs. `barplot()` and friends are
+all -- \code{pie(..., labels = NA)}, which draws no text, exported fine, which is
+what pins the failure on these grobs. \code{barplot()} and friends are
 unaffected because their text grobs already carry a numeric justification.
 }
 \details{
 Only NA components of text grobs are rewritten, so a grob that already has
 a usable justification passes through untouched. 0.5 is exactly what grid
-resolves NA to for the `just = "centre"` these grobs declare, so the drawn
+resolves NA to for the \code{just = "centre"} these grobs declare, so the drawn
 output is byte-identical.
 
 This is an upstream gridSVG/gridGraphics incompatibility rather than

--- a/man/replay_plot_call.Rd
+++ b/man/replay_plot_call.Rd
@@ -20,7 +20,7 @@ The result of the replayed call (invisibly)
 \description{
 Strips maidr-internal arguments and re-executes the call. When the
 recorded args contain unevaluated expressions (from non-standard
-evaluation, e.g. `curve(sin(x))` or `plot(y ~ x, subset = g == 1)`),
+evaluation, e.g. \code{curve(sin(x))} or \code{plot(y ~ x, subset = g == 1)}),
 the call is rebuilt and evaluated in the environment captured at record
 time so those expressions resolve exactly as they did originally.
 }

--- a/man/resolve_series_group_mapping.Rd
+++ b/man/resolve_series_group_mapping.Rd
@@ -24,8 +24,8 @@ contract.}
 }
 \value{
 list with \code{aes} (the winning spelling variants, or NULL when
-  nothing is mapped) and \code{column} (the mapped column name, or
-  "group" as a fallback)
+nothing is mapped) and \code{column} (the mapped column name, or
+"group" as a fallback)
 }
 \description{
 Mirrors ggplot2's precedence: the layer's own mapping wins over the

--- a/man/resolve_series_group_names.Rd
+++ b/man/resolve_series_group_names.Rd
@@ -20,7 +20,7 @@ Character vector, one name per distinct group id in ascending order
 \code{ggplot_build()} replaces the grouping column with integer group ids,
 so the user-facing name has to be recovered from the plot's own data. The
 ids are assigned in the sorted order of the grouping column's values, which
-is the order this function relies on. Falls back to "Series <id>" when the
+is the order this function relies on. Falls back to "Series \if{html}{\out{<id>}}" when the
 mapped column is not present on the plot data (for example an expression
 such as \code{aes(colour = paste(a, b))}).
 }

--- a/man/resolve_xy_args.Rd
+++ b/man/resolve_xy_args.Rd
@@ -10,12 +10,12 @@ resolve_xy_args(args)
 \item{args}{Recorded argument list}
 }
 \value{
-List with `x` and `y` (either may be NULL)
+List with \code{x} and \code{y} (either may be NULL)
 }
 \description{
-Mirrors how plot()/points()/lines() match their arguments: named `x`/`y`
+Mirrors how plot()/points()/lines() match their arguments: named \code{x}/\code{y}
 win, then the first two UNNAMED arguments in order. Blind positional
-access (`args[[2]]`) would grab graphical parameters instead
+access (\code{args[[2]]}) would grab graphical parameters instead
 (plot(x, type = "l") -> y = "l") or error for single-argument calls
 (plot(v), lines(v)).
 }

--- a/man/retry_call_in_caller_frame.Rd
+++ b/man/retry_call_in_caller_frame.Rd
@@ -14,7 +14,7 @@ retry_call_in_caller_frame(
 \arguments{
 \item{original_function}{The unwrapped plotting function}
 
-\item{recorded_call}{`match.call()` captured by the wrapper}
+\item{recorded_call}{\code{match.call()} captured by the wrapper}
 
 \item{caller_env}{The wrapper's calling frame}
 
@@ -25,8 +25,8 @@ Result of the retried call
 }
 \description{
 The formula methods resolve non-standard arguments relative to
-`parent.frame()`: `plot.formula()` evaluates `subset =` there, and
-`boxplot.formula()` reaches into the caller's `...`. A wrapper puts its
+\code{parent.frame()}: \code{plot.formula()} evaluates \verb{subset =} there, and
+\code{boxplot.formula()} reaches into the caller's \code{...}. A wrapper puts its
 own frame in that position, so calls that work in plain R fail through
 maidr:
 }

--- a/man/run_example.Rd
+++ b/man/run_example.Rd
@@ -7,25 +7,25 @@
 run_example(example = NULL, type = c("ggplot2", "base_r"))
 }
 \arguments{
-\item{example}{Character string specifying which example to run. If `NULL`
+\item{example}{Character string specifying which example to run. If \code{NULL}
 (the default), lists all available examples.}
 
 \item{type}{Character string specifying the plot system to use.
-Either `"ggplot2"` (default) or `"base_r"`.}
+Either \code{"ggplot2"} (default) or \code{"base_r"}.}
 }
 \value{
-Invisibly returns `NULL`. Called for its side effect of displaying
-  an interactive plot in the browser or listing available examples.
+Invisibly returns \code{NULL}. Called for its side effect of displaying
+an interactive plot in the browser or listing available examples.
 }
 \description{
 Launches example plots demonstrating MAIDR's accessible visualization
-capabilities. Each example creates an interactive plot using `show()`.
+capabilities. Each example creates an interactive plot using \code{show()}.
 }
 \details{
 Available examples include various plot types such as bar charts,
 histograms, scatter plots, line plots, boxplots, heatmaps, and more.
 
-Each example script creates a plot and calls `show()` to display it
+Each example script creates a plot and calls \code{show()} to display it
 in your default web browser with full MAIDR accessibility features
 including keyboard navigation and screen reader support.
 }
@@ -43,5 +43,5 @@ if (interactive()) {
 
 }
 \seealso{
-[show()] for displaying plots, [save_html()] for saving to file
+\code{\link[=show]{show()}} for displaying plots, \code{\link[=save_html]{save_html()}} for saving to file
 }

--- a/man/save_html.Rd
+++ b/man/save_html.Rd
@@ -13,9 +13,9 @@ save_html(plot = NULL, file = "plot.html", use_cdn = NULL, ...)
 
 \item{use_cdn}{Logical. Controls where MAIDR.js is loaded from:
 \itemize{
-  \item \code{TRUE}: Use CDN (requires internet)
-  \item \code{FALSE}: Use local bundled files (works offline)
-  \item \code{NULL} (default): Auto-detect based on internet availability
+\item \code{TRUE}: Use CDN (requires internet)
+\item \code{FALSE}: Use local bundled files (works offline)
+\item \code{NULL} (default): Auto-detect based on internet availability
 }}
 
 \item{...}{Additional arguments passed to internal functions}

--- a/man/schedule_auto_show.Rd
+++ b/man/schedule_auto_show.Rd
@@ -8,7 +8,7 @@ schedule_auto_show()
 }
 \description{
 Uses R's task callback mechanism. When a HIGH-level plot function is called,
-this schedules `show()` to run after the expression finishes. If another
+this schedules \code{show()} to run after the expression finishes. If another
 HIGH-level function is called in the same expression, the previous callback
 is replaced (only one auto-show fires per expression).
 }

--- a/man/set_maidr_data_attr.Rd
+++ b/man/set_maidr_data_attr.Rd
@@ -15,6 +15,6 @@ set_maidr_data_attr(svg_doc, maidr_data)
 NULL (invisible)
 }
 \description{
-Mutates `svg_doc` in place.
+Mutates \code{svg_doc} in place.
 }
 \keyword{internal}

--- a/man/show.Rd
+++ b/man/show.Rd
@@ -11,9 +11,9 @@ show(plot = NULL, use_cdn = NULL, shiny = FALSE, as_widget = FALSE, ...)
 
 \item{use_cdn}{Logical. Controls where MAIDR.js is loaded from:
 \itemize{
-  \item \code{TRUE}: Use CDN (requires internet)
-  \item \code{FALSE}: Use local bundled files (works offline)
-  \item \code{NULL} (default): Auto-detect based on internet availability
+\item \code{TRUE}: Use CDN (requires internet)
+\item \code{FALSE}: Use local bundled files (works offline)
+\item \code{NULL} (default): Auto-detect based on internet availability
 }}
 
 \item{shiny}{If TRUE, returns just the SVG content instead of full HTML document}

--- a/man/simplify_curve.Rd
+++ b/man/simplify_curve.Rd
@@ -20,6 +20,6 @@ Logical vector of length N (TRUE = keep this point)
 }
 \description{
 Uses binary search on epsilon to find the smallest tolerance that
-yields at most `target` retained points.
+yields at most \code{target} retained points.
 }
 \keyword{internal}

--- a/man/snapshot_call_env.Rd
+++ b/man/snapshot_call_env.Rd
@@ -17,7 +17,7 @@ An environment whose parent is \code{caller_env}
 \description{
 Recorded expressions are re-evaluated when the figure is rendered, long
 after the caller has moved on -- and R reuses ONE frame for every
-iteration of a `for` loop. Storing that frame therefore makes every
+iteration of a \code{for} loop. Storing that frame therefore makes every
 iteration replay with the LAST iteration's values:
 }
 \details{
@@ -26,7 +26,7 @@ par(mfrow = c(1, 2))
 for (g in c("a", "b")) plot(y ~ x, data = d, subset = grp == g)
 }
 
-Both panels drew `grp == "b"`, silently and without an error. Copying the
+Both panels drew \code{grp == "b"}, silently and without an error. Copying the
 whole frame would fix that but brings its own problems (large objects,
 active bindings, unforced promises, frames that are shared and mutated),
 so only the names the recorded expressions actually mention are copied,

--- a/man/strip_chartseries_date_axis.Rd
+++ b/man/strip_chartseries_date_axis.Rd
@@ -14,7 +14,7 @@ detect candlestick layers)}
 }
 \value{
 Modified SVG content (character vector). If any guard
-  fails, returns `svg_content` unchanged.
+fails, returns \code{svg_content} unchanged.
 }
 \description{
 quantmod::chartSeries() emits a bottom date axis (axis line, tick
@@ -29,11 +29,11 @@ in the maidr-data JSON for the screen reader.
 }
 \details{
 The relevant groups have IDs of the form
-`graphics-plot-N-bottom-axis-(line|ticks)-...`; we match by
-substring with `contains(@id, 'bottom-axis-(line|ticks)-')` and
-explicitly leave `bottom-axis-labels-` untouched.
+\code{graphics-plot-N-bottom-axis-(line|ticks)-...}; we match by
+substring with \verb{contains(@id, 'bottom-axis-(line|ticks)-')} and
+explicitly leave \verb{bottom-axis-labels-} untouched.
 
-Safety: no-op when `maidr_data` contains no candlestick layers
+Safety: no-op when \code{maidr_data} contains no candlestick layers
 (ggplot candlestick / non-candlestick plots use different SVG IDs
 and are unaffected), when xml2 is unavailable, when SVG parsing
 fails, or when no matching groups are found.

--- a/man/strip_chartseries_date_axis_doc.Rd
+++ b/man/strip_chartseries_date_axis_doc.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/svg_utils.R
 \name{strip_chartseries_date_axis_doc}
 \alias{strip_chartseries_date_axis_doc}
-\title{Document-level implementation of [strip_chartseries_date_axis()]}
+\title{Document-level implementation of \code{\link[=strip_chartseries_date_axis]{strip_chartseries_date_axis()}}}
 \usage{
 strip_chartseries_date_axis_doc(svg_doc)
 }
@@ -13,6 +13,6 @@ strip_chartseries_date_axis_doc(svg_doc)
 TRUE if the document was modified
 }
 \description{
-Mutates `svg_doc` in place.
+Mutates \code{svg_doc} in place.
 }
 \keyword{internal}

--- a/man/strip_chartseries_right_axis.Rd
+++ b/man/strip_chartseries_right_axis.Rd
@@ -14,7 +14,7 @@ detect candlestick layers)}
 }
 \value{
 Modified SVG content (character vector). If any guard
-  fails, returns `svg_content` unchanged.
+fails, returns \code{svg_content} unchanged.
 }
 \description{
 quantmod::chartSeries() draws a right-hand y-axis with a vertical
@@ -23,16 +23,16 @@ On sparse OHLC inputs (few candles spread across the plot region),
 the right-axis vertical line is positioned within the candle area
 and visually overlaps the rightmost candle, reading like a stray
 "axis through the middle" of the chart. This helper removes only
-the `right-axis-line-*` polyline; the tick marks and the price
+the \verb{right-axis-line-*} polyline; the tick marks and the price
 labels themselves are preserved so the chart still communicates
 the y-axis scale visually.
 }
 \details{
 The matched group has an ID of the form
-`graphics-plot-N-right-axis-line-...`; matched by substring with
-`contains(@id, 'right-axis-line-')`.
+\code{graphics-plot-N-right-axis-line-...}; matched by substring with
+\verb{contains(@id, 'right-axis-line-')}.
 
-Safety: no-op when `maidr_data` contains no candlestick layers
+Safety: no-op when \code{maidr_data} contains no candlestick layers
 (ggplot candlestick / non-candlestick plots use different SVG IDs
 and are unaffected), when xml2 is unavailable, when SVG parsing
 fails, or when no matching groups are found.

--- a/man/strip_chartseries_right_axis_doc.Rd
+++ b/man/strip_chartseries_right_axis_doc.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/svg_utils.R
 \name{strip_chartseries_right_axis_doc}
 \alias{strip_chartseries_right_axis_doc}
-\title{Document-level implementation of [strip_chartseries_right_axis()]}
+\title{Document-level implementation of \code{\link[=strip_chartseries_right_axis]{strip_chartseries_right_axis()}}}
 \usage{
 strip_chartseries_right_axis_doc(svg_doc)
 }
@@ -13,6 +13,6 @@ strip_chartseries_right_axis_doc(svg_doc)
 TRUE if the document was modified
 }
 \description{
-Mutates `svg_doc` in place.
+Mutates \code{svg_doc} in place.
 }
 \keyword{internal}

--- a/man/strip_violin_kde_metadata.Rd
+++ b/man/strip_violin_kde_metadata.Rd
@@ -13,9 +13,9 @@ strip_violin_kde_metadata(maidr_data)
 Cleaned maidr_data
 }
 \description{
-Removes the temporary fields (`.panel_x_range`, `.panel_y_range`,
-`.is_horizontal`, `.panel_index`, `.panel_name`, `data_left_x`,
-`data_right_x`, `data_y`) that must never appear in the serialized
+Removes the temporary fields (\code{.panel_x_range}, \code{.panel_y_range},
+\code{.is_horizontal}, \code{.panel_index}, \code{.panel_name}, \code{data_left_x},
+\code{data_right_x}, \code{data_y}) that must never appear in the serialized
 maidr-data JSON. Called unconditionally after coordinate injection, so a
 layer whose panel viewport could not be navigated still comes out clean.
 }

--- a/man/usable_xy_coords.Rd
+++ b/man/usable_xy_coords.Rd
@@ -7,15 +7,15 @@
 usable_xy_coords(coords)
 }
 \arguments{
-\item{coords}{Value returned by `grDevices::xy.coords()`, or NULL}
+\item{coords}{Value returned by \code{grDevices::xy.coords()}, or NULL}
 }
 \value{
 TRUE when both axes carry at least one finite value
 }
 \description{
-`grDevices::xy.coords()` coerces whatever it is given, so categorical
-coordinates come back as all-`NA` numerics rather than as an error. Those
-are worse than the raw input: `range()` on them yields infinities and a
+\code{grDevices::xy.coords()} coerces whatever it is given, so categorical
+coordinates come back as all-\code{NA} numerics rather than as an error. Those
+are worse than the raw input: \code{range()} on them yields infinities and a
 warning, where the raw character vector is simply rejected as non-numeric.
 }
 \keyword{internal}

--- a/man/validate_axes.Rd
+++ b/man/validate_axes.Rd
@@ -21,14 +21,14 @@ with a descriptive message.
 \details{
 Rules:
 \itemize{
-  \item \code{axes} must be NULL or a list.
-  \item Keys must be a subset of \code{\{"x","y","z"\}}.
-  \item Each axis value must be a list (AxisConfig), never a string/
-        number/array.
-  \item No \code{format}, \code{min}, \code{max}, \code{tickStep},
-        \code{fill}, or \code{level} at the top level of \code{axes}.
-  \item \code{min}, \code{max}, \code{tickStep} (when present inside an
-        axis) must be numeric scalars.
+\item \code{axes} must be NULL or a list.
+\item Keys must be a subset of \code{\{"x","y","z"\}}.
+\item Each axis value must be a list (AxisConfig), never a string/
+number/array.
+\item No \code{format}, \code{min}, \code{max}, \code{tickStep},
+\code{fill}, or \code{level} at the top level of \code{axes}.
+\item \code{min}, \code{max}, \code{tickStep} (when present inside an
+axis) must be numeric scalars.
 }
 }
 \keyword{internal}

--- a/man/warn_chartseries_ta_unsupported.Rd
+++ b/man/warn_chartseries_ta_unsupported.Rd
@@ -3,7 +3,7 @@
 \name{warn_chartseries_ta_unsupported}
 \alias{warn_chartseries_ta_unsupported}
 \title{Emit a one-time warning when quantmod::chartSeries() is called with a
-non-NULL `TA` argument (e.g. `TA = "addVo()"`).}
+non-NULL \code{TA} argument (e.g. \code{TA = "addVo()"}).}
 \usage{
 warn_chartseries_ta_unsupported()
 }


### PR DESCRIPTION
Closes #119. Raised by review on #118, which spotted it in that PR's new blocks; it turned out to be package-wide and predate it.

## The problem

Most roxygen comments here are written in markdown — backticks for code, `[fn()]` for links — but `DESCRIPTION` never enabled it and no file uses `@md`. roxygen2 copies the syntax through verbatim.

Counted on `main`:

| In roxygen blocks under `R/` | Lines |
|---|---|
| Backticks | 130 |
| `[fn()]` links | 21 |
| **Total** | **149**, across **17 files** |
| `\code{}` | 71 |
| `\link{}` | 7 |

Markdown is the dominant style by ~2:1. `?show` has been listing `[maidr_on()]` as literal bracketed text with no link, and a dozen internal topics show raw backticks.

So this enables it rather than rewriting 149 lines to Rd markup — that is the style the comments were evidently written for.

## Four escapes had to change

Enabling markdown reinterprets **every** block, not only the ones that meant to be markdown. I found these by rendering all 261 pages with `Rd2txt` before and after and diffing the text, rather than by reading the diff.

**`\%` is escaped again into `\\%`**, which Rd renders as a literal backslash and then starts a comment that eats the rest of the line:

```
before:  width: Width of the iframe (default: "100%")
after:   width: Width of the iframe (default: "100\
```

In `create_maidr_iframe.Rd` the truncation swallowed the rest of the `\itemize` block and left **malformed Rd** — `unknown macro '\item'`, `unexpected section header '\value'`. In markdown mode roxygen2 escapes the percent itself, so the three sites are now plain `%`.

**A bare bracket becomes a link.** The chartSeries header example `"[2024-01-12/2024-01-15]"` compiled to a link with no target:

```
* checking Rd cross-references ... WARNING
Missing link or links in documentation object 'adjust_chartseries_bracket.Rd':
  '2024-01-12/2024-01-15'
```

Now a code span, which is what it always was semantically.

**`[extract_data()]`** pointed at an R6 method, which has no topic to link to. Backticks, like every other method reference in the package. (From #104, not from #118.)

## Verification

Not assumed — each of these was checked:

| Check | Result |
|---|---|
| All `.Rd` parse without warnings | **261 / 261** |
| Every generated `\link[=target]` resolves to an `\alias` | **all 17** |
| `R CMD check` | 3 WARNINGs, 1 NOTE |
| `R CMD check` on `main`, same flags | 3 WARNINGs, 1 NOTE — **item for item identical** |
| `testthat::test_local()` | **FAIL 0 \| WARN 2 \| SKIP 98 \| PASS 4361** |

The baseline check was run by `git archive origin/main` into a clean tree and building it the same way, so the comparison is like for like. The remaining warnings are this container's missing `en_US.UTF-8` locale (pre-existing currency symbols in `format_utils.R`) and the vignette directory, an artefact of `--no-build-vignettes`. The 2 test warnings are the pre-existing `boxplot(notch = TRUE)` ones.

Every emphasis markdown introduced was checked to come from intentional prose (`*all*`, `*below*`, `*generic*`, `*internal*` and the bold headings in `maidr-package.Rd`) — no identifier containing `_` or `*` was mangled.

## One page renders better than before

`build_axes.Rd` on `main`:

```
empty, so it serializes as the JSON object  rather than as [].
```

The `{}` was being eaten — unescaped braces are Rd grouping. With markdown they are inside a code span and survive:

```
empty, so it serializes as the JSON object '{}' rather than as [].
```

## Scope

Comment text, `DESCRIPTION`, and regenerated `man/` only. No executable code changed — the four `R/` edits are all inside `#'` blocks. `NAMESPACE` unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmSHGxAWRw5wVWqDKdaZm6)_