### PR TITLE
style(tests): replace literal non-ASCII characters in test sources

### DIFF
--- a/tests/testthat/test-base-r-candlestick.R
+++ b/tests/testthat/test-base-r-candlestick.R
@@ -5,7 +5,7 @@
 # fallback when quantmod / xts is unavailable.
 
 # ==============================================================================
-# Helpers (local — quantmod, xts and zoo are Suggests)
+# Helpers (local - quantmod, xts and zoo are Suggests)
 # ==============================================================================
 
 skip_if_no_quantmod <- function() {
@@ -115,7 +115,7 @@ test_that("factory advertises 'candlestick' in supported types", {
 })
 
 # ==============================================================================
-# Tier 3: extract_data — trend, volatility, volume
+# Tier 3: extract_data - trend, volatility, volume
 # ==============================================================================
 
 test_that("extract_data returns one point per OHLC row with required fields", {
@@ -373,7 +373,7 @@ test_that("generate_selectors emits a single CandlestickSelector with per-candle
   testthat::expect_type(selectors, "list")
   testthat::expect_true(!is.null(names(selectors)))
   testthat::expect_true("body" %in% names(selectors))
-  # Two segments groups in the stub → wickHigh + wickLow keys present.
+  # Two segments groups in the stub -> wickHigh + wickLow keys present.
   testthat::expect_true("wickHigh" %in% names(selectors))
   testthat::expect_true("wickLow" %in% names(selectors))
   # `wick` (the fallback key) should NOT be present when both wickHigh/Low are.
@@ -391,8 +391,8 @@ test_that("generate_selectors emits a single CandlestickSelector with per-candle
   # wickHigh / wickLow are length-N character vectors targeting the two
   # distinct segments groups. quantmod chartSeries (chartSeries.chob.R
   # L169-173) calls segments() for LOWER wick FIRST, then UPPER wick:
-  #   seg_ids[[1L]] = "...-segments-1" = LOWER wick (→ wickLow)
-  #   seg_ids[[2L]] = "...-segments-2" = UPPER wick (→ wickHigh)
+  #   seg_ids[[1L]] = "...-segments-1" = LOWER wick (-> wickLow)
+  #   seg_ids[[2L]] = "...-segments-2" = UPPER wick (-> wickHigh)
   testthat::expect_type(selectors$wickHigh, "character")
   testthat::expect_equal(length(selectors$wickHigh), 4L)
   testthat::expect_type(selectors$wickLow, "character")

--- a/tests/testthat/test-fabricated-selector-guard.R
+++ b/tests/testthat/test-fabricated-selector-guard.R
@@ -4,7 +4,7 @@
 # instead of returning `list()` the way bar, point, boxplot, line, heatmap
 # and candlestick do. Every id these processors address carries grid's
 # session-wide grob counter (`geom_rect.rect.N`, `GRID.polyline.N`), so a
-# guessed N is right only by coincidence — and the coincidence is the bad
+# guessed N is right only by coincidence - and the coincidence is the bad
 # case, not the good one: in the composition below the smooth fallback
 # produced a selector byte-identical to the FIRST panel's, so the empty
 # panel highlighted another panel's fitted line while the payload still

--- a/tests/testthat/test-ggplot2-adapter-geom-ma.R
+++ b/tests/testthat/test-ggplot2-adapter-geom-ma.R
@@ -4,7 +4,7 @@
 # the unknown processor.
 
 # ==============================================================================
-# Helpers (local — tidyquant is in Suggests)
+# Helpers (local - tidyquant is in Suggests)
 # ==============================================================================
 
 create_test_candlestick_ma_df <- function() {

--- a/tests/testthat/test-ggplot2-candlestick-layer-processor.R
+++ b/tests/testthat/test-ggplot2-candlestick-layer-processor.R
@@ -4,7 +4,7 @@
 # selector generation, axis labels, and end-to-end orchestration.
 
 # ==============================================================================
-# Helpers (local — not added to global helper.R because tidyquant is Suggests)
+# Helpers (local - not added to global helper.R because tidyquant is Suggests)
 # ==============================================================================
 
 create_test_candlestick_df <- function() {

--- a/tests/testthat/test-ggplot2-candlestick-patchwork.R
+++ b/tests/testthat/test-ggplot2-candlestick-patchwork.R
@@ -12,7 +12,7 @@
 #      and volume y-values are embedded into each candlestick data point.
 
 # ==============================================================================
-# Helpers (local — tidyquant and patchwork are Suggests)
+# Helpers (local - tidyquant and patchwork are Suggests)
 # ==============================================================================
 
 create_test_ohlcv_df <- function() {

--- a/tests/testthat/test-ggplot2-step-layer-processor.R
+++ b/tests/testthat/test-ggplot2-step-layer-processor.R
@@ -456,7 +456,7 @@ test_that("Ggplot2StepLayerProcessor labels every series of a multi-series step"
 
 # ==============================================================================
 # Tier 6: Orchestrator integration (assert on the emitted layer, not on
-# "rendering succeeded" — an undetected geom_step degrades silently to a
+# "rendering succeeded" - an undetected geom_step degrades silently to a
 # static PNG)
 # ==============================================================================
 

--- a/tests/testthat/test-nested-patchwork-selectors.R
+++ b/tests/testthat/test-nested-patchwork-selectors.R
@@ -8,7 +8,7 @@
 #
 # These tests pin the emitted payload for the geoms that were affected:
 # every layer must carry selectors, every selector must address an element
-# of the exported SVG, and the marks it addresses must be the leaf's own —
+# of the exported SVG, and the marks it addresses must be the leaf's own -
 # a lookup that lands on a neighbour's panel resolves just as happily.
 
 skip_if_no_patchwork <- function() {

--- a/tests/testthat/test-svg-utils.R
+++ b/tests/testthat/test-svg-utils.R
@@ -387,7 +387,7 @@ test_that("the CDN branch links no stylesheet", {
   html <- maidr:::create_standalone_html(svg_fixture(), use_cdn = TRUE)
 
   # The script tag's own URL is what maidr.js resolves maidr-math.css
-  # against, so a <link> would be a request that changes nothing — and
+  # against, so a <link> would be a request that changes nothing - and
   # since maidr 3.75.1 maidr.css has no rules in it to change anything with.
   testthat::expect_false(grepl("maidr.css", html, fixed = TRUE))
   testthat::expect_false(grepl("rel=\"stylesheet\"", html, fixed = TRUE))


### PR DESCRIPTION
## What

#129 replaced the literal non-ASCII characters in `R/` and `man/` and left `tests/` alone. This finishes it: **twelve characters across eight files** — nine em dashes (`U+2014`) and three rightwards arrows (`U+2192`).

## Every occurrence is in a comment

Checked before touching anything, since a character inside a string could change what a test asserts:

```
COMMENT    test-base-r-candlestick.R:8      # Helpers (local — quantmod, xts and zoo are Suggests)
COMMENT    test-base-r-candlestick.R:376    # Two segments groups in the stub → wickHigh + wickLow …
COMMENT    test-svg-utils.R:390             # against, so a <link> would be a request that changes …
…
```

Twelve of twelve are comments, none in code, so no test can behave differently.

## Substitution

Follows #129 rather than picking a new convention — a reviewer diffing the two should see the same transformation:

| | | |
|---|---|---|
| `—` | → | `-` &nbsp;&nbsp;(what #129 used throughout `R/`) |
| `→` | → | `->` &nbsp;&nbsp;(what the `R/` comments already use) |

`--` was the alternative and is used 91 times in `R/`, against 190 for a single hyphen. I went with the single hyphen because it is what the *identical prior change* did.

## Verification

Full suite before and after: **4640 passed, 0 failed, 0 errors, 97 skipped** — unchanged in every column. The 97 skips are optional packages (`patchwork`, `quantmod`, `shiny`) not installed in this environment, unrelated to this change.

```
$ grep -rcP '[^\x00-\x7F]' tests/ --include=*.R | awk -F: '{s+=$2} END {print s+0}'
0
```

## Not related to the warnings that led here

`pkgload::load_all()` emits ten `unable to translate '<U+20AC>' to native encoding` warnings in a `C` locale. Those come from the `\uXXXX` escapes in `R/format_utils.R`, not from these files, and they are cosmetic. Chasing them turned up a real bug, filed as #139 and fixed in #140 — that one is worth reading; this PR is only tidying.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmSHGxAWRw5wVWqDKdaZm6)_