### PR TITLE
feat(ggplot2): emit stacked_normalized_bar for position = "fill"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,17 @@
 
 ## New Features
 
+* 100% stacked bar support for 'ggplot2'. A bar layer drawn with
+  `position = "fill"` is now emitted as `stacked_normalized_bar` rather than
+  being classified alongside `position = "stack"`. Filling rescales every
+  category to a common height, so a segment's value is its *share* of that
+  category and every bar totals 1 by construction; read as a plain stacked bar
+  those shares were announced as counts, implying the categories had equal
+  totals — the one thing a filled bar is drawn to deny. The emitted values now
+  follow the type: a filled layer reports the drawn share rather than
+  `stat_count()`'s untouched `count` column or the pre-rescale `y` from the
+  user's own data frame.
+
 * Added step plot support for 'ggplot2' (`geom_step()`) and Base R
   (`plot(type = "s")`, `plot(type = "S")`, and the `lines()` equivalents).
   A step plot describes a value that is piecewise constant — held across an

--- a/R/ggplot2_adapter.R
+++ b/R/ggplot2_adapter.R
@@ -89,6 +89,16 @@ Ggplot2Adapter <- R6::R6Class(
           has_fill <- (!is.null(layer_mapping) && !is.null(layer_mapping$fill)) ||
             (!is.null(plot_mapping) && !is.null(plot_mapping$fill))
           if (has_fill) {
+            # position = "fill" rescales every category to a common height, so
+            # a segment's value is its share of that category and every bar
+            # totals 1 by construction. Reading it as a plain stacked bar
+            # announces those shares as if they were counts and implies the
+            # categories have equal totals, which is the one thing a filled
+            # bar is drawn to deny. maidr.js has carried the distinct type
+            # since SegmentedTrace began serving NORMALIZED alongside STACKED.
+            if (position_class == "PositionFill") {
+              return("stacked_normalized_bar")
+            }
             return("stacked_bar")
           }
         }

--- a/R/ggplot2_processor_factory.R
+++ b/R/ggplot2_processor_factory.R
@@ -31,6 +31,10 @@ Ggplot2ProcessorFactory <- R6::R6Class(
         "bar" = Ggplot2BarLayerProcessor$new(layer_info),
         "dodged_bar" = Ggplot2DodgedBarLayerProcessor$new(layer_info),
         "stacked_bar" = Ggplot2StackedBarProcessor$new(layer_info),
+        # A filled bar is a stacked bar whose segments have been rescaled to
+        # shares, so it is extracted by the same processor; only the emitted
+        # type and the value it reads off the built data differ.
+        "stacked_normalized_bar" = Ggplot2StackedBarProcessor$new(layer_info),
         "pie" = Ggplot2PieLayerProcessor$new(layer_info),
         "hist" = Ggplot2HistogramLayerProcessor$new(layer_info),
         "line" = Ggplot2LineLayerProcessor$new(layer_info),
@@ -54,6 +58,7 @@ Ggplot2ProcessorFactory <- R6::R6Class(
         "bar",
         "dodged_bar",
         "stacked_bar",
+        "stacked_normalized_bar",
         "pie",
         "hist",
         "line",

--- a/R/ggplot2_stacked_bar_layer_processor.R
+++ b/R/ggplot2_stacked_bar_layer_processor.R
@@ -126,6 +126,15 @@ Ggplot2StackedBarProcessor <- R6::R6Class(
       has_y_mapping <- !is.null(y_quo)
       y_col <- if (has_y_mapping) rlang::as_label(y_quo) else NULL
 
+      # `position = "fill"` rescales every category to a common height, so the
+      # value the chart draws is a share and NOT the number sitting in the
+      # user's data frame. That matters twice below: the stat = "identity"
+      # branch reads `y` straight out of `original_data`, and the built-data
+      # branch prefers `stat_count()`'s untouched `count` column. Both would
+      # hand back tallies for a chart made entirely of proportions, so a
+      # normalized layer has to take the geometry route and subtract.
+      is_normalized <- identical(self$layer_info$type, "stacked_normalized_bar")
+
       if (is.null(built)) {
         built <- ggplot2::ggplot_build(plot)
       }
@@ -180,7 +189,7 @@ Ggplot2StackedBarProcessor <- R6::R6Class(
       # instead: it is what was actually drawn.
       rows_aligned <- nrow(original_data) == nrow(built_data_layer)
 
-      if (rows_aligned &&
+      if (!is_normalized && rows_aligned &&
           has_y_mapping && !is.null(y_col) && y_col %in% names(original_data) &&
           !is.null(fill_col) && fill_col %in% names(original_data) &&
           !is.null(x_col) && x_col %in% names(original_data)) {
@@ -316,9 +325,24 @@ Ggplot2StackedBarProcessor <- R6::R6Class(
             hex_color
           }
 
-          # Create a lookup of x_pos -> count for this fill color
+          # Create a lookup of x_pos -> value for this fill color.
+          #
+          # `count` is the raw tally `stat_count()` computed, and it is the
+          # right value for a stacked bar but the wrong one for a filled bar.
+          # `position = "fill"` rescales each category to a common height, so
+          # what the chart actually draws is every segment's *share* — while
+          # `count` keeps the untouched tally alongside it. Reading `count`
+          # there would announce counts for a chart made entirely of
+          # proportions, and the running total maidr.js derives would come out
+          # as the category total instead of the 1 the bar is drawn to.
+          # `geom_col()` has no `count` column at all and already falls
+          # through to the same subtraction once it reaches here.
           vals <- setNames(
-            if ("count" %in% names(group_rows)) group_rows$count else (group_rows$ymax - group_rows$ymin),
+            if (!is_normalized && "count" %in% names(group_rows)) {
+              group_rows$count
+            } else {
+              group_rows$ymax - group_rows$ymin
+            },
             group_rows$x
           )
 

--- a/inst/examples/ggplot2_all_plot_types_example.R
+++ b/inst/examples/ggplot2_all_plot_types_example.R
@@ -97,6 +97,29 @@ html_file_stacked <- file.path(output_dir, "example_stacked_bar_plot_ggplot2.htm
 result_stacked <- save_html(p_stacked, file = html_file_stacked)
 cat("Stacked bar plot (comma):", if (file.exists(html_file_stacked)) "OK" else "FAIL", "\n")
 
+# Test 3b: 100% stacked bar. The same data as above with `position = "fill"`,
+# which rescales every region to a common height so the segments read as
+# shares of that region rather than as sales volumes. MAIDR emits this as
+# `stacked_normalized_bar`, and the percent axis labels match the values the
+# layer carries.
+p_normalized <- ggplot(stacked_data, aes(x = Region, y = Sales, fill = Type)) +
+  geom_bar(stat = "identity", position = position_fill()) +
+  scale_y_continuous(labels = scales::label_percent()) +
+  labs(
+    title = "Regional Sales Mix by Channel",
+    x = "Region",
+    y = "Share of Regional Sales"
+  )
+
+html_file_normalized <- file.path(
+  output_dir, "example_normalized_stacked_bar_plot_ggplot2.html"
+)
+result_normalized <- save_html(p_normalized, file = html_file_normalized)
+cat(
+  "100% stacked bar (percent):",
+  if (file.exists(html_file_normalized)) "OK" else "FAIL", "\n"
+)
+
 # Test 4: Histogram with FIXED decimal formatting
 cat("\n=== TEST 4: Histogram (Fixed Decimal Formatting) ===\n")
 set.seed(42)

--- a/tests/testthat/test-normalized-stacked-bar.R
+++ b/tests/testthat/test-normalized-stacked-bar.R
@@ -1,0 +1,143 @@
+# `position = "fill"` rescales every category to a common height, so what the
+# chart draws is each segment's share of its category and every bar totals 1
+# by construction. r-maidr used to classify PositionFill as `stacked_bar`
+# alongside PositionStack, which announced those shares as counts and implied
+# the categories had equal totals -- the one thing a filled bar is drawn to
+# deny.
+#
+# The value side has its own trap, and it only shows on `geom_bar()`. ggplot2
+# keeps the untouched tally in `count` next to the rescaled `ymin`/`ymax`, so
+# an extractor that prefers `count` reads the raw numbers off a chart made
+# entirely of proportions. `geom_col()` has no `count` column and so was never
+# affected, which is why this needs testing on both geoms rather than one.
+
+skip_if_no_render <- function() {
+  testthat::skip_if_not_installed("ggplot2")
+  testthat::skip_if_not_installed("jsonlite")
+}
+
+# Long-form counts: category "a" splits 10/30, category "b" splits 50/50.
+# The two categories have deliberately different totals (40 vs 100) so a
+# normalized reading cannot be confused with a stacked one, and "b" is an even
+# split so a transposed extraction would still be caught by "a".
+COUNTS <- data.frame(
+  x = rep(c("a", "b"), each = 2),
+  f = rep(c("u", "v"), 2),
+  n = c(10, 30, 50, 50),
+  stringsAsFactors = FALSE
+)
+
+# The same data as one row per observation, for the `stat = "count"` path.
+OBSERVATIONS <- data.frame(
+  x = rep(COUNTS$x, COUNTS$n),
+  f = rep(COUNTS$f, COUNTS$n),
+  stringsAsFactors = FALSE
+)
+
+# Shares of each category, in the order the segments carry them.
+EXPECTED_SHARES <- list(u = c(10 / 40, 50 / 100), v = c(30 / 40, 50 / 100))
+
+# Render through the real pipeline and return the sole emitted layer.
+render_layer <- function(plot) {
+  file <- tempfile(fileext = ".html")
+  on.exit(unlink(file), add = TRUE)
+  suppressWarnings(save_html(plot, file))
+  html <- paste(readLines(file, warn = FALSE), collapse = "\n")
+
+  raw <- regmatches(html, regexpr('maidr-data="[^"]*"', html))
+  testthat::expect_length(raw, 1)
+  json <- sub('"$', "", sub('^maidr-data="', "", raw))
+  json <- gsub("&quot;", '"', json, fixed = TRUE)
+  json <- gsub("&lt;", "<", json, fixed = TRUE)
+  json <- gsub("&gt;", ">", json, fixed = TRUE)
+  json <- gsub("&amp;", "&", json, fixed = TRUE)
+
+  jsonlite::fromJSON(json, simplifyVector = FALSE)$subplots[[1]][[1]]$layers[[1]]
+}
+
+# Series values keyed by their fill label, so assertions do not depend on the
+# stacking order the extractor emits.
+values_by_fill <- function(layer) {
+  out <- list()
+  for (series in layer$data) {
+    label <- as.character(series[[1]]$z)
+    out[[label]] <- vapply(series, function(point) as.numeric(point$y), numeric(1))
+  }
+  out
+}
+
+test_that("geom_col(position = 'fill') is typed as a normalized stacked bar", {
+  skip_if_no_render()
+  plot <- ggplot2::ggplot(COUNTS, ggplot2::aes(x = x, y = n, fill = f)) +
+    ggplot2::geom_col(position = "fill")
+
+  expect_equal(render_layer(plot)$type, "stacked_normalized_bar")
+})
+
+test_that("geom_bar(position = 'fill') is typed as a normalized stacked bar", {
+  skip_if_no_render()
+  plot <- ggplot2::ggplot(OBSERVATIONS, ggplot2::aes(x = x, fill = f)) +
+    ggplot2::geom_bar(position = "fill")
+
+  expect_equal(render_layer(plot)$type, "stacked_normalized_bar")
+})
+
+test_that("position = 'stack' still reads as a plain stacked bar", {
+  skip_if_no_render()
+  plot <- ggplot2::ggplot(COUNTS, ggplot2::aes(x = x, y = n, fill = f)) +
+    ggplot2::geom_col(position = "stack")
+
+  layer <- render_layer(plot)
+  expect_equal(layer$type, "stacked_bar")
+  # The counts themselves must be untouched by the normalized branch.
+  values <- values_by_fill(layer)
+  expect_equal(values$u, c(10, 50))
+  expect_equal(values$v, c(30, 50))
+})
+
+test_that("a filled geom_col carries shares rather than counts", {
+  skip_if_no_render()
+  plot <- ggplot2::ggplot(COUNTS, ggplot2::aes(x = x, y = n, fill = f)) +
+    ggplot2::geom_col(position = "fill")
+
+  values <- values_by_fill(render_layer(plot))
+  expect_equal(values$u, EXPECTED_SHARES$u, tolerance = 1e-8)
+  expect_equal(values$v, EXPECTED_SHARES$v, tolerance = 1e-8)
+})
+
+test_that("a filled geom_bar carries shares, not the raw count column", {
+  skip_if_no_render()
+  # The regression this file exists for: `stat_count()` puts the untouched
+  # tally in `count`, so preferring it emits 10/30/50/50 for a chart drawn
+  # entirely out of proportions.
+  plot <- ggplot2::ggplot(OBSERVATIONS, ggplot2::aes(x = x, fill = f)) +
+    ggplot2::geom_bar(position = "fill")
+
+  values <- values_by_fill(render_layer(plot))
+  expect_equal(values$u, EXPECTED_SHARES$u, tolerance = 1e-8)
+  expect_equal(values$v, EXPECTED_SHARES$v, tolerance = 1e-8)
+})
+
+test_that("every category of a filled bar totals one", {
+  skip_if_no_render()
+  # maidr.js derives a running total per category from these values. For a
+  # filled bar that total has to come out as 1, because that is the height
+  # every bar is drawn to.
+  plot <- ggplot2::ggplot(OBSERVATIONS, ggplot2::aes(x = x, fill = f)) +
+    ggplot2::geom_bar(position = "fill")
+
+  values <- values_by_fill(render_layer(plot))
+  totals <- Reduce(`+`, values)
+  expect_equal(totals, rep(1, length(totals)), tolerance = 1e-8)
+})
+
+test_that("the ggplot2 factory can build a processor for the new type", {
+  factory <- Ggplot2ProcessorFactory$new()
+
+  expect_true("stacked_normalized_bar" %in% factory$get_supported_types())
+  processor <- factory$create_processor(
+    "stacked_normalized_bar",
+    list(type = "stacked_normalized_bar")
+  )
+  expect_s3_class(processor, "Ggplot2StackedBarProcessor")
+})


### PR DESCRIPTION
## Description

`PositionFill` was classified alongside `PositionStack` as `stacked_bar`, so `geom_bar(position = "fill")` — the standard way to draw a 100% stacked bar — was announced as a plain stacked bar. maidr.js has carried the distinct type for a while (`SegmentedTrace` serves `NORMALIZED` alongside `STACKED`); r-maidr simply never emitted it. The comments in `ggplot2_stacked_bar_layer_processor.R` and `ggplot2_dodged_bar_layer_processor.R` already anticipated this, noting the three types are built by the same machinery.

The distinction is not cosmetic. Filling rescales every category to a common height, so a segment's value is its **share** of that category and every bar totals 1 by construction. Read as a stacked bar, those shares are announced as counts and the categories are implied to have equal totals — the one thing a filled bar is drawn to deny.

Closes #133.

## Changes Made

**Classification** (`R/ggplot2_adapter.R`) — `PositionFill` splits off from `PositionStack`, still gated on a fill mapping being present.

**Registration** (`R/ggplot2_processor_factory.R`) — `stacked_normalized_bar` routes to the existing `Ggplot2StackedBarProcessor` and joins `get_supported_types()`. A filled bar is a stacked bar whose segments have been rescaled; only the emitted type and the value read off the built data differ.

**Values** (`R/ggplot2_stacked_bar_layer_processor.R`) — this is the part worth reviewing. Two separate paths were handing back the wrong number, and only one of them was obvious from the issue:

1. The `stat = "identity"` branch reads `y` straight out of the user's own data frame, which for a filled layer holds the numbers *before* rescaling. This is the `geom_col()` path.
2. The built-data branch prefers `stat_count()`'s `count` column, which ggplot2 leaves untouched next to the rescaled `ymin`/`ymax`. This is the `geom_bar()` path.

Either would announce tallies for a chart made entirely of proportions, and the running total maidr.js derives would come out as the category total instead of the 1 the bar is drawn to. A normalized layer now skips the identity branch and subtracts `ymax - ymin`.

I only found the first path because the test for `geom_col` failed after I had fixed the second — my initial reading of the extractor missed that the identity branch bypasses the built data entirely.

Verified against ggplot2 3.4.4, where `geom_bar(position = "fill")` gives `count = 10, 30, 50, 50` beside `ymax - ymin = 0.25, 0.75, 0.5, 0.5` for the same four segments.

## Testing

New file `tests/testthat/test-normalized-stacked-bar.R`, **18 assertions, all passing**. It covers both geoms on both axes of the problem — type classification and emitted values — because the two geoms fail differently and a test on one would have passed while the other stayed broken. It also asserts that `position = "stack"` still emits untouched counts, and that every category of a filled bar totals 1.

Full suite: `test_dir("tests/testthat")` reports **9 failures, all in the pie tests** (`test-ggplot2-pie-layer-processor.R` and the pie case in `test-fabricated-selector-guard.R`). Those are **pre-existing** — I confirmed it by stashing this branch and re-running on the base commit, which reproduces the identical 9. They look environment-related (gridSVG polygon rendering in this container) rather than a repo regression, but either way they are untouched by this change and I have not investigated further.

## Notes

The base R adapter has the same gap and is not addressed here — `R/base_r_adapter.R` classifies stacked barplots without a fill/normalized distinction, and its stacking is expressed differently enough to deserve its own change.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_