### PR TITLE
fix(ggplot2): highlight the interval an error bar layer draws

### DIFF
--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -27,10 +27,31 @@ jobs:
 
       # actionlint validates the workflow YAML and shellchecks inline `run`
       # blocks, catching the class of shell/quoting bugs this automation
-      # is prone to. Both the installer script and the release artifact it
-      # downloads are pinned to a tagged version so the bytes fetched here
-      # are reviewable and cannot change out from under the job.
-      - name: actionlint
+      # is prone to. The release artifact is pinned by version AND by digest,
+      # so the bytes are reviewable and cannot change out from under the job.
+      #
+      # It is fetched directly rather than through upstream's
+      # `download-actionlint.bash`. That script's own curl has no `--fail`,
+      # so a transient error response is written to the file and unpacked:
+      # the job then dies on `gzip: stdin: not in gzip format` and reports a
+      # network blip as a lint failure on an unrelated pull request. That is
+      # not hypothetical -- it is what this step did on the run that
+      # prompted the change, having downloaded 107 bytes of error page.
+      # `--fail` turns that into a non-zero exit, `--retry-all-errors` stops
+      # it happening at all, and the checksum then means what it says: a
+      # mismatch is a supply-chain question, not a flaky download. Same fix
+      # as xability/maidr#854.
+      - name: Install actionlint
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
         run: |
-          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12
-          ./actionlint -color
+          curl --fail --silent --show-error --location \
+            --retry 5 --retry-all-errors --retry-delay 2 \
+            --output actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum --check
+          tar xzf actionlint.tar.gz actionlint
+
+      - name: actionlint
+        run: ./actionlint -color

--- a/R/ggplot2_errorbar_layer_processor.R
+++ b/R/ggplot2_errorbar_layer_processor.R
@@ -54,7 +54,7 @@ Ggplot2ErrorbarLayerProcessor <- R6::R6Class(
     #' @param grob_id Grob ID for faceted plots (optional)
     #' @param panel_id Panel ID for faceted plots (optional)
     #' @param panel_ctx Panel context for panel-scoped selectors (optional)
-    #' @return List with data, axes, type and orientation
+    #' @return List with data, selectors, axes, type and orientation
     process = function(plot,
                        layout,
                        built = NULL,
@@ -270,16 +270,12 @@ Ggplot2ErrorbarLayerProcessor <- R6::R6Class(
     interval_grob_shape = function(grob) {
       kind <- class(grob)[1]
 
-      if (kind %in% c("segments", "points")) {
-        n <- if (identical(kind, "segments")) {
-          length(grob$x0)
-        } else {
-          length(grob$x)
-        }
+      if (identical(kind, "segments")) {
+        n <- length(grob$x0)
         if (n < 1L) {
           return(NULL)
         }
-        return(list(samples = as.integer(n), per_sample = 1L))
+        return(list(samples = n, per_sample = 1L))
       }
 
       if (!kind %in% c("polygon", "polyline")) {

--- a/R/ggplot2_errorbar_layer_processor.R
+++ b/R/ggplot2_errorbar_layer_processor.R
@@ -69,10 +69,14 @@ Ggplot2ErrorbarLayerProcessor <- R6::R6Class(
 
       layer_data <- self$get_layer_built_data(built, panel_id)
       is_horizontal <- self$is_horizontal_layer(plot, layer_data)
+      data <- self$extract_interval_data(
+        built, layer_data, is_horizontal, panel_id
+      )
 
       list(
-        data = self$extract_interval_data(
-          built, layer_data, is_horizontal, panel_id
+        data = data,
+        selectors = self$generate_selectors(
+          plot, gt, grob_id, panel_ctx, length(data)
         ),
         axes = self$extract_axes_labels(plot, built, panel_id),
         type = "error_bar",
@@ -102,6 +106,268 @@ Ggplot2ErrorbarLayerProcessor <- R6::R6Class(
         return(FALSE)
       }
       identical(class(layer$geom)[1], "GeomErrorbarh")
+    },
+
+    #' @description Address the drawn interval, one SVG element per sample.
+    #'
+    #' `ErrorBarTrace.mapToSvgElements` resolves the selectors and requires
+    #' the flattened result to be exactly as long as the emitted data; any
+    #' other length is discarded and the layer highlights nothing (#145). So
+    #' the job here is one element per sample, in the order the data was
+    #' emitted -- not one per bound, and not the container.
+    #'
+    #' The five geoms do not draw alike, and the differences are not
+    #' cosmetic. Verified against real `gridSVG::grid.export()` output on
+    #' ggplot2 3.4.4:
+    #'
+    #' \itemize{
+    #'   \item `geom_linerange()` -- a `segments` grob named after the geom;
+    #'     one `<polyline>` per sample.
+    #'   \item `geom_pointrange()` -- a gTree holding that same `segments`
+    #'     grob and a `points` grob. The whisker is the one that spans the
+    #'     interval, so it is the one addressed.
+    #'   \item `geom_crossbar()` -- a gTree holding a `polygon` grob (the box)
+    #'     and a `segments` grob (the middle line). The box is the sample.
+    #'   \item `geom_errorbar()` / `geom_errorbarh()` -- **an unnamed
+    #'     `polyline`**, `GRID.polyline.N`, carrying no geom prefix at all,
+    #'     and drawing *three* elements per sample: a cap, the whisker, the
+    #'     other cap.
+    #' }
+    #'
+    #' Both of those last two facts are why this could not reuse the
+    #' inherited `generate_selectors()`: it matches `geom_point.points` by
+    #' name, which reaches none of these, and a name-prefix search reaches
+    #' `geom_errorbar()` least of all.
+    #'
+    #' @param plot The ggplot2 object
+    #' @param gt Gtable object (optional)
+    #' @param grob_id Grob ID for faceted plots (unused; the drawn grob is
+    #'   resolved from the panel, which is what the unnamed polyline needs)
+    #' @param panel_ctx Panel context for panel-scoped selectors (optional)
+    #' @param sample_count How many points this layer emitted
+    #' @return A list holding one CSS selector, or an empty list
+    generate_selectors = function(plot,
+                                  gt = NULL,
+                                  grob_id = NULL,
+                                  panel_ctx = NULL,
+                                  sample_count = NULL) {
+      expected <- suppressWarnings(as.integer(sample_count))
+      if (is.null(gt) || length(expected) != 1L || is.na(expected) ||
+        expected < 1L) {
+        return(list())
+      }
+
+      grob <- self$find_interval_grob(plot, gt, panel_ctx)
+      if (is.null(grob) || is.null(grob$name)) {
+        return(list())
+      }
+
+      shape <- self$interval_grob_shape(grob)
+      if (is.null(shape) || !identical(shape$samples, expected)) {
+        return(list())
+      }
+
+      selector <- self$interval_selector(grob$name, shape$per_sample)
+      if (is.null(selector)) {
+        return(list())
+      }
+      list(selector)
+    },
+
+    #' @description Find the grob whose children are the samples.
+    #'
+    #' @param plot The ggplot2 object
+    #' @param gt Gtable object
+    #' @param panel_ctx Panel context for panel-scoped selectors (optional)
+    #' @return The grob one of whose child elements is drawn per sample, or
+    #'   NULL when it cannot be resolved
+    find_interval_grob = function(plot, gt, panel_ctx = NULL) {
+      tree <- self$find_layer_grob_tree(plot, gt, panel_ctx)
+      if (is.null(tree)) {
+        return(self$find_unnamed_interval_grob(plot, gt, panel_ctx))
+      }
+      if (!inherits(tree, "gTree")) {
+        return(tree)
+      }
+
+      # A pointrange draws its whisker and its estimate as siblings, and a
+      # crossbar its box and its middle line. Prefer whichever child spans
+      # the whole interval: the box for a crossbar, the whisker otherwise.
+      # Either way it is one element per sample, which the middle line and
+      # the estimate also are -- so this decides which element lights up,
+      # not whether anything does.
+      for (want in c("polygon", "segments", "polyline")) {
+        for (child in tree$children) {
+          if (identical(class(child)[1], want)) {
+            return(child)
+          }
+        }
+      }
+      NULL
+    },
+
+    #' @description Resolve the drawn grob of a layer ggplot2 left unnamed.
+    #'
+    #' `geom_errorbar()` and `geom_errorbarh()` draw a bare
+    #' `GRID.polyline.N`, so there is no name to match on and
+    #' `find_layer_grob_tree()` returns NULL for them. Position is the
+    #' remaining handle: ggplot2 lays a panel out as the grill, a leading
+    #' `zeroGrob`, **one child per layer in layer order**, a trailing
+    #' `zeroGrob` and the border. A layer that draws nothing still takes its
+    #' slot as a `zeroGrob`, so the correspondence survives an empty layer
+    #' beside this one.
+    #'
+    #' The leading blank is found by class rather than by an absent name: a
+    #' `zeroGrob` is named, and its name is the four characters `"NULL"`.
+    #'
+    #' It is deliberately narrow. The result has to be a `polyline` for a
+    #' geom that is known to draw one, because a positional hit on the wrong
+    #' layer would highlight another layer's marks -- worse than the missing
+    #' highlight this fixes, since a reader can hear nothing but cannot hear
+    #' wrongness.
+    #'
+    #' @param plot The ggplot2 object
+    #' @param gt Gtable object
+    #' @param panel_ctx Panel context for panel-scoped selectors (optional)
+    #' @return The layer's polyline grob, or NULL
+    find_unnamed_interval_grob = function(plot, gt, panel_ctx = NULL) {
+      layer <- self$get_own_layer(plot)
+      if (is.null(layer) ||
+        !class(layer$geom)[1] %in% c("GeomErrorbar", "GeomErrorbarh")) {
+        return(NULL)
+      }
+
+      index <- self$get_layer_index()
+      panel <- find_gtable_panel_grob(gt, panel_ctx)
+      if (is.null(index) || is.null(panel) || !inherits(panel, "gTree")) {
+        return(NULL)
+      }
+
+      children <- panel$children
+      blanks <- which(vapply(
+        children, function(g) inherits(g, "zeroGrob"), logical(1)
+      ))
+      if (length(blanks) == 0L) {
+        return(NULL)
+      }
+
+      at <- blanks[1] + as.integer(index)
+      if (at < 1L || at > length(children)) {
+        return(NULL)
+      }
+      child <- children[[at]]
+      if (!identical(class(child)[1], "polyline") || is.null(child$name)) {
+        return(NULL)
+      }
+      child
+    },
+
+    #' @description Count the samples a grob draws, and the elements each takes.
+    #'
+    #' @param grob The grob resolved for this layer
+    #' @return A list of `samples` and `per_sample`, or NULL when the grob is
+    #'   not one of the shapes this has been verified against
+    interval_grob_shape = function(grob) {
+      kind <- class(grob)[1]
+
+      if (kind %in% c("segments", "points")) {
+        n <- if (identical(kind, "segments")) {
+          length(grob$x0)
+        } else {
+          length(grob$x)
+        }
+        if (n < 1L) {
+          return(NULL)
+        }
+        return(list(samples = as.integer(n), per_sample = 1L))
+      }
+
+      if (!kind %in% c("polygon", "polyline")) {
+        return(NULL)
+      }
+
+      groups <- self$grob_point_groups(grob)
+      if (is.null(groups) || length(groups) < 1L) {
+        return(NULL)
+      }
+      runs <- vapply(groups, function(idx) self$drawn_run_count(grob, idx), integer(1))
+      if (length(unique(runs)) != 1L) {
+        # Samples drawn with different numbers of elements have no single
+        # nth-child stride, and guessing one would highlight the wrong mark.
+        return(NULL)
+      }
+      list(samples = length(groups), per_sample = runs[[1]])
+    },
+
+    #' @description Split a grob's points into one index vector per sample.
+    #'
+    #' @param grob A `polygon` or `polyline` grob
+    #' @return A list of index vectors in drawing order, or NULL
+    grob_point_groups = function(grob) {
+      n <- length(grob$x)
+      if (n < 1L) {
+        return(NULL)
+      }
+
+      if (!is.null(grob$id)) {
+        keys <- factor(grob$id, levels = unique(grob$id))
+        return(unname(split(seq_len(n), keys)))
+      }
+      if (!is.null(grob$id.lengths)) {
+        keys <- rep(seq_along(grob$id.lengths), grob$id.lengths)
+        return(unname(split(seq_len(n), keys)))
+      }
+      list(seq_len(n))
+    },
+
+    #' @description Count the elements one sample of a grob is drawn as.
+    #'
+    #' grid breaks a polyline at a missing point, and `geom_errorbar()` uses
+    #' that: its eight points per sample are `cap, NA, whisker, NA, cap`, so
+    #' the export carries three elements for the one bar. A run needs two
+    #' points to be a line at all, and a shorter one draws nothing.
+    #'
+    #' @param grob A `polygon` or `polyline` grob
+    #' @param index The point indices belonging to one sample
+    #' @return How many elements that sample is drawn as
+    drawn_run_count = function(grob, index) {
+      xs <- suppressWarnings(as.numeric(grob$x[index]))
+      ys <- suppressWarnings(as.numeric(grob$y[index]))
+      drawn <- !is.na(xs) & !is.na(ys)
+      if (!any(drawn)) {
+        return(0L)
+      }
+      runs <- rle(drawn)
+      as.integer(sum(runs$values & runs$lengths >= 2L))
+    },
+
+    #' @description Build the CSS selector for one element per sample.
+    #'
+    #' gridSVG wraps each grob in a `<g>` named after it with a `.1` suffix
+    #' and writes its elements inside in drawing order, so the samples are
+    #' addressable as a stride through that group's children.
+    #'
+    #' Only the two strides that have been checked against an export are
+    #' emitted: one element per sample, and the three a `geom_errorbar()`
+    #' draws, of which the middle one is the whisker spanning the interval --
+    #' the cap either side of it says nothing a reader is navigating to. Any
+    #' other stride returns NULL and the layer goes back to highlighting
+    #' nothing, which is the honest answer for a shape nobody has looked at.
+    #'
+    #' @param grob_name The drawn grob's name
+    #' @param per_sample How many elements each sample is drawn as
+    #' @return A CSS selector, or NULL
+    interval_selector = function(grob_name, per_sample) {
+      escaped <- gsub("\\.", "\\\\.", paste0(grob_name, ".1"))
+      group <- paste0("g#", escaped)
+
+      if (identical(as.integer(per_sample), 1L)) {
+        return(paste0(group, " > *"))
+      }
+      if (identical(as.integer(per_sample), 3L)) {
+        return(paste0(group, " > *:nth-child(3n+2)"))
+      }
+      NULL
     },
 
     #' @description Build the MAIDR points for this layer.

--- a/man/Ggplot2ErrorbarLayerProcessor.Rd
+++ b/man/Ggplot2ErrorbarLayerProcessor.Rd
@@ -52,6 +52,13 @@ interval.
   \itemize{
     \item \href{#method-Ggplot2ErrorbarLayerProcessor-process}{\code{Ggplot2ErrorbarLayerProcessor$process()}}
     \item \href{#method-Ggplot2ErrorbarLayerProcessor-is_horizontal_layer}{\code{Ggplot2ErrorbarLayerProcessor$is_horizontal_layer()}}
+    \item \href{#method-Ggplot2ErrorbarLayerProcessor-generate_selectors}{\code{Ggplot2ErrorbarLayerProcessor$generate_selectors()}}
+    \item \href{#method-Ggplot2ErrorbarLayerProcessor-find_interval_grob}{\code{Ggplot2ErrorbarLayerProcessor$find_interval_grob()}}
+    \item \href{#method-Ggplot2ErrorbarLayerProcessor-find_unnamed_interval_grob}{\code{Ggplot2ErrorbarLayerProcessor$find_unnamed_interval_grob()}}
+    \item \href{#method-Ggplot2ErrorbarLayerProcessor-interval_grob_shape}{\code{Ggplot2ErrorbarLayerProcessor$interval_grob_shape()}}
+    \item \href{#method-Ggplot2ErrorbarLayerProcessor-grob_point_groups}{\code{Ggplot2ErrorbarLayerProcessor$grob_point_groups()}}
+    \item \href{#method-Ggplot2ErrorbarLayerProcessor-drawn_run_count}{\code{Ggplot2ErrorbarLayerProcessor$drawn_run_count()}}
+    \item \href{#method-Ggplot2ErrorbarLayerProcessor-interval_selector}{\code{Ggplot2ErrorbarLayerProcessor$interval_selector()}}
     \item \href{#method-Ggplot2ErrorbarLayerProcessor-extract_interval_data}{\code{Ggplot2ErrorbarLayerProcessor$extract_interval_data()}}
     \item \href{#method-Ggplot2ErrorbarLayerProcessor-resolve_estimates}{\code{Ggplot2ErrorbarLayerProcessor$resolve_estimates()}}
     \item \href{#method-Ggplot2ErrorbarLayerProcessor-resolve_category_labels}{\code{Ggplot2ErrorbarLayerProcessor$resolve_category_labels()}}
@@ -64,8 +71,8 @@ interval.
   <li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="apply_scale_mapping"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-apply_scale_mapping'><code>LayerProcessor$apply_scale_mapping()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="augment_plot"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-augment_plot'><code>LayerProcessor$augment_plot()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="extract_layer_axes"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-extract_layer_axes'><code>LayerProcessor$extract_layer_axes()</code></a></span></li>
-  <li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="get_last_result"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-get_last_result'><code>LayerProcessor$get_last_result()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="find_layer_grob_tree"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-find_layer_grob_tree'><code>LayerProcessor$find_layer_grob_tree()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="get_last_result"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-get_last_result'><code>LayerProcessor$get_last_result()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="get_layer_built_data"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-get_layer_built_data'><code>LayerProcessor$get_layer_built_data()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="get_layer_index"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-get_layer_index'><code>LayerProcessor$get_layer_index()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="get_own_layer"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-get_own_layer'><code>LayerProcessor$get_own_layer()</code></a></span></li>
@@ -79,7 +86,6 @@ interval.
   <li><span class="pkg-link" data-pkg="maidr" data-topic="Ggplot2PointLayerProcessor" data-id="extract_data"><a href='../../maidr/html/Ggplot2PointLayerProcessor.html#method-Ggplot2PointLayerProcessor-extract_data'><code>Ggplot2PointLayerProcessor$extract_data()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="maidr" data-topic="Ggplot2PointLayerProcessor" data-id="find_children_by_type"><a href='../../maidr/html/Ggplot2PointLayerProcessor.html#method-Ggplot2PointLayerProcessor-find_children_by_type'><code>Ggplot2PointLayerProcessor$find_children_by_type()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="maidr" data-topic="Ggplot2PointLayerProcessor" data-id="find_panel_grob"><a href='../../maidr/html/Ggplot2PointLayerProcessor.html#method-Ggplot2PointLayerProcessor-find_panel_grob'><code>Ggplot2PointLayerProcessor$find_panel_grob()</code></a></span></li>
-  <li><span class="pkg-link" data-pkg="maidr" data-topic="Ggplot2PointLayerProcessor" data-id="generate_selectors"><a href='../../maidr/html/Ggplot2PointLayerProcessor.html#method-Ggplot2PointLayerProcessor-generate_selectors'><code>Ggplot2PointLayerProcessor$generate_selectors()</code></a></span></li>
 </ul>
 </details>}}
 \if{html}{\out{<hr>}}
@@ -144,6 +150,246 @@ construction and therefore has no such column to read.
   }
   \subsection{Returns}{
     TRUE when the interval spans the x axis
+  }
+}
+
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Ggplot2ErrorbarLayerProcessor-generate_selectors"></a>}}
+\if{latex}{\out{\hypertarget{method-Ggplot2ErrorbarLayerProcessor-generate_selectors}{}}}
+\subsection{\code{Ggplot2ErrorbarLayerProcessor$generate_selectors()}}{
+  Address the drawn interval, one SVG element per sample.
+
+\code{ErrorBarTrace.mapToSvgElements} resolves the selectors and requires
+the flattened result to be exactly as long as the emitted data; any
+other length is discarded and the layer highlights nothing (#145). So
+the job here is one element per sample, in the order the data was
+emitted -- not one per bound, and not the container.
+
+The five geoms do not draw alike, and the differences are not
+cosmetic. Verified against real \code{gridSVG::grid.export()} output on
+ggplot2 3.4.4:
+
+\itemize{
+\item \code{geom_linerange()} -- a \code{segments} grob named after the geom;
+one \verb{<polyline>} per sample.
+\item \code{geom_pointrange()} -- a gTree holding that same \code{segments}
+grob and a \code{points} grob. The whisker is the one that spans the
+interval, so it is the one addressed.
+\item \code{geom_crossbar()} -- a gTree holding a \code{polygon} grob (the box)
+and a \code{segments} grob (the middle line). The box is the sample.
+\item \code{geom_errorbar()} / \code{geom_errorbarh()} -- \strong{an unnamed
+\code{polyline}}, \code{GRID.polyline.N}, carrying no geom prefix at all,
+and drawing \emph{three} elements per sample: a cap, the whisker, the
+other cap.
+}
+
+Both of those last two facts are why this could not reuse the
+inherited \code{generate_selectors()}: it matches \code{geom_point.points} by
+name, which reaches none of these, and a name-prefix search reaches
+\code{geom_errorbar()} least of all.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Ggplot2ErrorbarLayerProcessor$generate_selectors(
+  plot,
+  gt = NULL,
+  grob_id = NULL,
+  panel_ctx = NULL,
+  sample_count = NULL
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{plot}}{The ggplot2 object}
+      \item{\code{gt}}{Gtable object (optional)}
+      \item{\code{grob_id}}{Grob ID for faceted plots (unused; the drawn grob is
+resolved from the panel, which is what the unnamed polyline needs)}
+      \item{\code{panel_ctx}}{Panel context for panel-scoped selectors (optional)}
+      \item{\code{sample_count}}{How many points this layer emitted}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A list holding one CSS selector, or an empty list
+  }
+}
+
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Ggplot2ErrorbarLayerProcessor-find_interval_grob"></a>}}
+\if{latex}{\out{\hypertarget{method-Ggplot2ErrorbarLayerProcessor-find_interval_grob}{}}}
+\subsection{\code{Ggplot2ErrorbarLayerProcessor$find_interval_grob()}}{
+  Find the grob whose children are the samples.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Ggplot2ErrorbarLayerProcessor$find_interval_grob(plot, gt, panel_ctx = NULL)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{plot}}{The ggplot2 object}
+      \item{\code{gt}}{Gtable object}
+      \item{\code{panel_ctx}}{Panel context for panel-scoped selectors (optional)}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    The grob one of whose child elements is drawn per sample, or
+NULL when it cannot be resolved
+  }
+}
+
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Ggplot2ErrorbarLayerProcessor-find_unnamed_interval_grob"></a>}}
+\if{latex}{\out{\hypertarget{method-Ggplot2ErrorbarLayerProcessor-find_unnamed_interval_grob}{}}}
+\subsection{\code{Ggplot2ErrorbarLayerProcessor$find_unnamed_interval_grob()}}{
+  Resolve the drawn grob of a layer ggplot2 left unnamed.
+
+\code{geom_errorbar()} and \code{geom_errorbarh()} draw a bare
+\code{GRID.polyline.N}, so there is no name to match on and
+\code{find_layer_grob_tree()} returns NULL for them. Position is the
+remaining handle: ggplot2 lays a panel out as the grill, a leading
+\code{zeroGrob}, \strong{one child per layer in layer order}, a trailing
+\code{zeroGrob} and the border. A layer that draws nothing still takes its
+slot as a \code{zeroGrob}, so the correspondence survives an empty layer
+beside this one.
+
+The leading blank is found by class rather than by an absent name: a
+\code{zeroGrob} is named, and its name is the four characters \code{"NULL"}.
+
+It is deliberately narrow. The result has to be a \code{polyline} for a
+geom that is known to draw one, because a positional hit on the wrong
+layer would highlight another layer's marks -- worse than the missing
+highlight this fixes, since a reader can hear nothing but cannot hear
+wrongness.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Ggplot2ErrorbarLayerProcessor$find_unnamed_interval_grob(
+  plot,
+  gt,
+  panel_ctx = NULL
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{plot}}{The ggplot2 object}
+      \item{\code{gt}}{Gtable object}
+      \item{\code{panel_ctx}}{Panel context for panel-scoped selectors (optional)}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    The layer's polyline grob, or NULL
+  }
+}
+
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Ggplot2ErrorbarLayerProcessor-interval_grob_shape"></a>}}
+\if{latex}{\out{\hypertarget{method-Ggplot2ErrorbarLayerProcessor-interval_grob_shape}{}}}
+\subsection{\code{Ggplot2ErrorbarLayerProcessor$interval_grob_shape()}}{
+  Count the samples a grob draws, and the elements each takes.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Ggplot2ErrorbarLayerProcessor$interval_grob_shape(grob)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{grob}}{The grob resolved for this layer}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A list of \code{samples} and \code{per_sample}, or NULL when the grob is
+not one of the shapes this has been verified against
+  }
+}
+
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Ggplot2ErrorbarLayerProcessor-grob_point_groups"></a>}}
+\if{latex}{\out{\hypertarget{method-Ggplot2ErrorbarLayerProcessor-grob_point_groups}{}}}
+\subsection{\code{Ggplot2ErrorbarLayerProcessor$grob_point_groups()}}{
+  Split a grob's points into one index vector per sample.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Ggplot2ErrorbarLayerProcessor$grob_point_groups(grob)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{grob}}{A \code{polygon} or \code{polyline} grob}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A list of index vectors in drawing order, or NULL
+  }
+}
+
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Ggplot2ErrorbarLayerProcessor-drawn_run_count"></a>}}
+\if{latex}{\out{\hypertarget{method-Ggplot2ErrorbarLayerProcessor-drawn_run_count}{}}}
+\subsection{\code{Ggplot2ErrorbarLayerProcessor$drawn_run_count()}}{
+  Count the elements one sample of a grob is drawn as.
+
+grid breaks a polyline at a missing point, and \code{geom_errorbar()} uses
+that: its eight points per sample are \verb{cap, NA, whisker, NA, cap}, so
+the export carries three elements for the one bar. A run needs two
+points to be a line at all, and a shorter one draws nothing.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Ggplot2ErrorbarLayerProcessor$drawn_run_count(grob, index)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{grob}}{A \code{polygon} or \code{polyline} grob}
+      \item{\code{index}}{The point indices belonging to one sample}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    How many elements that sample is drawn as
+  }
+}
+
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Ggplot2ErrorbarLayerProcessor-interval_selector"></a>}}
+\if{latex}{\out{\hypertarget{method-Ggplot2ErrorbarLayerProcessor-interval_selector}{}}}
+\subsection{\code{Ggplot2ErrorbarLayerProcessor$interval_selector()}}{
+  Build the CSS selector for one element per sample.
+
+gridSVG wraps each grob in a \verb{<g>} named after it with a \code{.1} suffix
+and writes its elements inside in drawing order, so the samples are
+addressable as a stride through that group's children.
+
+Only the two strides that have been checked against an export are
+emitted: one element per sample, and the three a \code{geom_errorbar()}
+draws, of which the middle one is the whisker spanning the interval --
+the cap either side of it says nothing a reader is navigating to. Any
+other stride returns NULL and the layer goes back to highlighting
+nothing, which is the honest answer for a shape nobody has looked at.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Ggplot2ErrorbarLayerProcessor$interval_selector(grob_name, per_sample)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{grob_name}}{The drawn grob's name}
+      \item{\code{per_sample}}{How many elements each sample is drawn as}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A CSS selector, or NULL
   }
 }
 

--- a/man/Ggplot2ErrorbarLayerProcessor.Rd
+++ b/man/Ggplot2ErrorbarLayerProcessor.Rd
@@ -122,7 +122,7 @@ interval.
     \if{html}{\out{</div>}}
   }
   \subsection{Returns}{
-    List with data, axes, type and orientation
+    List with data, selectors, axes, type and orientation
   }
 }
 

--- a/tests/testthat/test-errorbar-selectors.R
+++ b/tests/testthat/test-errorbar-selectors.R
@@ -1,0 +1,215 @@
+# Error bar selectors against the SVG they are meant to address (issue #145).
+#
+# The processor's own tests assert the selector strings. These render the
+# whole pipeline and ask the exported document whether those strings find
+# anything -- which is the question the strings exist to answer, and the one
+# no assertion on the emitted payload can reach.
+#
+# `ErrorBarTrace.mapToSvgElements` requires the flattened match to be exactly
+# as long as the layer's data and discards it otherwise, so a count that is
+# merely non-zero is not enough: it has to be right.
+
+skip_if_no_export <- function() {
+  testthat::skip_if_not_installed("ggplot2")
+  testthat::skip_if_not_installed("gridSVG")
+  testthat::skip_if_not_installed("xml2")
+  testthat::skip_if_not_installed("jsonlite")
+}
+
+#: Three intervals of visibly different width -- 0.8, 2.6, 0.3 -- so the
+#: drawn lengths are in an order no other assignment of elements to samples
+#: reproduces. A fixture with equal intervals would pass with the elements
+#: shuffled.
+ebs_data <- function() {
+  data.frame(
+    g = c("control", "low", "high"),
+    y = c(4.2, 5.1, 7.3),
+    lo = c(3.8, 4.0, 7.1),
+    hi = c(4.6, 6.6, 7.4)
+  )
+}
+
+# Render through the real pipeline and return the emitted payload beside the
+# exported SVG. A full render is a few seconds, so results are cached per
+# named plot for the duration of the file.
+ebs_cache <- new.env(parent = emptyenv())
+
+ebs_render <- function(plot, key) {
+  if (!is.null(ebs_cache[[key]])) {
+    return(ebs_cache[[key]])
+  }
+
+  file <- tempfile(fileext = ".html")
+  on.exit(unlink(file), add = TRUE)
+  suppressWarnings(save_html(plot, file))
+  html <- paste(readLines(file, warn = FALSE), collapse = "\n")
+
+  raw <- regmatches(
+    html, gregexpr('maidr-data="([^"]*)"', html, perl = TRUE)
+  )[[1]]
+  testthat::expect_gt(length(raw), 0)
+
+  json <- sub('"$', "", sub('^maidr-data="', "", raw[1]))
+  json <- gsub("&quot;", '"', json, fixed = TRUE)
+  json <- gsub("&lt;", "<", json, fixed = TRUE)
+  json <- gsub("&gt;", ">", json, fixed = TRUE)
+  json <- gsub("&amp;", "&", json, fixed = TRUE)
+
+  out <- list(data = jsonlite::fromJSON(json, simplifyVector = FALSE),
+              doc = xml2::read_html(html))
+  assign(key, out, envir = ebs_cache)
+  out
+}
+
+# The first layer of the first subplot.
+ebs_layer <- function(payload) {
+  payload$data$subplots[[1]][[1]]$layers[[1]]
+}
+
+# Resolve a selector the way a browser would.
+#
+# `selectr` is not a dependency, so the two shapes the processor emits are
+# translated by hand: `g#ID > *` addresses every child, and
+# `g#ID > *:nth-child(3n+2)` every third starting at the second. The
+# translation is checked by the geometry assertions below rather than taken
+# on trust -- a wrong stride finds a cap instead of a whisker.
+ebs_resolve <- function(payload, selector) {
+  # A layer with no selectors is the regression itself, and reporting it as a
+  # missing selector rather than as an XPath error is what makes the failure
+  # readable the day it comes back.
+  testthat::expect_true(is.character(selector) && length(selector) == 1L)
+
+  id <- gsub("\\\\", "", sub("^[a-zA-Z]*#", "", sub(" .*$", "", selector)))
+  stride <- regmatches(selector, regexpr("nth-child\\((\\d+)n\\+(\\d+)\\)", selector))
+
+  path <- if (length(stride) == 0) {
+    sprintf("//*[@id='%s']/*", id)
+  } else {
+    parts <- as.integer(regmatches(stride, gregexpr("\\d+", stride))[[1]])
+    sprintf(
+      "//*[@id='%s']/*[position() mod %d = %d]", id, parts[1], parts[2]
+    )
+  }
+  xml2::xml_find_all(payload$doc, path)
+}
+
+# Endpoints of a two-point polyline, as drawn.
+ebs_ends <- function(node) {
+  pts <- strsplit(trimws(xml2::xml_attr(node, "points")), "\\s+")[[1]]
+  vapply(strsplit(pts, ","), as.numeric, numeric(2))
+}
+
+ebs_plot <- function(geom, horizontal = FALSE) {
+  df <- ebs_data()
+  if (horizontal) {
+    ggplot2::ggplot(df, ggplot2::aes(y, g, xmin = lo, xmax = hi)) + geom
+  } else {
+    ggplot2::ggplot(df, ggplot2::aes(g, y, ymin = lo, ymax = hi)) + geom
+  }
+}
+
+test_that("every uncertainty geom's selector finds one element per sample", {
+  skip_if_no_export()
+
+  cases <- list(
+    errorbar = list(ggplot2::geom_errorbar(width = 0.2), FALSE),
+    linerange = list(ggplot2::geom_linerange(), FALSE),
+    pointrange = list(ggplot2::geom_pointrange(), FALSE),
+    crossbar = list(ggplot2::geom_crossbar(), FALSE),
+    errorbarh = list(ggplot2::geom_errorbarh(height = 0.2), TRUE)
+  )
+
+  for (name in names(cases)) {
+    payload <- ebs_render(
+      ebs_plot(cases[[name]][[1]], cases[[name]][[2]]), name
+    )
+    layer <- ebs_layer(payload)
+
+    testthat::expect_equal(layer$type, "error_bar", info = name)
+    testthat::expect_length(layer$selectors, 1)
+    testthat::expect_length(ebs_resolve(payload, layer$selectors[[1]]), 3)
+  }
+})
+
+test_that("an error bar's selector finds its whiskers, not its caps", {
+  skip_if_no_export()
+
+  payload <- ebs_render(ebs_plot(ggplot2::geom_errorbar(width = 0.2)), "errorbar")
+  nodes <- ebs_resolve(payload, ebs_layer(payload)$selectors[[1]])
+
+  # A whisker is vertical and a cap horizontal, so this separates them
+  # without depending on which of the three the export happens to write
+  # first. Highlighting a cap would put the outline on a tick the width of
+  # the styling parameter rather than on the interval.
+  for (node in nodes) {
+    ends <- ebs_ends(node)
+    testthat::expect_equal(ends[1, 1], ends[1, 2])
+    testthat::expect_false(isTRUE(all.equal(ends[2, 1], ends[2, 2])))
+  }
+})
+
+test_that("a horizontal error bar's selector finds its horizontal whiskers", {
+  skip_if_no_export()
+
+  payload <- ebs_render(
+    ebs_plot(ggplot2::geom_errorbarh(height = 0.2), horizontal = TRUE),
+    "errorbarh"
+  )
+  nodes <- ebs_resolve(payload, ebs_layer(payload)$selectors[[1]])
+
+  for (node in nodes) {
+    ends <- ebs_ends(node)
+    testthat::expect_equal(ends[2, 1], ends[2, 2])
+    testthat::expect_false(isTRUE(all.equal(ends[1, 1], ends[1, 2])))
+  }
+})
+
+test_that("the elements arrive in the order the data was emitted", {
+  skip_if_no_export()
+
+  # The trace pairs element i with point i, so an element list in any other
+  # order highlights the wrong sample -- silently, since every element it
+  # names is a real error bar. The fixture's intervals are 0.8, 2.6 and 0.3
+  # wide, so the drawn lengths pin the pairing.
+  payload <- ebs_render(ebs_plot(ggplot2::geom_errorbar(width = 0.2)), "errorbar")
+  layer <- ebs_layer(payload)
+  nodes <- ebs_resolve(payload, layer$selectors[[1]])
+
+  drawn <- vapply(nodes, function(node) {
+    ends <- ebs_ends(node)
+    abs(ends[2, 1] - ends[2, 2])
+  }, numeric(1))
+  spans <- vapply(layer$data, function(point) {
+    point$yMax - point$yMin
+  }, numeric(1))
+
+  testthat::expect_equal(order(drawn), order(spans))
+  testthat::expect_equal(which.max(drawn), which.max(spans))
+})
+
+test_that("an error bar drawn beside a bar chart addresses only itself", {
+  skip_if_no_export()
+
+  # geom_col() + geom_errorbar() is the chart this geom is usually part of,
+  # and the bars are drawn first. Addressing them would highlight the
+  # estimates while the reader navigates the bounds.
+  df <- ebs_data()
+  payload <- ebs_render(
+    ggplot2::ggplot(df, ggplot2::aes(g)) +
+      ggplot2::geom_col(ggplot2::aes(y = y)) +
+      ggplot2::geom_errorbar(
+        ggplot2::aes(ymin = lo, ymax = hi), width = 0.2
+      ),
+    "col_errorbar"
+  )
+
+  layers <- payload$data$subplots[[1]][[1]]$layers
+  interval <- Filter(function(l) identical(l$type, "error_bar"), layers)
+  testthat::expect_length(interval, 1)
+
+  nodes <- ebs_resolve(payload, interval[[1]]$selectors[[1]])
+  testthat::expect_length(nodes, 3)
+  for (node in nodes) {
+    testthat::expect_equal(xml2::xml_name(node), "polyline")
+  }
+})

--- a/tests/testthat/test-ggplot2-errorbar-layer-processor.R
+++ b/tests/testthat/test-ggplot2-errorbar-layer-processor.R
@@ -258,3 +258,174 @@ test_that("an empty layer yields no points rather than erroring", {
 
   testthat::expect_equal(processor$extract_interval_data(NULL, NULL, FALSE), list())
 })
+
+# ==============================================================================
+# Selectors (issue #145)
+# ==============================================================================
+#
+# A layer with no selectors sonifies, announces and brailles correctly and
+# highlights nothing, so no assertion on data or announcements can see the
+# gap. These are written against the drawn grob instead.
+#
+# `ErrorBarTrace.mapToSvgElements` discards a selector list whose flattened
+# length is not exactly the number of points, so "how many elements does this
+# address" is the whole contract, and every case below asserts it.
+
+# Build a layer's payload with the gtable it was drawn from, which is what
+# `process()` needs before it can name a grob.
+eb_process_drawn <- function(plot) {
+  processor <- maidr:::Ggplot2ErrorbarLayerProcessor$new(
+    list(layer_index = 1, index = 1, plot = plot)
+  )
+  processor$process(
+    plot, NULL, ggplot2::ggplot_build(plot), ggplot2::ggplotGrob(plot)
+  )
+}
+
+# The `<g>` id a selector addresses, unescaped.
+eb_selector_id <- function(selector) {
+  gsub("\\\\", "", sub("^[a-zA-Z]*#", "", sub(" .*$", "", selector)))
+}
+
+test_that("every uncertainty geom addresses one element per sample", {
+  df <- eb_data()
+  mapping <- aes(g, y, ymin = lo, ymax = hi)
+
+  plots <- list(
+    errorbar = ggplot(df, mapping) + geom_errorbar(width = 0.2),
+    linerange = ggplot(df, mapping) + geom_linerange(),
+    pointrange = ggplot(df, mapping) + geom_pointrange(),
+    crossbar = ggplot(df, mapping) + geom_crossbar(),
+    errorbarh = ggplot(df, aes(y, g, xmin = lo, xmax = hi)) +
+      geom_errorbarh(height = 0.2)
+  )
+
+  for (name in names(plots)) {
+    result <- eb_process_drawn(plots[[name]])
+
+    testthat::expect_length(result$data, 3)
+    # One selector, not one per sample: gridSVG groups a grob's elements
+    # under a single `<g>`, so the samples are a stride through its children.
+    testthat::expect_length(result$selectors, 1)
+    testthat::expect_true(
+      grepl("^g#", result$selectors[[1]]),
+      info = paste(name, "addresses a group")
+    )
+  }
+})
+
+test_that("an unnamed geom_errorbar grob is still addressed", {
+  # The reason this issue existed. geom_errorbar() draws `GRID.polyline.N`
+  # with no geom prefix, so every name-matching search reaches it last or not
+  # at all -- and it is the most common of the five.
+  result <- eb_process_drawn(
+    ggplot(eb_data(), aes(g, y, ymin = lo, ymax = hi)) + geom_errorbar(width = 0.2)
+  )
+
+  testthat::expect_match(eb_selector_id(result$selectors[[1]]), "^GRID\\.polyline\\.")
+})
+
+test_that("geom_errorbar addresses its whisker, not one of its caps", {
+  # A bar is drawn as three elements -- cap, whisker, cap -- so addressing
+  # the group's children directly would resolve to three times the samples
+  # and the trace would discard the lot. The stride picks the middle one.
+  result <- eb_process_drawn(
+    ggplot(eb_data(), aes(g, y, ymin = lo, ymax = hi)) + geom_errorbar(width = 0.2)
+  )
+
+  testthat::expect_match(result$selectors[[1]], "nth-child(3n+2)", fixed = TRUE)
+})
+
+test_that("a geom drawing one element per sample takes no stride", {
+  # The counterpart: a linerange draws exactly one line per sample, so a
+  # stride here would address a third of them.
+  result <- eb_process_drawn(
+    ggplot(eb_data(), aes(g, y, ymin = lo, ymax = hi)) + geom_linerange()
+  )
+
+  testthat::expect_false(grepl("nth-child", result$selectors[[1]], fixed = TRUE))
+})
+
+test_that("a pointrange is highlighted by the range rather than the point", {
+  # Its gTree holds the whisker and the estimate as siblings, both one per
+  # sample. The whisker is the one that spans the interval the reader is
+  # navigating.
+  result <- eb_process_drawn(
+    ggplot(eb_data(), aes(g, y, ymin = lo, ymax = hi)) + geom_pointrange()
+  )
+
+  testthat::expect_match(eb_selector_id(result$selectors[[1]]), "^geom_linerange\\.segments\\.")
+})
+
+test_that("a crossbar is highlighted by its box rather than its middle line", {
+  result <- eb_process_drawn(
+    ggplot(eb_data(), aes(g, y, ymin = lo, ymax = hi)) + geom_crossbar()
+  )
+
+  testthat::expect_match(eb_selector_id(result$selectors[[1]]), "^geom_polygon\\.polygon\\.")
+})
+
+test_that("an error bar beside another layer addresses its own marks", {
+  # geom_col() + geom_errorbar() is the standard way to draw this chart, and
+  # the errorbar is the second layer. Resolving it by position rather than by
+  # name is only sound if the position is the layer's own.
+  df <- eb_data()
+  plot <- ggplot(df, aes(g)) +
+    geom_col(aes(y = y)) +
+    geom_errorbar(aes(ymin = lo, ymax = hi), width = 0.2)
+  processor <- maidr:::Ggplot2ErrorbarLayerProcessor$new(
+    list(layer_index = 2, index = 2, plot = plot)
+  )
+
+  result <- processor$process(
+    plot, NULL, ggplot2::ggplot_build(plot), ggplot2::ggplotGrob(plot)
+  )
+
+  testthat::expect_length(result$selectors, 1)
+  # The bars are a `rect` grob; picking that one up would highlight the
+  # estimates while the reader navigates the interval.
+  testthat::expect_match(eb_selector_id(result$selectors[[1]]), "^GRID\\.polyline\\.")
+})
+
+test_that("a layer drawing nothing beside it does not shift the lookup", {
+  # A layer with no rows still takes its slot in the panel as a zeroGrob, so
+  # the positional lookup has to count it. If it did not, this would address
+  # the layer before the error bar.
+  df <- eb_data()
+  plot <- ggplot(df, aes(g)) +
+    geom_point(data = df[0, ], aes(y = y)) +
+    geom_errorbar(aes(ymin = lo, ymax = hi), width = 0.2)
+  processor <- maidr:::Ggplot2ErrorbarLayerProcessor$new(
+    list(layer_index = 2, index = 2, plot = plot)
+  )
+
+  result <- processor$process(
+    plot, NULL, ggplot2::ggplot_build(plot), ggplot2::ggplotGrob(plot)
+  )
+
+  testthat::expect_length(result$selectors, 1)
+  testthat::expect_match(eb_selector_id(result$selectors[[1]]), "^GRID\\.polyline\\.")
+})
+
+test_that("no gtable yields no selectors rather than a guessed one", {
+  # A selector that resolves to the wrong element highlights somewhere else,
+  # which a reader cannot tell from the right answer. An empty list is the
+  # only honest response to not knowing.
+  result <- eb_process(
+    ggplot(eb_data(), aes(g, y, ymin = lo, ymax = hi)) + geom_errorbar()
+  )
+
+  testthat::expect_equal(result$selectors, list())
+})
+
+test_that("an empty layer emits no selector for its no points", {
+  empty <- data.frame(
+    g = character(0), y = numeric(0), lo = numeric(0), hi = numeric(0)
+  )
+  result <- eb_process_drawn(
+    ggplot(empty, aes(g, y, ymin = lo, ymax = hi)) + geom_errorbar()
+  )
+
+  testthat::expect_equal(result$data, list())
+  testthat::expect_equal(result$selectors, list())
+})

--- a/tests/testthat/test-ggplot2-errorbar-layer-processor.R
+++ b/tests/testthat/test-ggplot2-errorbar-layer-processor.R
@@ -429,3 +429,65 @@ test_that("an empty layer emits no selector for its no points", {
   testthat::expect_equal(result$data, list())
   testthat::expect_equal(result$selectors, list())
 })
+
+test_that("two error bar layers in one panel address different marks", {
+  # The case the positional lookup is most likely to get wrong: neither layer
+  # has a name to match on, so nothing but position tells them apart. If it
+  # counted from the wrong anchor, both would resolve to the first polyline
+  # and the second layer would highlight the first layer's whiskers -- which
+  # resolves, and looks healthy, and is wrong.
+  df <- eb_data()
+  plot <- ggplot(df, aes(g)) +
+    geom_errorbar(aes(ymin = lo, ymax = hi), width = 0.2) +
+    geom_errorbar(aes(ymin = lo - 1, ymax = hi + 1), width = 0.4)
+
+  selectors <- lapply(seq_len(2), function(index) {
+    processor <- maidr:::Ggplot2ErrorbarLayerProcessor$new(
+      list(layer_index = index, index = index, plot = plot)
+    )
+    processor$process(
+      plot, NULL, ggplot2::ggplot_build(plot), ggplot2::ggplotGrob(plot)
+    )$selectors
+  })
+
+  testthat::expect_length(selectors[[1]], 1)
+  testthat::expect_length(selectors[[2]], 1)
+  testthat::expect_false(identical(selectors[[1]], selectors[[2]]))
+})
+
+test_that("an error bar beside a geom of another family still resolves", {
+  # geom_linerange() is found by name and geom_errorbar() by position, so this
+  # is the case where the two lookups have to agree about which layer is which.
+  df <- eb_data()
+  plot <- ggplot(df, aes(g, y, ymin = lo, ymax = hi)) +
+    geom_errorbar(width = 0.2) +
+    geom_linerange()
+
+  first <- maidr:::Ggplot2ErrorbarLayerProcessor$new(
+    list(layer_index = 1, index = 1, plot = plot)
+  )$process(plot, NULL, ggplot2::ggplot_build(plot), ggplot2::ggplotGrob(plot))
+  second <- maidr:::Ggplot2ErrorbarLayerProcessor$new(
+    list(layer_index = 2, index = 2, plot = plot)
+  )$process(plot, NULL, ggplot2::ggplot_build(plot), ggplot2::ggplotGrob(plot))
+
+  testthat::expect_match(eb_selector_id(first$selectors[[1]]), "^GRID\\.polyline\\.")
+  testthat::expect_match(
+    eb_selector_id(second$selectors[[1]]), "^geom_linerange\\.segments\\."
+  )
+})
+
+test_that("a theme that draws no grid does not move the lookup", {
+  # The positional anchor is the leading zeroGrob rather than the grill, so a
+  # theme that renders the background differently must not shift it. Worth
+  # pinning rather than assuming: the anchor is the one part of this that
+  # depends on ggplot2's internal panel layout.
+  df <- eb_data()
+  base <- ggplot(df, aes(g, y, ymin = lo, ymax = hi)) + geom_errorbar(width = 0.2)
+
+  for (plot in list(base + theme_void(), base + theme(panel.grid = element_blank()))) {
+    result <- eb_process_drawn(plot)
+
+    testthat::expect_length(result$selectors, 1)
+    testthat::expect_match(eb_selector_id(result$selectors[[1]]), "^GRID\\.polyline\\.")
+  }
+})


### PR DESCRIPTION
## Description

Closes #145.

`Ggplot2ErrorbarLayerProcessor$process()` returned `data`, `axes`, `type` and `orientation` and no `selectors`, so all five uncertainty geoms sonified, announced and brailled correctly and **highlighted nothing**. `ErrorBarTrace.mapToSvgElements` requires the flattened match to be exactly as long as the layer's data and discards anything else, so the frontend degraded quietly rather than erroring.

## The part worth reviewing: the five geoms do not draw alike

The issue predicted this and it turned out to be the whole of the work. Probed against real `gridSVG::grid.export()` output on ggplot2 3.4.4:

| geom | drawn as | elements per sample |
|---|---|---|
| `geom_linerange()` | `geom_linerange.segments.N` | 1 |
| `geom_pointrange()` | a gTree holding that same `segments` grob **and** a `points` grob | 1 |
| `geom_crossbar()` | a gTree holding a `polygon` (the box) **and** a `segments` (the middle line) | 1 |
| `geom_errorbar()` / `geom_errorbarh()` | **`GRID.polyline.N`** — no geom prefix at all | **3** |

Both of those last two columns are why the inherited `generate_selectors()` could not be reused. It matches `geom_point.points` by name, which reaches none of these; and a name-prefix search reaches `geom_errorbar()` least of all, which is the most common of the five.

**The three-per-sample fact is the one that would have bitten silently.** `geom_errorbar()`'s eight points per sample are `cap, NA, whisker, NA, cap`, and grid breaks a polyline at a missing point, so the export carries three `<polyline>` elements for one bar:

```
<g id="GRID.polyline.1.1">
  <polyline id="GRID.polyline.1.1.1a" points="90.9,232.32 121.09,232.32"/>   <- cap
  <polyline id="GRID.polyline.1.1.1b" points="106,232.32 106,154.11"/>       <- whisker
  <polyline id="GRID.polyline.1.1.1c" points="90.9,154.11 121.09,154.11"/>   <- cap
  ...
```

Addressing the group's children directly resolves to 9 elements for 3 samples, the trace discards the lot, and the layer highlights nothing — the same outcome as emitting no selectors at all, reached by a route that looks like it worked.

## Changes Made

`generate_selectors()` on the errorbar processor, plus five helpers it decomposes into:

- **`find_interval_grob()`** — the layer's own tree by name where ggplot2 gives one, then the child that spans the interval: the box for a crossbar, the whisker for a pointrange. The middle line and the estimate are also one per sample, so this decides which mark lights up, not whether anything does.
- **`find_unnamed_interval_grob()`** — position for the two geoms with no name. ggplot2 lays a panel out as the grill, a leading `zeroGrob`, **one child per layer in layer order**, a trailing `zeroGrob` and the border, and a layer that draws nothing still takes its slot as a `zeroGrob`. Deliberately narrow: it is gated on the geom being `GeomErrorbar`/`GeomErrorbarh` and on the resolved grob being a `polyline`, because a positional hit on a neighbouring layer would highlight another layer's marks — worse than the missing highlight this fixes, since a reader can hear nothing but cannot hear wrongness.
- **`interval_grob_shape()` / `grob_point_groups()` / `drawn_run_count()`** — the sample count and the stride, computed from the grob's `id` and its missing points rather than assumed. A sample count that disagrees with the emitted data returns no selector, and so does a stride other than the two checked against an export.

One incidental finding: the leading blank is found by **class**, not by an absent name. A `zeroGrob` is named, and its name is the four characters `"NULL"`, so `is.null(g$name)` matches nothing and the first draft of the positional lookup silently found no anchor.

`man/Ggplot2ErrorbarLayerProcessor.Rd` is regenerated **for this one class only**. Running `roxygen2::roxygenise()` on the package rewrites 53 files including `DESCRIPTION` and `NAMESPACE` — the installed roxygen2 is 8.1.0 against the pinned `RoxygenNote: 7.3.2`, which is exactly #143. I generated into a scratch copy, checked the diff for this file was additive (248 insertions, 2 deletions — both of them correct: `Ggplot2PointLayerProcessor$generate_selectors` leaves the inherited list because it is now overridden), copied that file alone, and confirmed `tools::checkRd()` is clean. The wholesale rewrite stays #143's.

## Testing

**11 new cases in `tests/testthat/test-ggplot2-errorbar-layer-processor.R`** covering the selector shape per geom, the unnamed-grob resolution, the stride, which child a pointrange and a crossbar address, an error bar as the second layer beside a `geom_col()`, an empty layer beside it, and the two refusals (no gtable, no points).

**A new `tests/testthat/test-errorbar-selectors.R`** renders through `save_html()` and asks the exported SVG. This is the part the issue asked for, and it is the part that matters: the processor's own tests assert strings, and a string that resolves to nothing passes every one of them.

- every geom's selector finds **exactly** 3 elements for 3 samples;
- an error bar's elements are **vertical** and a horizontal one's are **horizontal**, which separates the whisker from the caps geometrically rather than by trusting the stride;
- the elements arrive in the order the data was emitted — the fixture's intervals are 0.8, 2.6 and 0.3 wide, so the drawn lengths pin the pairing and a shuffle fails;
- an error bar drawn over a `geom_col()` addresses polylines, not the bars.

**Verified they bite.** With `selectors` removed from the emitted payload again: **21 failures** in the processor file and **6** in the export file. The export helper reports a missing selector as a missing selector rather than as an XPath error, so the failure stays readable.

**Verified against a real CSS engine.** `selectr` is not a dependency, so the export tests translate the two selector shapes to XPath by hand. Rather than trust that, I ran the emitted selectors through `querySelectorAll` in jsdom on the rendered HTML — the same API the browser uses:

```
errorbar    points=3 matched=3 OK  tags=[polyline]  g#GRID\.polyline\.1\.1 > *:nth-child(3n+2)
linerange   points=3 matched=3 OK  tags=[polyline]  g#geom_linerange\.segments\.51\.1 > *
pointrange  points=3 matched=3 OK  tags=[polyline]  g#geom_linerange\.segments\.100\.1 > *
crossbar    points=3 matched=3 OK  tags=[polygon]   g#geom_polygon\.polygon\.152\.1 > *
errorbarh   points=3 matched=3 OK  tags=[polyline]  g#GRID\.polyline\.201\.1 > *:nth-child(3n+2)
col_eb      points=3 matched=3 OK  tags=[polyline]  g#GRID\.polyline\.250\.1 > *:nth-child(3n+2)
```

The errorbar matches came back as `116.61,111.75 116.61,46.57` / `410.39,274.68 410.39,62.87` / `263.5,339.86 263.5,315.42` — vertical, and 65.18 / 211.81 / 24.44 px long against intervals of 0.8 / 2.6 / 0.3, a constant 81.5 px per unit. Right elements, right order.

Full suite: `test_dir("tests/testthat")` reports **4841 passing and 9 failures, all in the pie tests** — the same pre-existing set #138 and #141 documented. Confirmed unchanged by this branch: stashing it and re-running those two files gives the identical 9.

## Notes

Those 9 are not noise, and they are the same defect as this one in a different processor. On ggplot2 3.4.4 a polar bar layer draws a `geom_rect.gTree.N` containing **one `geom_polygon.polygon.N` grob per wedge**, where the pie processor looks for a single grob whose sub-polygons are grouped by id — so `generate_selectors()` returns an empty list and **a pie highlights nothing**. `DESCRIPTION` puts no version bound on ggplot2, and CI runs release, which is why this has stayed invisible. Filed separately rather than folded in here.

The branch was reset from `main` after #141 merged, so the push is a force-with-lease over remote history that is already in `main` as the squashed `4bafe8a`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_