### PR TITLE
ci: stop two bundle refreshes from racing each other

### DIFF
--- a/.github/workflows/update-maidr-bundle.yml
+++ b/.github/workflows/update-maidr-bundle.yml
@@ -57,6 +57,20 @@ permissions:
 jobs:
   check-and-update:
     runs-on: ubuntu-latest
+    # Two triggers means two runs can be in flight at once -- the daily cron
+    # and a dispatch arriving while it works -- and both push to ``main``.
+    # The second push is then a non-fast-forward against a checkout taken
+    # before the first landed, and the run fails.
+    #
+    # Nothing is corrupted when that happens and the next run recovers, since
+    # both were installing the same bundle. It is still a red run for a
+    # condition this repository can simply decline to enter, and the schedules
+    # no longer keep them apart: the cron is fixed at 09:00 UTC, but an
+    # off-schedule upstream release fires a dispatch at any hour.
+    #
+    # Queuing, not cancelling, since the default is to wait. A run held behind
+    # another then finds the bundle already current and commits nothing.
+    concurrency: update-maidr-bundle
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Follow-up to #131, which gave this workflow its second trigger without considering what happens when both fire close together.

## The race

`update-maidr-bundle.yml` now runs on the daily cron *and* on a `repository_dispatch` from maidr's release workflow. Nothing stopped both from being in flight at once, and both push to `main` via `git-auto-commit-action`. The second push is then a non-fast-forward against a checkout taken before the first landed, and the run fails.

Nothing is corrupted when that happens, and the next run recovers, since both were installing the same bundle. It is still a red run for a condition this repository can decline to enter for one line.

The schedules used to keep the two apart and no longer do. The cron is fixed at 09:00 UTC and upstream's scheduled release is 15:00 UTC, but an off-schedule upstream release fires a dispatch at any hour — one was published manually today at 17:52 UTC.

## The fix

A job-level `concurrency` group. Queuing rather than cancelling, since waiting is the default: a run held behind another then finds the bundle already current and commits nothing.

The group name is workflow-specific here, unlike the py-maidr sibling change, because nothing else in this repository pushes to `main` — only this workflow needs serialising, and only against itself.

## Credit

This came out of review on xability/py-maidr#355, where the same class of race is worse: there two *different* workflows push to `main` — the bundle refresh and `python-semantic-release` — so the loser is a failed release rather than a failed refresh. Checking whether the same thing applied here is what turned this up.

## Verification

`actionlint` passes. The workflow still parses with all three triggers intact (`repository_dispatch`, `schedule`, `workflow_dispatch`), and the job now carries `concurrency: update-maidr-bundle`.

CI-only; no R code, no tests, and nothing in the package changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZocjnGTiRvLDCbcvqYqa3)_