### PR TITLE
ci: refresh the bundled maidr.js as soon as upstream publishes

### DIFF
--- a/.github/workflows/update-maidr-bundle.yml
+++ b/.github/workflows/update-maidr-bundle.yml
@@ -7,20 +7,42 @@ name: Update MAIDR Bundle
 # Unlike py-maidr — where the routine refresh happens inside the automated
 # release workflow so the bundle ships with each release — r-maidr has no
 # release pipeline to hook into (CRAN submissions are manual), so the
-# scheduled refresh here is what keeps ``main`` current: whatever is bundled
-# on ``main`` at submission time is what ships to CRAN. The download is
+# refresh here is what keeps ``main`` current: whatever is bundled on
+# ``main`` at submission time is what ships to CRAN. The download is
 # verified against the integrity hash published in the npm registry
 # metadata (see ``.github/scripts/fetch-maidr-bundle.sh``), so a tampered
 # CDN/registry response fails the job instead of landing on ``main``.
+#
+# Two triggers, doing different jobs. maidr's release workflow pings this
+# repository as soon as it publishes to npm, which is what makes a new
+# upstream version land promptly; the daily schedule is the backstop for a
+# ping that never arrives. Neither is redundant: without the ping a release
+# waits up to a day, and without the schedule a dropped ping waits forever.
 #
 # The commit uses the ``chore:`` prefix so a bundle refresh reads as
 # maintenance, not a feature, in the history.
 
 on:
+  repository_dispatch:
+    # Sent by maidr's release workflow the moment ``npm publish`` succeeds,
+    # so a new upstream release lands here in minutes rather than waiting
+    # for the next scheduled poll. ``client_payload.version`` names the
+    # version that was just published; the job below fetches that exact
+    # version rather than re-resolving ``latest``, which sidesteps the
+    # window where the ``latest`` dist-tag has not propagated yet.
+    #
+    # Note that repository_dispatch only ever triggers the workflow file as
+    # it exists on the default branch, so changes to this trigger take
+    # effect once they are on ``main`` and not before.
+    types: [maidr-released]
   schedule:
-    # Run daily at 9 AM UTC so new npm releases land on ``main`` within
-    # 24 hours. The commit step below is a no-op when the bundle is
-    # already current, so the daily cadence adds no commit noise.
+    # The backstop, kept deliberately. The dispatch above is one cross-repo
+    # hop that can be missed -- an expired token, a release published
+    # outside CI, a change to the sending workflow -- and the failure mode
+    # is silent, because nothing here would run at all. The daily poll
+    # bounds that miss at 24 hours instead of forever. The commit step is a
+    # no-op when the bundle is already current, so the pair costs no extra
+    # commit noise.
     - cron: '0 9 * * *'
   workflow_dispatch:
     inputs:
@@ -43,10 +65,17 @@ jobs:
       - name: Resolve, download and verify bundled assets
         id: bundle
         env:
-          # Pass the dispatch input through the environment rather than
+          # Pass the requested version through the environment rather than
           # interpolating ${{ ... }} into the script text, which would be a
-          # shell-injection surface in a job holding contents: write.
-          MAIDR_VERSION: ${{ github.event.inputs.maidr_version }}
+          # shell-injection surface in a job holding contents: write. The
+          # same reasoning covers ``client_payload``, which is written by
+          # whoever holds the sending token rather than by this repository;
+          # the script validates the version against a strict pattern before
+          # it reaches a URL or a path.
+          #
+          # Empty on a scheduled run, which is what makes the script resolve
+          # ``latest`` on its own.
+          MAIDR_VERSION: ${{ github.event.inputs.maidr_version || github.event.client_payload.version }}
         run: |
           set -euo pipefail
           # Resolve (or use the requested version), download, verify, and


### PR DESCRIPTION
Receiving half of a two-repo change. The sending half is a PR on xability/maidr, linked below.

## Why

The bundle refresh ran on a daily schedule alone, so a new upstream release reached users' plots up to 24 hours after it was published. For a fix in `maidr.js` that is a day of readers still hearing the old behaviour — the current `#121` is exactly this shape: the fix is merged upstream and users cannot have it yet.

Nothing about npm makes a poll the right shape for this. Publishing is an event upstream already knows about, so it can just say so.

## What changes

`update-maidr-bundle.yml` gains a `repository_dispatch` trigger on `maidr-released`. maidr's release workflow fires it the moment `npm publish` succeeds, carrying the version it published:

```json
{"event_type": "maidr-released", "client_payload": {"version": "4.0.1"}}
```

The job takes the version from `client_payload` when present, falling back to the `workflow_dispatch` input and then to nothing — which is what makes a scheduled run resolve `latest` on its own, exactly as before.

Naming the version rather than re-resolving `latest` is deliberate: it sidesteps the window right after a publish where the `latest` dist-tag has not propagated, and the per-version registry endpoint is available immediately.

## The schedule stays, on purpose

It is a backstop, not leftover. The dispatch is one cross-repo hop that can be missed — an expired token, a release published outside CI, a change to the sending workflow — and it fails **silently**, because the symptom is that nothing runs at all. The daily poll bounds that miss at 24 hours instead of forever.

Neither trigger covers the other's failure mode, so removing either one leaves a real gap.

## Trust

No new trust is granted here. `client_payload` is attacker-controlled in the sense that it is written by whoever holds the sending token — but that token needs write access to this repository to send a `repository_dispatch` at all, and anyone holding that could push to `main` directly. The version still passes through the existing strict pattern check in `fetch-maidr-bundle.sh` before it reaches a URL or a path, and the download is still verified against the registry's published integrity hash.

## One manual step before this does anything

The sending workflow reads a secret, `DOWNSTREAM_DISPATCH_TOKEN`, that does not exist yet and can only be created by a repository admin. Until it is set, the sending step logs that it is unconfigured and exits 0, and this repository keeps behaving exactly as it does today on the daily schedule. Nothing breaks in the meantime; the change simply does not take effect.

The token needs write access to **this** repository only (a fine-grained PAT scoped to `xability/r-maidr` with Contents: write is the tightest fit) and is stored in **maidr's** secrets.

Note also that `repository_dispatch` only ever triggers the workflow file as it exists on the default branch, so this has to be on `main` before any dispatch can be received. That is why this side lands first.

## Verification

`actionlint` — the same version and invocation `workflow-lint.yml` runs — passes on the changed file.

The version-capture shell on the sending side was exercised under `bash -e`, the Actions default shell, for both cases: a release writes `new_release=true` and `version=4.0.1`, and a failed `git describe` writes neither and does not abort the step.

This is CI-only; no R code, no tests, and nothing in the package itself changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZocjnGTiRvLDCbcvqYqa3)_