### PR TITLE
feat(base-r): read a normalized barplot as stacked_normalized_bar

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,5 +55,5 @@ Suggests:
     xts
 Config/testthat/edition: 3
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
 VignetteBuilder: knitr
+Config/roxygen2/version: 8.1.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,5 +55,5 @@ Suggests:
     xts
 Config/testthat/edition: 3
 Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.3.2
 VignetteBuilder: knitr
-Config/roxygen2/version: 8.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,17 @@
   follow the type: a filled layer reports the drawn share rather than
   `stat_count()`'s untouched `count` column or the pre-rescale `y` from the
   user's own data frame.
+* 100% stacked bar support for Base R. `barplot()` takes no normalisation
+  argument at all — the idiomatic 100% stacked bar is written by normalising
+  the matrix first, as `barplot(prop.table(m, 2))` — so the classification
+  reads the drawn geometry instead: a stacked barplot whose every column sums
+  to 1 is emitted as `stacked_normalized_bar`. Deliberately narrow, and it
+  claims nothing it cannot read. Columns summing to 100 stay a plain stacked
+  bar, because a matrix of counts can total 100 by coincidence and the drawing
+  does not distinguish that from percentages; a single-row matrix stays one
+  too, since a series stacked against nothing is not a stack. The values need
+  no adjustment here, unlike the 'ggplot2' case above: they already are the
+  drawn shares.
 
 * Added step plot support for 'ggplot2' (`geom_step()`) and Base R
   (`plot(type = "s")`, `plot(type = "S")`, and the `lines()` equivalents).

--- a/R/base_r_adapter.R
+++ b/R/base_r_adapter.R
@@ -130,6 +130,8 @@ BaseRAdapter <- R6::R6Class(
         "barplot" = {
           if (self$is_dodged_barplot(args)) {
             "dodged_bar"
+          } else if (self$is_normalized_barplot(args)) {
+            "stacked_normalized_bar"
           } else if (self$is_stacked_barplot(args)) {
             "stacked_bar"
           } else {
@@ -334,6 +336,50 @@ BaseRAdapter <- R6::R6Class(
       beside_false <- if (is.null(beside)) TRUE else !isTRUE(beside)
 
       is_matrix && beside_false
+    },
+
+    #' @description Check if a barplot call draws a 100% stacked bar
+    #'
+    #' Base R has no `position = "fill"` to read: `barplot()` takes no
+    #' normalisation argument at all, and the idiomatic way to draw a 100%
+    #' stacked bar is to normalise the matrix first, as
+    #' `barplot(prop.table(m, 2))`. The only signal left is the drawn geometry.
+    #'
+    #' So this reads what the chart shows rather than guessing what the author
+    #' meant, and the two are the same thing here: when every column sums to 1,
+    #' every bar is drawn to a common full height and each segment is that
+    #' category's share. A chart like that IS a 100% stacked bar whatever the
+    #' numbers were before they reached `barplot()`.
+    #'
+    #' Deliberately narrow. It does not also accept columns summing to 100,
+    #' because a matrix of raw counts can total 100 by coincidence and nothing
+    #' about the drawing would distinguish that from percentages. And it needs
+    #' two or more rows, because a single series stacked against nothing is not
+    #' a stack.
+    #'
+    #' @param args The arguments from the barplot call
+    #' @return TRUE if every column of the height matrix sums to 1
+    is_normalized_barplot = function(args) {
+      if (!self$is_stacked_barplot(args)) {
+        return(FALSE)
+      }
+
+      height <- args[[1]]
+      if (nrow(height) < 2) {
+        return(FALSE)
+      }
+
+      sums <- colSums(height, na.rm = TRUE)
+      if (length(sums) == 0 || !all(is.finite(sums))) {
+        return(FALSE)
+      }
+
+      # `prop.table()` divides, so the columns land near 1 rather than on it.
+      isTRUE(all.equal(
+        unname(sums),
+        rep(1, length(sums)),
+        tolerance = 1e-8
+      ))
     },
 
     #' @description Create an orchestrator for this system (Base R)

--- a/R/base_r_processor_factory.R
+++ b/R/base_r_processor_factory.R
@@ -30,6 +30,9 @@ BaseRProcessorFactory <- R6::R6Class(
         "bar" = BaseRBarplotLayerProcessor$new(layer_info),
         "dodged_bar" = BaseRDodgedBarLayerProcessor$new(layer_info),
         "stacked_bar" = BaseRStackedBarLayerProcessor$new(layer_info),
+        # Same extraction as a plain stack: base R has no normalisation
+        # argument, so the values already are the drawn shares.
+        "stacked_normalized_bar" = BaseRStackedBarLayerProcessor$new(layer_info),
         "smooth" = BaseRSmoothLayerProcessor$new(layer_info),
         "line" = BaseRLineLayerProcessor$new(layer_info),
         "step" = BaseRStepLayerProcessor$new(layer_info),
@@ -53,6 +56,7 @@ BaseRProcessorFactory <- R6::R6Class(
         "bar",
         "dodged_bar",
         "stacked_bar",
+        "stacked_normalized_bar",
         "smooth",
         "line",
         "step",

--- a/R/base_r_stacked_bar_layer_processor.R
+++ b/R/base_r_stacked_bar_layer_processor.R
@@ -27,7 +27,15 @@ BaseRStackedBarLayerProcessor <- R6::R6Class(
       list(
         data = data,
         selectors = selectors,
-        type = "stacked_bar",
+        # A 100% stacked bar is extracted by this same processor -- the values
+        # are already the drawn shares, since base R has no `position = "fill"`
+        # and the author normalised the matrix before calling `barplot()`. Only
+        # the emitted type differs, so read it rather than hardcoding one.
+        type = if (identical(self$layer_info$type, "stacked_normalized_bar")) {
+          "stacked_normalized_bar"
+        } else {
+          "stacked_bar"
+        },
         title = title,
         axes = axes,
         domMapping = list(groupDirection = "forward")

--- a/man/BaseRAdapter.Rd
+++ b/man/BaseRAdapter.Rd
@@ -22,6 +22,7 @@ to intercept Base R plotting calls and detect plot types.
 \item \href{#method-BaseRAdapter-detect_layer_type}{\code{BaseRAdapter$detect_layer_type()}}
 \item \href{#method-BaseRAdapter-is_dodged_barplot}{\code{BaseRAdapter$is_dodged_barplot()}}
 \item \href{#method-BaseRAdapter-is_stacked_barplot}{\code{BaseRAdapter$is_stacked_barplot()}}
+\item \href{#method-BaseRAdapter-is_normalized_barplot}{\code{BaseRAdapter$is_normalized_barplot()}}
 \item \href{#method-BaseRAdapter-create_orchestrator}{\code{BaseRAdapter$create_orchestrator()}}
 \item \href{#method-BaseRAdapter-get_system_name}{\code{BaseRAdapter$get_system_name()}}
 \item \href{#method-BaseRAdapter-get_adapter}{\code{BaseRAdapter$get_adapter()}}
@@ -125,6 +126,43 @@ Check if a barplot call represents a stacked bar plot
 }
 \subsection{Returns}{
 TRUE if this is a stacked bar plot, FALSE otherwise
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-BaseRAdapter-is_normalized_barplot"></a>}}
+\if{latex}{\out{\hypertarget{method-BaseRAdapter-is_normalized_barplot}{}}}
+\subsection{Method \code{is_normalized_barplot()}}{
+Check if a barplot call draws a 100\% stacked bar
+
+Base R has no \code{position = "fill"} to read: \code{barplot()} takes no
+normalisation argument at all, and the idiomatic way to draw a 100\%
+stacked bar is to normalise the matrix first, as
+\code{barplot(prop.table(m, 2))}. The only signal left is the drawn geometry.
+
+So this reads what the chart shows rather than guessing what the author
+meant, and the two are the same thing here: when every column sums to 1,
+every bar is drawn to a common full height and each segment is that
+category's share. A chart like that IS a 100\% stacked bar whatever the
+numbers were before they reached \code{barplot()}.
+
+Deliberately narrow. It does not also accept columns summing to 100,
+because a matrix of raw counts can total 100 by coincidence and nothing
+about the drawing would distinguish that from percentages. And it needs
+two or more rows, because a single series stacked against nothing is not
+a stack.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{BaseRAdapter$is_normalized_barplot(args)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{args}}{The arguments from the barplot call}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+TRUE if every column of the height matrix sums to 1
 }
 }
 \if{html}{\out{<hr>}}

--- a/tests/testthat/test-base-r-normalized-bar.R
+++ b/tests/testthat/test-base-r-normalized-bar.R
@@ -1,0 +1,89 @@
+# Base R has no `position = "fill"`. `barplot()` takes no normalisation
+# argument at all, so the idiomatic 100% stacked bar is written by normalising
+# the matrix first — `barplot(prop.table(m, 2))` — and the only signal left to
+# read is the drawn geometry.
+#
+# That makes the classification here a reading of what the chart shows rather
+# than of what the author declared, which is a weaker footing than the ggplot2
+# side has and is worth pinning from both directions: the shapes that must be
+# claimed, and the ones that must not.
+
+# Counts: category "a" splits 10/30, category "b" splits 50/50. Deliberately
+# different column totals (40 vs 100), so a normalized reading of the raw
+# matrix would be plainly wrong.
+COUNTS <- matrix(
+  c(10, 30, 50, 50),
+  nrow = 2,
+  dimnames = list(c("u", "v"), c("a", "b"))
+)
+
+# Build the layer shape `detect_layer_type()` reads.
+barplot_layer <- function(height, ...) {
+  list(function_name = "barplot", args = c(list(height), list(...)))
+}
+
+classify <- function(height, ...) {
+  maidr:::BaseRAdapter$new()$detect_layer_type(barplot_layer(height, ...))
+}
+
+test_that("a raw count matrix is a plain stacked bar", {
+  expect_equal(classify(COUNTS), "stacked_bar")
+})
+
+test_that("a column-normalized matrix is a 100% stacked bar", {
+  expect_equal(classify(prop.table(COUNTS, 2)), "stacked_normalized_bar")
+})
+
+test_that("beside = TRUE stays dodged even when the columns sum to one", {
+  # The dodge check runs first, and must: side-by-side bars are not a stack at
+  # all, whatever their columns add up to.
+  expect_equal(classify(prop.table(COUNTS, 2), beside = TRUE), "dodged_bar")
+})
+
+test_that("a single-series matrix is not claimed as normalized", {
+  # One row of ones sums to 1 per column, but a single series stacked against
+  # nothing is not a stack — reading it as "100% stacked" would announce a
+  # composition that has no parts.
+  single <- matrix(c(1, 1, 1), nrow = 1, dimnames = list("u", c("a", "b", "c")))
+  expect_equal(classify(single), "stacked_bar")
+})
+
+test_that("columns summing to 100 are not claimed as normalized", {
+  # Percentages and raw counts are indistinguishable at 100, and a count
+  # matrix reaching 100 by coincidence is entirely ordinary. Claiming those as
+  # shares would be a guess rather than a reading.
+  hundreds <- matrix(
+    c(25, 75, 40, 60),
+    nrow = 2,
+    dimnames = list(c("u", "v"), c("a", "b"))
+  )
+  expect_equal(classify(hundreds), "stacked_bar")
+})
+
+test_that("a vector barplot is unaffected", {
+  # Only a matrix stacks; a bare vector is a plain bar chart whatever it sums
+  # to, and must not be dragged into either stacked branch.
+  expect_equal(classify(c(0.25, 0.75)), "bar")
+})
+
+test_that("floating point drift still reads as normalized", {
+  # `prop.table()` divides, so the columns land near 1 rather than exactly on
+  # it. An equality test would reject the very charts this exists to catch.
+  drifted <- matrix(
+    c(1 / 3, 1 / 3, 1 / 3, 0.2, 0.3, 0.5),
+    nrow = 3,
+    dimnames = list(c("u", "v", "w"), c("a", "b"))
+  )
+  expect_equal(classify(drifted), "stacked_normalized_bar")
+})
+
+test_that("the base R factory can build a processor for the new type", {
+  factory <- maidr:::BaseRProcessorFactory$new()
+
+  expect_true("stacked_normalized_bar" %in% factory$get_supported_types())
+  processor <- factory$create_processor(
+    "stacked_normalized_bar",
+    list(type = "stacked_normalized_bar")
+  )
+  expect_s3_class(processor, "BaseRStackedBarLayerProcessor")
+})


### PR DESCRIPTION
## Description

The base R adapter classified every stacked barplot as `stacked_bar`, so a 100% stacked bar was announced as a plain one and its segments framed as magnitudes rather than as shares of their category. This is the base R half that #138 explicitly left out.

## The part worth reviewing: there is no flag to read

I went looking for the base R equivalent of ggplot2's `position = "fill"` and there isn't one. `barplot.default` takes no normalisation argument at all:

```
height, width, space, names.arg, legend.text, beside, horiz, density, angle,
col, border, main, sub, xlab, ylab, xlim, ylim, xpd, log, axes, axisnames,
cex.axis, cex.names, inside, plot, axis.lty, offset, add, ann, args.legend, ...
```

The idiomatic 100% stacked bar in base R is written by normalising the matrix first — `barplot(prop.table(m, 2))` — and by the time the call is recorded, that normalisation is indistinguishable from data that arrived proportional.

So the classification here reads **what the chart draws** rather than what the author declared. When every column sums to 1, every bar is drawn to a common full height and each segment is that category's share; a chart like that is a 100% stacked bar whatever the numbers were beforehand. That is a weaker footing than the ggplot2 side has, and it is why the tests pin the **refusals** as carefully as the claims.

**Not claimed:**
- Columns summing to **100** — a count matrix can total 100 by coincidence, and nothing in the drawing distinguishes that from percentages. Claiming it would be a guess rather than a reading.
- A **single-row** matrix — one series stacked against nothing is not a stack, and reading it as "100% stacked" would announce a composition with no parts.
- `beside = TRUE` — the dodge check runs first and must.
- A bare **vector** — only a matrix stacks.

Tolerance rather than equality on the sum, because `prop.table()` divides and the columns land near 1 rather than exactly on it. An equality test would reject the very charts this exists to catch; there is a case for that too.

## Changes Made

- `is_normalized_barplot()` on the base R adapter, checked before the plain stacked branch.
- `stacked_normalized_bar` registered in the base R processor factory and `get_supported_types()`, routing to the existing `BaseRStackedBarLayerProcessor`.
- That processor **hardcoded** `type = "stacked_bar"` in its result — unlike the ggplot2 side, where the orchestrator carries the detected type through — so it now reads its own `layer_info$type`.

**No value changes were needed**, which is the other difference from #138. There the `count` column and the pre-rescale `y` both had to be bypassed; here the values already are the drawn shares, because the author normalised before calling `barplot()`. Only the emitted type differs.

## Testing

New file `tests/testthat/test-base-r-normalized-bar.R`, **9 assertions, all passing**.

An earlier draft of this file guarded every case with `skip_if_not(exists("BaseRAdapter"))`, and every one of them silently **skipped** — the internal classes are not visible the way the file was being run. A test that skips proves nothing, so the guards are gone and the file reaches the classes through `maidr:::`; a missing symbol now fails loudly instead of reporting green.

Full suite: `test_dir("tests/testthat")` reports **9 failures, all in the pie tests** — the same pre-existing set #138 documented, unchanged in count and identity by this branch.

## Notes

The branch was reset from `main` after #138 merged, so the push is a force-with-lease over remote history that is already in `main` as the squashed `271ac3d`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_