### PR TITLE
style: replace literal non-ASCII characters in R sources with ASCII

### DIFF
--- a/R/base_r_function_patching.R
+++ b/R/base_r_function_patching.R
@@ -320,8 +320,8 @@ snapshot_call_env <- function(args, caller_env) {
 #' Evaluate an expression, muffling the retry's promise-restart warning
 #'
 #' When a call fails part-way through forcing an argument, that argument's
-#' promise is left interrupted. Forcing it again — which both the retry and
-#' the argument recording do — makes R warn "restarting interrupted promise
+#' promise is left interrupted. Forcing it again - which both the retry and
+#' the argument recording do - makes R warn "restarting interrupted promise
 #' evaluation". It is an artifact of retrying, not anything the user's call
 #' did, so it is muffled; every other warning passes through untouched.
 #'
@@ -471,7 +471,7 @@ initialize_base_r_patching <- function(include_low = TRUE, include_layout = TRUE
   # a later call (e.g. via a packageEvent hook for quantmod).
   lapply(fns_to_wrap, wrap_function)
 
-  # Special handling for S3 generics (lines, points) — only the first
+  # Special handling for S3 generics (lines, points) - only the first
   # call actually installs them (gated on .saved_graphics_fns).
   if (is.null(.maidr_patching_env$.saved_graphics_fns[["lines"]]) ||
       is.null(.maidr_patching_env$.saved_graphics_fns[["points"]])) {
@@ -513,7 +513,7 @@ wrap_function <- function(function_name) {
   tryCatch(
     assign(function_name, wrapper, envir = ns),
     error = function(e) {
-      # Namespace is sealed — wrapper was already installed during .onLoad
+      # Namespace is sealed - wrapper was already installed during .onLoad
       NULL
     }
   )
@@ -1178,7 +1178,7 @@ apply_barplot_sorting <- function(args) {
 #' @return NULL (invisible)
 #' @keywords internal
 restore_original_functions <- function() {
-  # Deactivate patching — wrappers will pass through to originals
+  # Deactivate patching - wrappers will pass through to originals
 
   .maidr_patching_env$.patching_active <- FALSE
 

--- a/R/base_r_wrapper_exports.R
+++ b/R/base_r_wrapper_exports.R
@@ -130,7 +130,7 @@ chartSeries <- function(...) {
   # expressions, so an explicit `TA = NULL` reaches quantmod as a `name`
   # and dies in `sapply(chob@passed.args$TA, function(x) eval(x@call))`.
   # Retrying with the call rebuilt in the caller's frame gives quantmod
-  # the literal arguments it expects — the same fallback the generated
+  # the literal arguments it expects - the same fallback the generated
   # wrappers use (see retry_call_in_caller_frame()).
   call_failed <- FALSE
   result <- tryCatch(

--- a/R/ggplot2_heatmap_layer_processor.R
+++ b/R/ggplot2_heatmap_layer_processor.R
@@ -136,7 +136,7 @@ Ggplot2HeatmapLayerProcessor <- R6::R6Class(
       # Cell VALUES, in contrast, must come from this panel's rows only.
       # `built_data` is filtered to the panel but `original_data` is not, so
       # the (x, y) lookup below matched rows in every panel and took the
-      # first one — each panel reported panel 1's values.
+      # first one - each panel reported panel 1's values.
       panel_source <- original_data
       panel_layout <- built$layout$layout
       if (!is.null(panel_id) && !is.null(panel_layout)) {

--- a/R/ggplot2_line_layer_processor.R
+++ b/R/ggplot2_line_layer_processor.R
@@ -1000,7 +1000,7 @@ Ggplot2LineLayerProcessor <- R6::R6Class(
     #' Delegates to `polyline_layer_position()`, which counts both "line" and
     #' "step" layers. `layer_polyline_grobs()` skips only the layers that name
     #' their grob tree after their geom, and `GeomStep` draws through
-    #' `GeomPath$draw_panel()` — a bare `polylineGrob` — so a `geom_step()`
+    #' `GeomPath$draw_panel()` - a bare `polylineGrob` - so a `geom_step()`
     #' sits in that candidate list exactly as a `geom_line()` does. Counting
     #' only "line" layers would therefore index the wrong polyline for *both*
     #' layers of a plot that combines the two.

--- a/R/ggplot2_patchwork_utils.R
+++ b/R/ggplot2_patchwork_utils.R
@@ -800,8 +800,8 @@ collapse_lines_to_multiseries <- function(panel) {
 #' used to be load-bearing, because the generator discovered *all* polyline
 #' grobs in the panel and handed every one of N line layers the same length-N
 #' set. What still has to hold after merging is the frontend precondition
-#' `selectors.length === data.length` — one selector per merged series —
-#' which is why the trim below stays. There is deliberately no pad: a short
+#' `selectors.length === data.length`, one selector per merged series, which
+#' is why the trim below stays. There is deliberately no pad: a short
 #' list fails that precondition and the frontend drops the layer's highlight
 #' rather than aiming it at the wrong curve.
 #' @keywords internal

--- a/R/ggplot2_plot_orchestrator.R
+++ b/R/ggplot2_plot_orchestrator.R
@@ -246,7 +246,7 @@ Ggplot2PlotOrchestrator <- R6::R6Class(
         # tagged "skip" by the adapter; the orchestrator leaves a NULL slot).
         if (is.null(result)) next
 
-        # --- Multi-layer expansion (e.g. violin → violin_box + violin_kde) ---
+        # --- Multi-layer expansion (e.g. violin -> violin_box + violin_kde) ---
         if (isTRUE(result$multi_layer) && !is.null(result$layers)) {
           for (sub in result$layers) {
             layer_counter <- layer_counter + 1

--- a/R/ggplot2_print_method.R
+++ b/R/ggplot2_print_method.R
@@ -44,7 +44,7 @@ register_ggplot2_print_method <- function() {
   }
 
   if (is.null(orig)) {
-    # ggplot2 not available — can't register
+    # ggplot2 not available - can't register
     return(invisible(NULL))
   }
 
@@ -120,11 +120,11 @@ maidr_print_ggplot <- function(x, newpage = is.null(vp), vp = NULL, ...) {
     !isTRUE(tryCatch(orchestrator$should_fallback(), error = function(e) TRUE))
 
   if (!supported) {
-    # Unsupported plot — fall back to normal ggplot2 rendering
+    # Unsupported plot - fall back to normal ggplot2 rendering
     return(original_print(x, newpage = newpage, vp = vp, ...))
   }
 
-  # Supported plot — render in MAIDR interactive viewer, reusing the
+  # Supported plot - render in MAIDR interactive viewer, reusing the
   # orchestrator created for the support check
   rendered <- tryCatch(
     {

--- a/R/ggplot2_system_init.R
+++ b/R/ggplot2_system_init.R
@@ -71,7 +71,7 @@ quantmod_mask_advice <- function() {
 #'
 #' Names the quantmod masking case when it applies: the bare
 #' "create a plot first" wording is actively misleading there, because the
-#' user *did* draw a chart — it just went to quantmod unrecorded.
+#' user *did* draw a chart - it just went to quantmod unrecorded.
 #'
 #' @return The error message string.
 #' @keywords internal
@@ -146,7 +146,7 @@ no_base_r_plots_message <- function() {
       register_ggplot2_print_method()
     },
     error = function(e) {
-      # Not critical — ggplot2 may not be installed
+      # Not critical - ggplot2 may not be installed
       NULL
     }
   )
@@ -212,7 +212,7 @@ no_base_r_plots_message <- function() {
 
   # maidr is normally attached at position 2, ahead of anything loaded
   # earlier, so this only fires for an explicit library(maidr, pos = ...).
-  # The common ordering problem — quantmod attached *after* maidr — is
+  # The common ordering problem - quantmod attached *after* maidr - is
   # caught by .maidr_quantmod_attach_hook instead.
   if (quantmod_masks_maidr()) {
     packageStartupMessage("maidr: ", quantmod_mask_advice())

--- a/R/ggplot2_violin_layer_processor.R
+++ b/R/ggplot2_violin_layer_processor.R
@@ -139,7 +139,7 @@ Ggplot2ViolinLayerProcessor <- R6::R6Class(
       # gridSVG applies scale(1,-1) Y-flip for vertical plots, which
       # inverts 'top'/'bottom' edges of the IQ polygon.  Signal this via
       # domMapping.iqrDirection so the JS frontend (ViolinBoxTrace) can
-      # swap Q1/Q3 edge selection — same pattern used by BoxTrace.
+      # swap Q1/Q3 edge selection - same pattern used by BoxTrace.
       iqr_direction <- if (orientation == "vert") "reverse" else "forward"
 
       box_layer <- list(
@@ -671,10 +671,10 @@ Ggplot2ViolinLayerProcessor <- R6::R6Class(
 
         if (!is.null(whisker_id)) {
           wid <- with_suffix(whisker_id)
-          # ggplot2 draws the upper whisker (Q3→ymax) first and the lower
-          # whisker (Q1→ymin) second, so in gridSVG DOM:
-          #   nth-child(1) = upper whisker → max
-          #   nth-child(2) = lower whisker → min
+          # ggplot2 draws the upper whisker (Q3->ymax) first and the lower
+          # whisker (Q1->ymin) second, so in gridSVG DOM:
+          #   nth-child(1) = upper whisker -> max
+          #   nth-child(2) = lower whisker -> min
           box_sel$max <- paste0(
             "g#", esc(wid), " > polyline:nth-child(1)"
           )

--- a/R/html_dependencies.R
+++ b/R/html_dependencies.R
@@ -22,7 +22,7 @@ maidr_cdn_url <- function() {
 #' Behavior is controlled by the `use_cdn` parameter:
 #' - If `TRUE`: Use CDN (requires internet)
 #' - If `FALSE` (default): Use local bundled files (works offline)
-#' - If `NULL`: Same as `FALSE` — use local bundled files
+#' - If `NULL`: Same as `FALSE` - use local bundled files
 #'
 #' We default to local bundled assets for deterministic rendering. Previously
 #' we auto-detected via `curl::has_internet()`; when internet was available

--- a/R/svg_utils.R
+++ b/R/svg_utils.R
@@ -365,8 +365,8 @@ inject_violin_kde_svg_coords <- function(gt, maidr_data) {
           }
           # Sort points along the value axis for smooth keyboard navigation.
           # ViolinKdeTrace uses point order directly as the navigation order.
-          #   Vertical:   value axis = Y → sort by svg_y (bottom-to-top)
-          #   Horizontal: value axis = X → sort by svg_x (left-to-right)
+          #   Vertical:   value axis = Y -> sort by svg_y (bottom-to-top)
+          #   Horizontal: value axis = X -> sort by svg_x (left-to-right)
           sort_vals <- if (is_horizontal) {
             vapply(points, function(p) {
               if (!is.null(p$svg_x)) p$svg_x else NA_real_
@@ -565,8 +565,8 @@ inject_candlestick_open_close_doc <- function(svg_doc, maidr_data) {
 
       trend <- layer$data[[i]]$trend
       # In gridSVG's flipped local space, smaller raw y = lower data value.
-      # Bull (close > open): open is the lower edge → y; close → y + h.
-      # Bear (close < open): open is the higher edge → y + h; close → y.
+      # Bull (close > open): open is the lower edge -> y; close -> y + h.
+      # Bear (close < open): open is the higher edge -> y + h; close -> y.
       if (identical(trend, "Bull")) {
         open_y  <- y
         close_y <- y + h

--- a/man/Ggplot2LineLayerProcessor.Rd
+++ b/man/Ggplot2LineLayerProcessor.Rd
@@ -908,7 +908,7 @@ Position of this layer among the polyline-producing layers.
 Delegates to \code{polyline_layer_position()}, which counts both "line" and
 "step" layers. \code{layer_polyline_grobs()} skips only the layers that name
 their grob tree after their geom, and \code{GeomStep} draws through
-\code{GeomPath$draw_panel()} — a bare \code{polylineGrob} — so a \code{geom_step()}
+\code{GeomPath$draw_panel()} - a bare \code{polylineGrob} - so a \code{geom_step()}
 sits in that candidate list exactly as a \code{geom_line()} does. Counting
 only "line" layers would therefore index the wrong polyline for \emph{both}
 layers of a plot that combines the two.

--- a/man/maidr_html_dependencies.Rd
+++ b/man/maidr_html_dependencies.Rd
@@ -19,7 +19,7 @@ Behavior is controlled by the \code{use_cdn} parameter:
 \itemize{
 \item If \code{TRUE}: Use CDN (requires internet)
 \item If \code{FALSE} (default): Use local bundled files (works offline)
-\item If \code{NULL}: Same as \code{FALSE} — use local bundled files
+\item If \code{NULL}: Same as \code{FALSE} - use local bundled files
 }
 }
 \details{

--- a/man/merge_line_layers.Rd
+++ b/man/merge_line_layers.Rd
@@ -17,8 +17,8 @@ The dedupe-and-trim below is kept as a backstop, not as the mechanism: it
 used to be load-bearing, because the generator discovered \emph{all} polyline
 grobs in the panel and handed every one of N line layers the same length-N
 set. What still has to hold after merging is the frontend precondition
-\verb{selectors.length === data.length} — one selector per merged series —
-which is why the trim below stays. There is deliberately no pad: a short
+\verb{selectors.length === data.length}, one selector per merged series, which
+is why the trim below stays. There is deliberately no pad: a short
 list fails that precondition and the frontend drops the layer's highlight
 rather than aiming it at the wrong curve.
 }

--- a/man/muffle_promise_restart.Rd
+++ b/man/muffle_promise_restart.Rd
@@ -14,8 +14,8 @@ The value of \code{expr}
 }
 \description{
 When a call fails part-way through forcing an argument, that argument's
-promise is left interrupted. Forcing it again — which both the retry and
-the argument recording do — makes R warn "restarting interrupted promise
+promise is left interrupted. Forcing it again - which both the retry and
+the argument recording do - makes R warn "restarting interrupted promise
 evaluation". It is an artifact of retrying, not anything the user's call
 did, so it is muffled; every other warning passes through untouched.
 }

--- a/man/no_base_r_plots_message.Rd
+++ b/man/no_base_r_plots_message.Rd
@@ -12,6 +12,6 @@ The error message string.
 \description{
 Names the quantmod masking case when it applies: the bare
 "create a plot first" wording is actively misleading there, because the
-user \emph{did} draw a chart — it just went to quantmod unrecorded.
+user \emph{did} draw a chart - it just went to quantmod unrecorded.
 }
 \keyword{internal}


### PR DESCRIPTION
Closes #126.

## The NOTE

`R CMD check` asks for ASCII in R sources, and 31 literal characters — 20 em dashes and 11 rightwards arrows, on 26 lines across 11 files — were tripping it:

```
* checking R files for non-ASCII characters ... NOTE
Portable packages must use only ASCII characters in their R files,
using \uxxxx escapes for other characters.
```

It has been invisible because `.github/workflows/R-CMD-check.yaml` uses `check-r-package@v2`, which fails on warnings and above, so a NOTE passes. This is a CRAN blocker rather than a runtime one — nothing misbehaves today.

## Changes

Every occurrence is in a comment or a roxygen block, so this is textual and carries no behaviour change:

- an em dash used as a parenthetical break becomes a plain hyphen
- an arrow becomes `->` (`Q3→ymax` reads `Q3->ymax`, `value axis = Y → sort by svg_y` reads `-> sort by svg_y`)
- one roxygen sentence in `merge_line_layers()` that used a *pair* of em dashes as parentheses is reworded with commas, because the second one fell at end of line and a trailing ` -` read as a dangling operator

`man/` is regenerated for the five topics whose roxygen text changed. It was in sync with `R/` before this change and is in sync after.

Escapes would satisfy the rule too, but plain ASCII reads the same in prose and leaves nothing to remember.

## Verification

```r
files <- list.files(c("R", "man"), pattern = "[.](R|r|Rd)$", full.names = TRUE)
Filter(function(f) length(capture.output(tools::showNonASCIIfile(f))) > 0, files)
#> 0 files
```

Full test suite: **FAIL 0 | WARN 18 | SKIP 2 | PASS 5598**. The 18 warnings are pre-existing ggplot2 aesthetic warnings from the candlestick/patchwork fixtures, unrelated to this change.

## Not the lintr failure

`lintr::lint_package()` aborting with `subscript out of bounds` on `R/format_utils.R` is a separate thing and is **not** a repository defect, so nothing here addresses it. That file's currency symbols are already written the portable way, and the abort only happens in a session whose `LC_CTYPE` is `C`; under a UTF-8 locale `lint_package()` runs to completion. Detail is in #126.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZocjnGTiRvLDCbcvqYqa3)_