### PR TITLE
fix(format): resolve a currency prefix outside a UTF-8 locale

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,7 +52,8 @@ Suggests:
     quantmod,
     TTR,
     zoo,
-    xts
+    xts,
+    pkgload
 Config/testthat/edition: 3
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2

--- a/R/format_utils.R
+++ b/R/format_utils.R
@@ -146,6 +146,44 @@ extract_from_scales_closure <- function(label_func) {
   build_format_config(format_type, prefix, suffix, accuracy, digits)
 }
 
+#' Declare a String's Encoding as UTF-8
+#'
+#' The currency symbols in this file are written as `\uXXXX` escapes, which
+#' always produce UTF-8 bytes. What varies is whether R *marks* them: in a
+#' UTF-8 session it does, and in a `C` session it leaves them `"unknown"`.
+#' A prefix arriving from `readr`, `jsonlite` or `read.csv(encoding =)` is
+#' marked `"UTF-8"` either way, so in a non-UTF-8 session the two sides
+#' disagree and `match()` -- which translates to the native encoding first,
+#' where a euro has no representation -- misses on identical bytes. Every
+#' non-dollar currency then fell through to the `USD` default, and a euro
+#' axis was announced as dollars (#139).
+#'
+#' Declaring the encoding states what the bytes already are; it does not
+#' convert them. `enc2utf8()` is not a substitute -- it reads an `"unknown"`
+#' string as native and mistranslates these keys.
+#'
+#' @param x A character vector.
+#' @return `x`, marked as UTF-8.
+#' @keywords internal
+#' @noRd
+as_utf8 <- function(x) {
+  Encoding(x) <- "UTF-8"
+  x
+}
+
+#' Currency Symbols Recognised as a Prefix
+#'
+#' Shared by [detect_scales_format_type()] and [prefix_to_currency_code()] so
+#' the test that decides something is a currency cannot drift from the map
+#' that names which one.
+#'
+#' @keywords internal
+#' @noRd
+CURRENCY_SYMBOLS <- c(
+  "$", "\u20ac", "\u00a3", "\u00a5", "\u20b9",
+  "\u20a9", "\u20bd", "\u20aa", "\u20b1", "\u0e3f"
+)
+
 #' Detect Format Type from scales Closure Parameters
 #'
 #' @param prefix Prefix string from closure
@@ -166,10 +204,10 @@ detect_scales_format_type <- function(prefix, suffix, digits, scale, accuracy) {
     return("percent")
   }
 
-  # Currency: common currency symbols as prefix
-  currency_symbols <- c("$", "\u20ac", "\u00a3", "\u00a5", "\u20b9",
-                        "\u20a9", "\u20bd", "\u20aa", "\u20b1", "\u0e3f")
-  if (!is.null(prefix) && (prefix %in% currency_symbols ||
+  # Currency: common currency symbols as prefix.  Both sides are declared
+  # UTF-8 so the comparison does not depend on the session locale -- see
+  # `as_utf8()`.
+  if (!is.null(prefix) && (as_utf8(prefix) %in% as_utf8(CURRENCY_SYMBOLS) ||
       grepl("^[A-Z]{0,2}\\$", prefix))) {
     return("currency")
   }
@@ -252,32 +290,45 @@ prefix_to_currency_code <- function(prefix) {
     return("USD")
   }
 
-  # Common currency mappings
-  currency_map <- list(
-    "$" = "USD",
-    "\u20ac" = "EUR", # Euro sign
-    "\u00a3" = "GBP", # Pound sign
-    "\u00a5" = "JPY", # Yen sign
-    "\u20b9" = "INR", # Indian Rupee sign
-    "\u20a9" = "KRW", # Korean Won sign
-    "\u20bd" = "RUB", # Russian Ruble sign
-    "R$" = "BRL", # Brazilian Real
-    "CHF" = "CHF", # Swiss Franc
-    "C$" = "CAD", # Canadian Dollar
-    "A$" = "AUD", # Australian Dollar
-    "NZ$" = "NZD", # New Zealand Dollar
-    "HK$" = "HKD", # Hong Kong Dollar
-    "S$" = "SGD", # Singapore Dollar
-    "\u20aa" = "ILS", # Israeli Shekel sign
-    "\u20b1" = "PHP", # Philippine Peso sign
-    "\u0e3f" = "THB", # Thai Baht sign
-    "kr" = "SEK", # Swedish Krona (also NOK, DKK)
-    "z\u0142" = "PLN" # Polish Zloty
+  # Two parallel vectors rather than a named list.  A `\uXXXX` escape in a
+  # *tag* position -- `list("\u20ac" = "EUR")` -- is not stored as the euro at
+  # all outside a UTF-8 session: a tag becomes a symbol, symbols must be
+  # representable in the native encoding, and R substitutes the placeholder
+  # text `<U+20AC>`.  So the key was already destroyed at parse time and no
+  # comparison could have recovered it (#139).  The same escape in an ordinary
+  # string keeps its bytes and its UTF-8 mark, which is why the vectors below
+  # survive where the tags did not.
+  prefixes <- c(
+    "$",
+    "\u20ac", # Euro sign
+    "\u00a3", # Pound sign
+    "\u00a5", # Yen sign
+    "\u20b9", # Indian Rupee sign
+    "\u20a9", # Korean Won sign
+    "\u20bd", # Russian Ruble sign
+    "R$", # Brazilian Real
+    "CHF", # Swiss Franc
+    "C$", # Canadian Dollar
+    "A$", # Australian Dollar
+    "NZ$", # New Zealand Dollar
+    "HK$", # Hong Kong Dollar
+    "S$", # Singapore Dollar
+    "\u20aa", # Israeli Shekel sign
+    "\u20b1", # Philippine Peso sign
+    "\u0e3f", # Thai Baht sign
+    "kr", # Swedish Krona (also NOK, DKK)
+    "z\u0142" # Polish Zloty
+  )
+  codes <- c(
+    "USD", "EUR", "GBP", "JPY", "INR", "KRW", "RUB", "BRL", "CHF", "CAD",
+    "AUD", "NZD", "HKD", "SGD", "ILS", "PHP", "THB", "SEK", "PLN"
   )
 
-  # Return mapped code or the prefix itself as fallback
-  if (prefix %in% names(currency_map)) {
-    return(currency_map[[prefix]])
+  # Declared on both sides so the comparison does not depend on the session
+  # locale either -- see `as_utf8()`.
+  matched <- match(as_utf8(prefix), as_utf8(prefixes))
+  if (!is.na(matched)) {
+    return(codes[[matched]])
   }
 
   # If prefix looks like an ISO code (3 uppercase letters), use it directly

--- a/tests/testthat/test-format-utils.R
+++ b/tests/testthat/test-format-utils.R
@@ -1,0 +1,165 @@
+# Currency prefix resolution (#139)
+#
+# A `\uXXXX` escape behaves differently depending on where it sits. In an
+# ordinary string it keeps its bytes and its UTF-8 mark in every locale. In a
+# *tag* -- `list("€" = "EUR")` -- it becomes a symbol, symbols must be
+# representable in the native encoding, and outside a UTF-8 session R stores
+# the placeholder text `<U+20AC>` instead. The key is then gone before any
+# comparison runs, and every non-dollar currency fell through to the `USD`
+# default: a euro axis announced as dollars, silently.
+#
+# That failure is invisible in a UTF-8 session, which is what CI runs, so the
+# behavioural case below forces a `C` locale in a subprocess. The static case
+# needs no subprocess and states the rule for code written later.
+
+# ---------------------------------------------------------------------------
+# Behaviour, in a locale that cannot represent the symbols
+# ---------------------------------------------------------------------------
+
+#' Run an expression in a fresh R session under a given locale.
+#'
+#' @param body Lines of R to run after the package is loaded.
+#' @param locale Value for `LC_ALL`.
+#' @return The subprocess's stdout, or `NULL` if it could not be run.
+#' @noRd
+in_locale <- function(body, locale = "C") {
+  rscript <- file.path(R.home("bin"), "Rscript")
+  if (!file.exists(rscript)) {
+    return(NULL)
+  }
+
+  root <- normalizePath(testthat::test_path("..", ".."), mustWork = FALSE)
+  script <- tempfile(fileext = ".R")
+  on.exit(unlink(script), add = TRUE)
+
+  writeLines(
+    c(
+      sprintf(".libPaths(%s)", paste(deparse(.libPaths()), collapse = "")),
+      # `load_all()` under test, `library()` under R CMD check, where the
+      # package is installed and the source tree may not be beside us.
+      sprintf(
+        "if (requireNamespace('pkgload', quietly = TRUE) && dir.exists(%s)) {
+           suppressMessages(pkgload::load_all(%s, quiet = TRUE))
+         } else {
+           suppressMessages(library(maidr))
+         }",
+        deparse(file.path(root, "R")), deparse(root)
+      ),
+      body
+    ),
+    script
+  )
+
+  out <- suppressWarnings(system2(
+    rscript, script,
+    stdout = TRUE, stderr = FALSE,
+    env = c(paste0("LC_ALL=", locale), paste0("LANG=", locale))
+  ))
+  if (!is.null(attr(out, "status")) && attr(out, "status") != 0) {
+    return(NULL)
+  }
+  out
+}
+
+test_that("every currency prefix resolves outside a UTF-8 locale", {
+  out <- in_locale(c(
+    "syms <- c('\\u20ac', '\\u00a3', '\\u00a5', '\\u20b9', '\\u20a9',",
+    "          '\\u20bd', '\\u20aa', '\\u20b1', '\\u0e3f', 'z\\u0142', '$')",
+    "mark <- function(s) { Encoding(s) <- 'UTF-8'; s }",
+    "cat(vapply(syms, function(s)",
+    "  maidr:::prefix_to_currency_code(mark(s)), ''), sep = ' ')"
+  ))
+  skip_if(is.null(out), "could not run a subprocess in the C locale")
+
+  expect_equal(
+    strsplit(trimws(paste(out, collapse = " ")), "\\s+")[[1]],
+    c("EUR", "GBP", "JPY", "INR", "KRW", "RUB", "ILS", "PHP", "THB",
+      "PLN", "USD")
+  )
+})
+
+test_that("a currency prefix is detected outside a UTF-8 locale", {
+  out <- in_locale(c(
+    "mark <- function(s) { Encoding(s) <- 'UTF-8'; s }",
+    "cat(maidr:::detect_scales_format_type(",
+    "  mark('\\u20ac'), NULL, NULL, NULL, NULL))"
+  ))
+  skip_if(is.null(out), "could not run a subprocess in the C locale")
+
+  expect_equal(trimws(paste(out, collapse = "")), "currency")
+})
+
+# ---------------------------------------------------------------------------
+# Behaviour in this session, whatever locale it is
+# ---------------------------------------------------------------------------
+
+test_that("a currency prefix resolves however its encoding is declared", {
+  euro_bytes <- rawToChar(as.raw(c(0xe2, 0x82, 0xac)))
+  marked <- euro_bytes
+  Encoding(marked) <- "UTF-8"
+
+  # Same bytes, one declared and one not. A reader gets the prefix from
+  # whichever of `readr`, `jsonlite` or a literal produced it, and must not
+  # hear a different currency because of that.
+  expect_equal(prefix_to_currency_code(marked), "EUR")
+  expect_equal(prefix_to_currency_code(euro_bytes), "EUR")
+})
+
+test_that("an unknown prefix still falls back rather than erroring", {
+  expect_equal(prefix_to_currency_code("₿"), "USD") # Bitcoin sign
+  expect_equal(prefix_to_currency_code(NULL), "USD")
+  expect_equal(prefix_to_currency_code(""), "USD")
+  expect_equal(prefix_to_currency_code("SEK"), "SEK") # ISO code passthrough
+})
+
+# ---------------------------------------------------------------------------
+# The rule, for code written later
+# ---------------------------------------------------------------------------
+
+test_that("no non-ASCII escape sits in a tag position in R/", {
+  # The behavioural cases above only bite in a `C` locale, and a future
+  # `list("€" = ...)` written on a UTF-8 machine would pass every test
+  # here while being broken for the same readers as before. This case bites
+  # in any locale, because it reads the source rather than running it.
+  sources <- list.files(
+    testthat::test_path("..", "..", "R"),
+    pattern = "\\.R$", full.names = TRUE
+  )
+  skip_if(length(sources) == 0, "no R/ sources beside the tests")
+
+  # Read through the parser rather than with a regex: `EQ_SUB` is the token R
+  # uses for a tag inside a call, so a comment that merely discusses the
+  # mistake -- as the one above `prefixes` does -- is a `COMMENT` token and
+  # cannot be mistaken for the mistake itself.
+  offenders <- character()
+  for (path in sources) {
+    parsed <- tryCatch(
+      utils::getParseData(parse(path, keep.source = TRUE)),
+      error = function(e) NULL
+    )
+    if (is.null(parsed) || nrow(parsed) == 0) {
+      next
+    }
+
+    code <- parsed[parsed$terminal & parsed$token != "COMMENT", ]
+    code <- code[order(code$line1, code$col1), ]
+    tagged <- which(code$token == "EQ_SUB")
+    keys <- tagged[tagged > 1L] - 1L
+    keys <- keys[code$token[keys] == "STR_CONST"]
+    escaped <- keys[grepl("\\\\u[0-9a-fA-F]{4}", code$text[keys])]
+
+    if (length(escaped)) {
+      offenders <- c(
+        offenders, sprintf("%s:%d", basename(path), code$line1[escaped])
+      )
+    }
+  }
+
+  expect_equal(
+    offenders, character(),
+    info = paste(
+      "a \\uXXXX escape in a tag becomes the text <U+XXXX> outside a UTF-8",
+      "locale; put the escape in a plain string and match on it instead"
+    )
+  )
+})

--- a/tests/testthat/test-format-utils.R
+++ b/tests/testthat/test-format-utils.R
@@ -2,7 +2,7 @@
 #
 # A `\uXXXX` escape behaves differently depending on where it sits. In an
 # ordinary string it keeps its bytes and its UTF-8 mark in every locale. In a
-# *tag* -- `list("€" = "EUR")` -- it becomes a symbol, symbols must be
+# *tag* -- `list("\\u20ac" = "EUR")` -- it becomes a symbol, symbols must be
 # representable in the native encoding, and outside a UTF-8 session R stores
 # the placeholder text `<U+20AC>` instead. The key is then gone before any
 # comparison runs, and every non-dollar currency fell through to the `USD`
@@ -106,7 +106,7 @@ test_that("a currency prefix resolves however its encoding is declared", {
 })
 
 test_that("an unknown prefix still falls back rather than erroring", {
-  expect_equal(prefix_to_currency_code("₿"), "USD") # Bitcoin sign
+  expect_equal(prefix_to_currency_code("\u20bf"), "USD") # Bitcoin sign
   expect_equal(prefix_to_currency_code(NULL), "USD")
   expect_equal(prefix_to_currency_code(""), "USD")
   expect_equal(prefix_to_currency_code("SEK"), "SEK") # ISO code passthrough
@@ -118,7 +118,7 @@ test_that("an unknown prefix still falls back rather than erroring", {
 
 test_that("no non-ASCII escape sits in a tag position in R/", {
   # The behavioural cases above only bite in a `C` locale, and a future
-  # `list("€" = ...)` written on a UTF-8 machine would pass every test
+  # `list("\\u20ac" = ...)` written on a UTF-8 machine would pass every test
   # here while being broken for the same readers as before. This case bites
   # in any locale, because it reads the source rather than running it.
   sources <- list.files(


### PR DESCRIPTION
## What was wrong

A euro-denominated axis was announced to a screen-reader user **as dollars**. Same chart, same code — the answer decided by the session locale:

```r
euro <- rawToChar(as.raw(c(0xe2, 0x82, 0xac))); Encoding(euro) <- "UTF-8"
p <- ggplot(df, aes(cat, val)) + geom_col() +
  scale_y_continuous(labels = scales::label_dollar(prefix = euro))
maidr:::extract_axis_format(ggplot2::ggplot_build(p), "y")
```

| locale | emitted |
|---|---|
| `C.UTF-8` | `$currency: "EUR"` |
| `C` | `$currency: "USD"` |

Every non-dollar currency was affected — GBP, JPY, INR, KRW, RUB, ILS, PHP, THB, PLN — with no error, no warning, and a payload that is internally consistent. Nothing looks wrong from the inside.

## Why — and why my first diagnosis in #139 was only half of it

I opened #139 thinking this was an encoding *mark* mismatch, fixable by declaring both sides UTF-8 before comparing. That fix did not work, and printing the parsed function showed why:

```
`<U+20AA>` = "ILS", `<U+20B1>` = "PHP", `z<U+0142>` = "PLN"
```

**The key was already destroyed at parse time.** A `\uXXXX` escape behaves differently depending on where it sits:

- in an ordinary string it keeps its bytes and its UTF-8 mark in every locale;
- in a **tag** — `list("€" = "EUR")` — it becomes a symbol, symbols must be representable in the native encoding, and outside a UTF-8 session R substitutes the placeholder *text* `<U+20AC>`.

So no comparison could have recovered it. The map had to stop being a named list. It is now two parallel vectors matched on index, which is why `CURRENCY_SYMBOLS` — a plain character vector all along — was never affected and `detect_scales_format_type()` half-worked.

`as_utf8()` covers the genuine second half, which #139 did describe correctly: a prefix from `readr`, `jsonlite`, or `read.csv(encoding = "UTF-8")` carries a `"UTF-8"` mark, and native-marked keys will not match it even on identical bytes. `enc2utf8()` is **not** a substitute — it reads an `"unknown"` string as native and mistranslates these keys, leaving the C-locale case still failing. I tried that first.

## Verification

All 15 mapped prefixes, both locales, and both input encodings (UTF-8-marked and unmarked):

```
=== C ===        locale: C         all correct: TRUE
=== UTF-8 ===    locale: C.UTF-8   all correct: TRUE
```

## Tests

`tests/testthat/test-format-utils.R`, 9 cases. The awkward part is that **a UTF-8 session cannot see this bug at all**, so an ordinary test would have passed before and after and proved nothing. Two devices instead:

1. **A subprocess forced into `LC_ALL=C`**, which resolves all eleven symbols and checks currency *detection* separately. Skips rather than fails if a subprocess cannot be started.
2. **A static case that reads `R/` through the parser** and rejects any `\uXXXX` escape in tag position. This bites in *any* locale, and it is the one that matters going forward: a future `list("€" = ...)` written on a UTF-8 machine would pass every behavioural test here while being broken for exactly the readers this repo exists for.

The static case uses `getParseData()` rather than a regex, because `EQ_SUB` is the token R uses for a tag — so the comment above `prefixes` that *discusses* the mistake is a `COMMENT` token and cannot be mistaken for the mistake. It caught that false positive on its first run, which is how I found out I needed the parser.

**Verified they bite:** against the code this replaces, **4 of the 9 fail** — both in-session behavioural cases (`USD` where `EUR` was expected), the forced-locale case, and the static case.

| Gate | Result |
|---|---|
| full suite | **4649 passed**, 0 failed, 0 errors (from 4640) |
| skipped | 97, unchanged — all optional packages (`patchwork`, `quantmod`, `shiny`) |
| non-ASCII literals in `R/format_utils.R` | 0, unchanged — the escapes are kept, only their position moved |

## Related

Closes #139.

Found while chasing the ten `unable to translate '<U+20AC>' to native encoding` warnings that `pkgload::load_all()` emits in a `C` locale. Those warnings are cosmetic — `parse()` reporting it cannot render the escapes for source references — but they were the thread that led here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmSHGxAWRw5wVWqDKdaZm6)_