### PR TITLE
test(ggplot2): fix and re-enable the multiple-layer orchestrator test

### DIFF
--- a/tests/testthat/test-ggplot2-orchestrator.R
+++ b/tests/testthat/test-ggplot2-orchestrator.R
@@ -86,18 +86,24 @@ test_that("Orchestrator detects layer type correctly", {
 })
 
 test_that("Orchestrator detects multiple layers", {
-  testthat::skip("Multiple layer detection needs data scope fix")
-
   testthat::skip_if_not_installed("ggplot2")
 
-  # Create plot with multiple layers (use existing data in plot)
+  # `y`, not `mpg`: create_test_ggplot_bar() builds its plot on a three-row
+  # frame of x/y, so a second layer mapped to `mpg` fails in aes() before the
+  # orchestrator is ever reached. That error is what this test used to be
+  # skipped for, and it was the test's own, not the orchestrator's.
   p <- create_test_ggplot_bar() +
-    ggplot2::geom_point(ggplot2::aes(y = mpg))
+    ggplot2::geom_point(ggplot2::aes(y = y))
 
   orchestrator <- maidr:::Ggplot2PlotOrchestrator$new(p)
   layers <- orchestrator$get_layers()
 
   testthat::expect_gte(length(layers), 2)
+  # Both layers, not one of them twice: a bare count would pass either way.
+  testthat::expect_equal(
+    vapply(layers, function(layer) layer$type, character(1)),
+    c("bar", "point")
+  )
 })
 
 test_that("Layer info contains required fields", {


### PR DESCRIPTION
Closes #125.

## The skip was hiding a broken test, not a broken feature

`tests/testthat/test-ggplot2-orchestrator.R:89` skipped with

```r
testthat::skip("Multiple layer detection needs data scope fix")
```

which reads like a defect in `Ggplot2PlotOrchestrator`. It is not. The test mapped its second layer to `mpg`:

```r
p <- create_test_ggplot_bar() + ggplot2::geom_point(ggplot2::aes(y = mpg))
```

and `create_test_ggplot_bar()` (`tests/testthat/helper.R:13`) builds its plot on `data.frame(x = c("A","B","C"), y = c(10,20,30))` — no `mpg` anywhere. Removing the skip and running it gives

```
Error: Problem while computing aesthetics.
i Error occurred in the 2nd layer.
Caused by error:
! object 'mpg' not found
```

`aes()` fails before the orchestrator is ever reached. Pointing the layer at a column the fixture has:

```r
maidr:::Ggplot2PlotOrchestrator$new(
  create_test_ggplot_bar() + ggplot2::geom_point(ggplot2::aes(y = y))
)$get_layers()
#> 2 layers, types: "bar", "point"
```

The assertion the test was written to make passes, and presumably always would have.

## Changes

- `aes(y = mpg)` becomes `aes(y = y)`, with a comment recording why the original failed so nobody re-skips it.
- The `skip()` is gone.
- Added an assertion on the layer *types*. `expect_gte(length(layers), 2)` alone would pass just as happily if the orchestrator ever returned one layer twice, which is exactly the failure a test named "detects multiple layers" exists to catch.

Nothing in `R/` changes.

## Verification

`test-ggplot2-orchestrator.R`: **39 pass, 0 fail, 0 skip** (was 38 pass, 1 skip).

The new type assertion is mutation-checked: flipping the expected order to `c("point", "bar")` fails it, so it is testing the layer identities rather than restating the count.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZocjnGTiRvLDCbcvqYqa3)_