### PR TITLE
fix(ggplot2): find a pie's wedges however ggplot2 drew them

### DIFF
--- a/R/ggplot2_pie_layer_processor.R
+++ b/R/ggplot2_pie_layer_processor.R
@@ -290,20 +290,18 @@ Ggplot2PieLayerProcessor <- R6::R6Class(
         return(list())
       }
 
-      polygon_grob <- NULL
-
+      roots <- list()
       if (!is.null(panel_ctx) && !is.null(panel_ctx$panel_name)) {
         # Facet / patchwork path: scope the search to this panel's grob
         panel_grob <- find_gtable_panel_grob(gt, panel_ctx)
         if (!is.null(panel_grob)) {
-          polygon_grob <- self$find_polygon_grob(panel_grob)
+          roots <- list(panel_grob)
         }
       } else if ("grobs" %in% names(gt)) {
-        for (grob in gt$grobs) {
-          polygon_grob <- self$find_polygon_grob(grob)
-          if (!is.null(polygon_grob)) break
-        }
+        roots <- gt$grobs
       }
+
+      polygon_grob <- self$resolve_layer_polygon_grob(plot, roots)
 
       # No polygon grob means this layer drew no wedges here: an empty facet
       # level, a zero-row layer, a coord that renders no polygons. The layer
@@ -350,7 +348,96 @@ Ggplot2PieLayerProcessor <- R6::R6Class(
     #'
     #' @param grob Grob to search
     #' @return Grob name, or NULL when the tree holds none
+    #' @description Pick the wedge container belonging to *this* layer
+    #'
+    #' A panel can hold more than one polar \code{geom_rect} layer -- two
+    #' \code{geom_col()}s under \code{coord_polar()} is an ordinary way to
+    #' draw a ring over a pie -- and a search that takes the first match
+    #' hands every layer the first layer's wedges. Those selectors resolve,
+    #' and the payload looks healthy, and the outline is on the wrong marks.
+    #'
+    #' \code{LayerProcessor$find_layer_grob_tree()} cannot be reused for
+    #' this: it matches on the geom's own class, and a \code{geom_col()}
+    #' layer is \code{GeomCol} while the grob it draws is named after
+    #' \code{geom_rect}. So the containers are collected in drawing order --
+    #' which is layer order -- and indexed.
+    #'
+    #' When the counts do not line up the answer is no selector rather than
+    #' a guess, for the reason \code{generate_selectors()} already gives: a
+    #' wrong selector highlights another layer's wedges, and the caller can
+    #' tell an empty list from a wrong one where a reader cannot.
+    #'
+    #' @param plot The ggplot2 object, or NULL when the caller has none
+    #' @param roots Grobs to search, in drawing order
+    #' @return Grob name, or NULL
+    resolve_layer_polygon_grob = function(plot, roots) {
+      containers <- unlist(
+        lapply(roots, function(root) self$collect_polygon_grobs(root)),
+        use.names = FALSE
+      )
+      if (length(containers) == 0L) {
+        return(NULL)
+      }
+      if (length(containers) == 1L) {
+        return(containers[[1]])
+      }
+
+      index <- self$get_layer_index()
+      layers <- if (is.null(plot)) NULL else plot$layers
+      if (is.null(layers) || length(containers) != length(layers) ||
+        is.null(index) || index < 1L || index > length(containers)) {
+        return(NULL)
+      }
+      containers[[index]]
+    },
+
+    #' @description Every wedge container in a grob tree, in drawing order
+    #'
+    #' One entry per layer that drew wedges. A match is not descended into:
+    #' the container is the whole layer's wedges, and its children are the
+    #' individual ones.
+    #'
+    #' @param grob Grob to search
+    #' @return Character vector of grob names, possibly empty
+    collect_polygon_grobs = function(grob) {
+      if (is.null(grob)) {
+        return(character(0))
+      }
+
+      own <- self$find_own_polygon_grob(grob)
+      if (!is.null(own)) {
+        return(own)
+      }
+
+      found <- character(0)
+      if ("children" %in% names(grob)) {
+        for (child in grob$children) {
+          found <- c(found, self$collect_polygon_grobs(child))
+        }
+      }
+      found
+    },
+
+    #' @description Whether this grob is itself a wedge container
+    #' @param grob Grob to test
+    #' @return Grob name, or NULL
+    find_own_polygon_grob = function(grob) {
+      if (is.null(grob$name)) {
+        return(NULL)
+      }
+      if (grepl("^geom_rect\\.polygon", grob$name)) {
+        return(grob$name)
+      }
+      if (grepl("^geom_rect\\.gTree", grob$name) && self$holds_polygon(grob)) {
+        return(grob$name)
+      }
+      NULL
+    },
+
     find_polygon_grob = function(grob) {
+      if (is.null(grob)) {
+        return(NULL)
+      }
       named <- self$find_named_polygon_grob(grob)
       if (!is.null(named)) {
         return(named)
@@ -363,7 +450,7 @@ Ggplot2PieLayerProcessor <- R6::R6Class(
     #' @param grob Grob to search
     #' @return Grob name, or NULL
     find_named_polygon_grob = function(grob) {
-      if (!is.null(grob$name) && grepl("geom_rect\\.polygon", grob$name)) {
+      if (!is.null(grob$name) && grepl("^geom_rect\\.polygon", grob$name)) {
         return(grob$name)
       }
 

--- a/R/ggplot2_pie_layer_processor.R
+++ b/R/ggplot2_pie_layer_processor.R
@@ -323,22 +323,53 @@ Ggplot2PieLayerProcessor <- R6::R6Class(
       list(paste0("#", escaped_svg_id, " polygon"))
     },
 
-    #' @description Find this layer's wedge polygon grob within a grob tree
+    #' @description Find the grob whose \code{<polygon>} descendants are the wedges
     #'
-    #' Matches on the \code{geom_rect.polygon} prefix, which the polar grill's
-    #' own polygon (named \code{GRID.polygon.<N>} under \code{coord_radial()})
-    #' does not carry.
+    #' ggplot2 does not draw a polar bar layer the same way across versions,
+    #' and the difference is not cosmetic. Verified against real
+    #' \code{gridSVG::grid.export()} output:
+    #'
+    #' \itemize{
+    #'   \item One \code{geom_rect.polygon.<N>} grob holding every wedge,
+    #'     grouped by id. This is what the lookup was written for.
+    #'   \item A \code{geom_rect.gTree.<N>} holding **one
+    #'     \code{geom_polygon.polygon.<N>} grob per wedge}. On ggplot2 3.4.4
+    #'     this is what a pie draws, and nothing named
+    #'     \code{geom_rect.polygon} exists anywhere in the tree -- so the
+    #'     lookup found nothing, \code{generate_selectors()} returned an empty
+    #'     list, and **a pie highlighted nothing at all** (#151).
+    #' }
+    #'
+    #' Either way the answer is a container whose \code{<polygon>} descendants
+    #' are the wedges in slice order, so the caller's descendant selector
+    #' resolves against both without knowing which it got.
+    #'
+    #' The polar grill draws a polygon of its own under
+    #' \code{coord_radial()}, named \code{GRID.polygon.<N>}; neither branch
+    #' carries a name that matches it.
     #'
     #' @param grob Grob to search
     #' @return Grob name, or NULL when the tree holds none
     find_polygon_grob = function(grob) {
+      named <- self$find_named_polygon_grob(grob)
+      if (!is.null(named)) {
+        return(named)
+      }
+      self$find_wedge_container(grob)
+    },
+
+    #' @description Find a single grob holding every wedge, if there is one.
+    #'
+    #' @param grob Grob to search
+    #' @return Grob name, or NULL
+    find_named_polygon_grob = function(grob) {
       if (!is.null(grob$name) && grepl("geom_rect\\.polygon", grob$name)) {
         return(grob$name)
       }
 
       if ("children" %in% names(grob)) {
         for (child in grob$children) {
-          result <- self$find_polygon_grob(child)
+          result <- self$find_named_polygon_grob(child)
           if (!is.null(result)) {
             return(result)
           }
@@ -346,6 +377,53 @@ Ggplot2PieLayerProcessor <- R6::R6Class(
       }
 
       NULL
+    },
+
+    #' @description Find the layer tree whose polygon children are the wedges.
+    #'
+    #' Requires the tree to actually hold a polygon. A \code{geom_rect} gTree
+    #' that drew none is a layer with nothing to point at, and naming it would
+    #' emit a selector resolving to nothing -- which the caller cannot tell
+    #' apart from a working one, and a reader cannot tell apart from a bug.
+    #'
+    #' @param grob Grob to search
+    #' @return Grob name, or NULL
+    find_wedge_container = function(grob) {
+      if (!is.null(grob$name) && grepl("^geom_rect\\.gTree", grob$name) &&
+        self$holds_polygon(grob)) {
+        return(grob$name)
+      }
+
+      if ("children" %in% names(grob)) {
+        for (child in grob$children) {
+          result <- self$find_wedge_container(child)
+          if (!is.null(result)) {
+            return(result)
+          }
+        }
+      }
+
+      NULL
+    },
+
+    #' @description Whether a grob tree draws at least one polygon.
+    #'
+    #' @param grob Grob to search
+    #' @return TRUE when the tree holds a polygon grob
+    holds_polygon = function(grob) {
+      if (identical(class(grob)[1], "polygon")) {
+        return(TRUE)
+      }
+
+      if ("children" %in% names(grob)) {
+        for (child in grob$children) {
+          if (self$holds_polygon(child)) {
+            return(TRUE)
+          }
+        }
+      }
+
+      FALSE
     }
   )
 )

--- a/R/ggplot2_pie_layer_processor.R
+++ b/R/ggplot2_pie_layer_processor.R
@@ -290,19 +290,19 @@ Ggplot2PieLayerProcessor <- R6::R6Class(
         return(list())
       }
 
-      roots <- list()
-      if (!is.null(panel_ctx) && !is.null(panel_ctx$panel_name)) {
-        # Facet / patchwork path: scope the search to this panel's grob
-        panel_grob <- find_gtable_panel_grob(gt, panel_ctx)
-        if (!is.null(panel_grob)) {
-          roots <- list(panel_grob)
-        }
-      } else if ("grobs" %in% names(gt)) {
-        roots <- gt$grobs
+      panel <- find_gtable_panel_grob(gt, panel_ctx)
+      slot <- self$layer_slot_grob(panel)
+      polygon_grob <- if (!is.null(slot)) {
+        # The slot is this layer's, so whatever it holds is the answer --
+        # including "not a container", which means this layer drew no wedges.
+        # Falling through to the search here would hand a label layer the
+        # pie's wedges.
+        self$find_own_polygon_grob(slot)
+      } else {
+        self$sole_wedge_container(
+          if (is.null(panel) && "grobs" %in% names(gt)) gt$grobs else list(panel)
+        )
       }
-
-      polygon_grob <- self$resolve_layer_polygon_grob(plot, roots)
-
       # No polygon grob means this layer drew no wedges here: an empty facet
       # level, a zero-row layer, a coord that renders no polygons. The layer
       # INDEX is not the grob id - every `geom_rect.polygon.N` id carries
@@ -321,74 +321,68 @@ Ggplot2PieLayerProcessor <- R6::R6Class(
       list(paste0("#", escaped_svg_id, " polygon"))
     },
 
-    #' @description Find the grob whose \code{<polygon>} descendants are the wedges
+    #' @description The grob slot belonging to *this* layer
     #'
-    #' ggplot2 does not draw a polar bar layer the same way across versions,
-    #' and the difference is not cosmetic. Verified against real
-    #' \code{gridSVG::grid.export()} output:
+    #' ggplot2 lays a panel out as the grill, a leading \code{zeroGrob},
+    #' \strong{one child per layer in layer order}, a trailing
+    #' \code{zeroGrob} and the axis tree. So the slot is the handle: layer
+    #' \emph{k} owns the \emph{k}th child after the leading blank, whether or
+    #' not it drew anything.
     #'
-    #' \itemize{
-    #'   \item One \code{geom_rect.polygon.<N>} grob holding every wedge,
-    #'     grouped by id. This is what the lookup was written for.
-    #'   \item A \code{geom_rect.gTree.<N>} holding **one
-    #'     \code{geom_polygon.polygon.<N>} grob per wedge}. On ggplot2 3.4.4
-    #'     this is what a pie draws, and nothing named
-    #'     \code{geom_rect.polygon} exists anywhere in the tree -- so the
-    #'     lookup found nothing, \code{generate_selectors()} returned an empty
-    #'     list, and **a pie highlighted nothing at all** (#151).
-    #' }
+    #' It matters because a panel can hold more than one polar
+    #' \code{geom_rect} layer -- two \code{geom_col()}s under
+    #' \code{coord_polar()} is an ordinary way to draw a ring over a pie --
+    #' and a search that takes the first container hands every layer the first
+    #' layer's wedges. Those selectors resolve, and the payload looks healthy,
+    #' and the outline is on the wrong marks.
     #'
-    #' Either way the answer is a container whose \code{<polygon>} descendants
-    #' are the wedges in slice order, so the caller's descendant selector
-    #' resolves against both without knowing which it got.
+    #' \code{LayerProcessor$find_layer_grob_tree()} cannot be reused for this:
+    #' it matches on the geom's own class, and a \code{geom_col()} layer is
+    #' \code{GeomCol} while the grob it draws is named after
+    #' \code{geom_rect}. Counting containers instead of slots does not work
+    #' either -- a \code{geom_text()} label layer occupies a slot and draws no
+    #' container, so the counts stop lining up and both rings of an annotated
+    #' pie lose their selectors.
     #'
-    #' The polar grill draws a polygon of its own under
-    #' \code{coord_radial()}, named \code{GRID.polygon.<N>}; neither branch
-    #' carries a name that matches it.
+    #' @param panel The panel grob, or NULL
+    #' @return This layer's grob, or NULL when the slot cannot be established
+    layer_slot_grob = function(panel) {
+      index <- self$get_layer_index()
+      if (is.null(panel) || !inherits(panel, "gTree") || is.null(index)) {
+        return(NULL)
+      }
+
+      children <- panel$children
+      blanks <- which(vapply(
+        children, function(g) inherits(g, "zeroGrob"), logical(1)
+      ))
+      if (length(blanks) == 0L) {
+        return(NULL)
+      }
+
+      at <- blanks[1] + as.integer(index)
+      if (at < 1L || at > length(children)) {
+        return(NULL)
+      }
+      children[[at]]
+    },
+
+    #' @description The one wedge container in a tree, when there is exactly one
     #'
-    #' @param grob Grob to search
-    #' @return Grob name, or NULL when the tree holds none
-    #' @description Pick the wedge container belonging to *this* layer
+    #' The fallback for when the slot lookup cannot resolve -- a panel shape
+    #' with no leading blank, or a caller handing over a gtable rather than a
+    #' panel. Correct whenever the search finds a single container, which is
+    #' every chart that is only a pie; ambiguous otherwise, and ambiguous
+    #' means no selector for the reason \code{generate_selectors()} gives.
     #'
-    #' A panel can hold more than one polar \code{geom_rect} layer -- two
-    #' \code{geom_col()}s under \code{coord_polar()} is an ordinary way to
-    #' draw a ring over a pie -- and a search that takes the first match
-    #' hands every layer the first layer's wedges. Those selectors resolve,
-    #' and the payload looks healthy, and the outline is on the wrong marks.
-    #'
-    #' \code{LayerProcessor$find_layer_grob_tree()} cannot be reused for
-    #' this: it matches on the geom's own class, and a \code{geom_col()}
-    #' layer is \code{GeomCol} while the grob it draws is named after
-    #' \code{geom_rect}. So the containers are collected in drawing order --
-    #' which is layer order -- and indexed.
-    #'
-    #' When the counts do not line up the answer is no selector rather than
-    #' a guess, for the reason \code{generate_selectors()} already gives: a
-    #' wrong selector highlights another layer's wedges, and the caller can
-    #' tell an empty list from a wrong one where a reader cannot.
-    #'
-    #' @param plot The ggplot2 object, or NULL when the caller has none
-    #' @param roots Grobs to search, in drawing order
+    #' @param roots Grobs to search
     #' @return Grob name, or NULL
-    resolve_layer_polygon_grob = function(plot, roots) {
+    sole_wedge_container = function(roots) {
       containers <- unlist(
         lapply(roots, function(root) self$collect_polygon_grobs(root)),
         use.names = FALSE
       )
-      if (length(containers) == 0L) {
-        return(NULL)
-      }
-      if (length(containers) == 1L) {
-        return(containers[[1]])
-      }
-
-      index <- self$get_layer_index()
-      layers <- if (is.null(plot)) NULL else plot$layers
-      if (is.null(layers) || length(containers) != length(layers) ||
-        is.null(index) || index < 1L || index > length(containers)) {
-        return(NULL)
-      }
-      containers[[index]]
+      if (length(containers) == 1L) containers[[1]] else NULL
     },
 
     #' @description Every wedge container in a grob tree, in drawing order
@@ -419,10 +413,36 @@ Ggplot2PieLayerProcessor <- R6::R6Class(
     },
 
     #' @description Whether this grob is itself a wedge container
+    #'
+    #' ggplot2 does not draw a polar bar layer the same way across versions,
+    #' and the difference is not cosmetic. Verified against real
+    #' \code{gridSVG::grid.export()} output:
+    #'
+    #' \itemize{
+    #'   \item One \code{geom_rect.polygon.<N>} grob holding every wedge,
+    #'     grouped by id. This is what the lookup was written for.
+    #'   \item A \code{geom_rect.gTree.<N>} holding \strong{one
+    #'     \code{geom_polygon.polygon.<N>} grob per wedge}. On ggplot2 3.4.4
+    #'     this is what a pie draws, and nothing named
+    #'     \code{geom_rect.polygon} exists anywhere in the tree -- so the
+    #'     lookup found nothing, \code{generate_selectors()} returned an empty
+    #'     list, and \strong{a pie highlighted nothing at all} (#151).
+    #' }
+    #'
+    #' Either way the answer is a container whose \code{<polygon>} descendants
+    #' are the wedges in slice order, so the caller's descendant selector
+    #' resolves against both without knowing which it got.
+    #'
+    #' The polar grill draws a polygon of its own under
+    #' \code{coord_radial()}, named \code{GRID.polygon.<N>}; neither branch
+    #' carries a name that matches it. The gTree branch also requires a
+    #' polygon to be there: a \code{geom_rect} layer that drew none has
+    #' nothing to point at.
+    #'
     #' @param grob Grob to test
     #' @return Grob name, or NULL
     find_own_polygon_grob = function(grob) {
-      if (is.null(grob$name)) {
+      if (is.null(grob) || is.null(grob$name)) {
         return(NULL)
       }
       if (grepl("^geom_rect\\.polygon", grob$name)) {
@@ -431,65 +451,6 @@ Ggplot2PieLayerProcessor <- R6::R6Class(
       if (grepl("^geom_rect\\.gTree", grob$name) && self$holds_polygon(grob)) {
         return(grob$name)
       }
-      NULL
-    },
-
-    find_polygon_grob = function(grob) {
-      if (is.null(grob)) {
-        return(NULL)
-      }
-      named <- self$find_named_polygon_grob(grob)
-      if (!is.null(named)) {
-        return(named)
-      }
-      self$find_wedge_container(grob)
-    },
-
-    #' @description Find a single grob holding every wedge, if there is one.
-    #'
-    #' @param grob Grob to search
-    #' @return Grob name, or NULL
-    find_named_polygon_grob = function(grob) {
-      if (!is.null(grob$name) && grepl("^geom_rect\\.polygon", grob$name)) {
-        return(grob$name)
-      }
-
-      if ("children" %in% names(grob)) {
-        for (child in grob$children) {
-          result <- self$find_named_polygon_grob(child)
-          if (!is.null(result)) {
-            return(result)
-          }
-        }
-      }
-
-      NULL
-    },
-
-    #' @description Find the layer tree whose polygon children are the wedges.
-    #'
-    #' Requires the tree to actually hold a polygon. A \code{geom_rect} gTree
-    #' that drew none is a layer with nothing to point at, and naming it would
-    #' emit a selector resolving to nothing -- which the caller cannot tell
-    #' apart from a working one, and a reader cannot tell apart from a bug.
-    #'
-    #' @param grob Grob to search
-    #' @return Grob name, or NULL
-    find_wedge_container = function(grob) {
-      if (!is.null(grob$name) && grepl("^geom_rect\\.gTree", grob$name) &&
-        self$holds_polygon(grob)) {
-        return(grob$name)
-      }
-
-      if ("children" %in% names(grob)) {
-        for (child in grob$children) {
-          result <- self$find_wedge_container(child)
-          if (!is.null(result)) {
-            return(result)
-          }
-        }
-      }
-
       NULL
     },
 

--- a/man/Ggplot2PieLayerProcessor.Rd
+++ b/man/Ggplot2PieLayerProcessor.Rd
@@ -34,12 +34,10 @@ declines them, and they stay bar / stacked / dodged as before.
     \item \href{#method-Ggplot2PieLayerProcessor-scale_labels}{\code{Ggplot2PieLayerProcessor$scale_labels()}}
     \item \href{#method-Ggplot2PieLayerProcessor-extract_pie_axes}{\code{Ggplot2PieLayerProcessor$extract_pie_axes()}}
     \item \href{#method-Ggplot2PieLayerProcessor-generate_selectors}{\code{Ggplot2PieLayerProcessor$generate_selectors()}}
-    \item \href{#method-Ggplot2PieLayerProcessor-resolve_layer_polygon_grob}{\code{Ggplot2PieLayerProcessor$resolve_layer_polygon_grob()}}
+    \item \href{#method-Ggplot2PieLayerProcessor-layer_slot_grob}{\code{Ggplot2PieLayerProcessor$layer_slot_grob()}}
+    \item \href{#method-Ggplot2PieLayerProcessor-sole_wedge_container}{\code{Ggplot2PieLayerProcessor$sole_wedge_container()}}
     \item \href{#method-Ggplot2PieLayerProcessor-collect_polygon_grobs}{\code{Ggplot2PieLayerProcessor$collect_polygon_grobs()}}
     \item \href{#method-Ggplot2PieLayerProcessor-find_own_polygon_grob}{\code{Ggplot2PieLayerProcessor$find_own_polygon_grob()}}
-    \item \href{#method-Ggplot2PieLayerProcessor-find_polygon_grob}{\code{Ggplot2PieLayerProcessor$find_polygon_grob()}}
-    \item \href{#method-Ggplot2PieLayerProcessor-find_named_polygon_grob}{\code{Ggplot2PieLayerProcessor$find_named_polygon_grob()}}
-    \item \href{#method-Ggplot2PieLayerProcessor-find_wedge_container}{\code{Ggplot2PieLayerProcessor$find_wedge_container()}}
     \item \href{#method-Ggplot2PieLayerProcessor-holds_polygon}{\code{Ggplot2PieLayerProcessor$holds_polygon()}}
     \item \href{#method-Ggplot2PieLayerProcessor-clone}{\code{Ggplot2PieLayerProcessor$clone()}}
   }
@@ -346,46 +344,73 @@ order.
 }
 
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Ggplot2PieLayerProcessor-resolve_layer_polygon_grob"></a>}}
-\if{latex}{\out{\hypertarget{method-Ggplot2PieLayerProcessor-resolve_layer_polygon_grob}{}}}
-\subsection{\code{Ggplot2PieLayerProcessor$resolve_layer_polygon_grob()}}{
-  
+\if{html}{\out{<a id="method-Ggplot2PieLayerProcessor-layer_slot_grob"></a>}}
+\if{latex}{\out{\hypertarget{method-Ggplot2PieLayerProcessor-layer_slot_grob}{}}}
+\subsection{\code{Ggplot2PieLayerProcessor$layer_slot_grob()}}{
+  The grob slot belonging to \emph{this} layer
 
+ggplot2 lays a panel out as the grill, a leading \code{zeroGrob},
+\strong{one child per layer in layer order}, a trailing
+\code{zeroGrob} and the axis tree. So the slot is the handle: layer
+\emph{k} owns the \emph{k}th child after the leading blank, whether or
+not it drew anything.
 
-  Pick the wedge container belonging to \emph{this} layer
+It matters because a panel can hold more than one polar
+\code{geom_rect} layer -- two \code{geom_col()}s under
+\code{coord_polar()} is an ordinary way to draw a ring over a pie --
+and a search that takes the first container hands every layer the first
+layer's wedges. Those selectors resolve, and the payload looks healthy,
+and the outline is on the wrong marks.
 
-A panel can hold more than one polar \code{geom_rect} layer -- two
-\code{geom_col()}s under \code{coord_polar()} is an ordinary way to
-draw a ring over a pie -- and a search that takes the first match
-hands every layer the first layer's wedges. Those selectors resolve,
-and the payload looks healthy, and the outline is on the wrong marks.
-
-\code{LayerProcessor$find_layer_grob_tree()} cannot be reused for
-this: it matches on the geom's own class, and a \code{geom_col()}
-layer is \code{GeomCol} while the grob it draws is named after
-\code{geom_rect}. So the containers are collected in drawing order --
-which is layer order -- and indexed.
-
-When the counts do not line up the answer is no selector rather than
-a guess, for the reason \code{generate_selectors()} already gives: a
-wrong selector highlights another layer's wedges, and the caller can
-tell an empty list from a wrong one where a reader cannot.
+\code{LayerProcessor$find_layer_grob_tree()} cannot be reused for this:
+it matches on the geom's own class, and a \code{geom_col()} layer is
+\code{GeomCol} while the grob it draws is named after
+\code{geom_rect}. Counting containers instead of slots does not work
+either -- a \code{geom_text()} label layer occupies a slot and draws no
+container, so the counts stop lining up and both rings of an annotated
+pie lose their selectors.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{Ggplot2PieLayerProcessor$resolve_layer_polygon_grob(plot, roots)}
+    \preformatted{Ggplot2PieLayerProcessor$layer_slot_grob(panel)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{plot}}{The ggplot2 object, or NULL when the caller has none}
-      \item{\code{roots}}{Grobs to search, in drawing order}
-      \item{\code{grob}}{Grob to search}
+      \item{\code{panel}}{The panel grob, or NULL}
     }
     \if{html}{\out{</div>}}
   }
   \subsection{Returns}{
-    Grob name, or NULL when the tree holds none
+    This layer's grob, or NULL when the slot cannot be established
+  }
+}
+
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Ggplot2PieLayerProcessor-sole_wedge_container"></a>}}
+\if{latex}{\out{\hypertarget{method-Ggplot2PieLayerProcessor-sole_wedge_container}{}}}
+\subsection{\code{Ggplot2PieLayerProcessor$sole_wedge_container()}}{
+  The one wedge container in a tree, when there is exactly one
+
+The fallback for when the slot lookup cannot resolve -- a panel shape
+with no leading blank, or a caller handing over a gtable rather than a
+panel. Correct whenever the search finds a single container, which is
+every chart that is only a pie; ambiguous otherwise, and ambiguous
+means no selector for the reason \code{generate_selectors()} gives.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Ggplot2PieLayerProcessor$sole_wedge_container(roots)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{roots}}{Grobs to search}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Grob name, or NULL
   }
 }
 
@@ -420,6 +445,31 @@ individual ones.
 \if{latex}{\out{\hypertarget{method-Ggplot2PieLayerProcessor-find_own_polygon_grob}{}}}
 \subsection{\code{Ggplot2PieLayerProcessor$find_own_polygon_grob()}}{
   Whether this grob is itself a wedge container
+
+ggplot2 does not draw a polar bar layer the same way across versions,
+and the difference is not cosmetic. Verified against real
+\code{gridSVG::grid.export()} output:
+
+\itemize{
+\item One \code{geom_rect.polygon.<N>} grob holding every wedge,
+grouped by id. This is what the lookup was written for.
+\item A \code{geom_rect.gTree.<N>} holding \strong{one
+\code{geom_polygon.polygon.<N>} grob per wedge}. On ggplot2 3.4.4
+this is what a pie draws, and nothing named
+\code{geom_rect.polygon} exists anywhere in the tree -- so the
+lookup found nothing, \code{generate_selectors()} returned an empty
+list, and \strong{a pie highlighted nothing at all} (#151).
+}
+
+Either way the answer is a container whose \code{<polygon>} descendants
+are the wedges in slice order, so the caller's descendant selector
+resolves against both without knowing which it got.
+
+The polar grill draws a polygon of its own under
+\code{coord_radial()}, named \code{GRID.polygon.<N>}; neither branch
+carries a name that matches it. The gTree branch also requires a
+polygon to be there: a \code{geom_rect} layer that drew none has
+nothing to point at.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2PieLayerProcessor$find_own_polygon_grob(grob)}
@@ -429,66 +479,6 @@ individual ones.
     \if{html}{\out{<div class="arguments">}}
     \describe{
       \item{\code{grob}}{Grob to test}
-    }
-    \if{html}{\out{</div>}}
-  }
-  \subsection{Returns}{
-    Grob name, or NULL
-  }
-}
-
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Ggplot2PieLayerProcessor-find_polygon_grob"></a>}}
-\if{latex}{\out{\hypertarget{method-Ggplot2PieLayerProcessor-find_polygon_grob}{}}}
-\subsection{\code{Ggplot2PieLayerProcessor$find_polygon_grob()}}{
-  \subsection{Usage}{
-    \if{html}{\out{<div class="r">}}
-    \preformatted{Ggplot2PieLayerProcessor$find_polygon_grob(grob)}
-    \if{html}{\out{</div>}}
-  }
-}
-
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Ggplot2PieLayerProcessor-find_named_polygon_grob"></a>}}
-\if{latex}{\out{\hypertarget{method-Ggplot2PieLayerProcessor-find_named_polygon_grob}{}}}
-\subsection{\code{Ggplot2PieLayerProcessor$find_named_polygon_grob()}}{
-  Find a single grob holding every wedge, if there is one.
-  \subsection{Usage}{
-    \if{html}{\out{<div class="r">}}
-    \preformatted{Ggplot2PieLayerProcessor$find_named_polygon_grob(grob)}
-    \if{html}{\out{</div>}}
-  }
-  \subsection{Arguments}{
-    \if{html}{\out{<div class="arguments">}}
-    \describe{
-      \item{\code{grob}}{Grob to search}
-    }
-    \if{html}{\out{</div>}}
-  }
-  \subsection{Returns}{
-    Grob name, or NULL
-  }
-}
-
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Ggplot2PieLayerProcessor-find_wedge_container"></a>}}
-\if{latex}{\out{\hypertarget{method-Ggplot2PieLayerProcessor-find_wedge_container}{}}}
-\subsection{\code{Ggplot2PieLayerProcessor$find_wedge_container()}}{
-  Find the layer tree whose polygon children are the wedges.
-
-Requires the tree to actually hold a polygon. A \code{geom_rect} gTree
-that drew none is a layer with nothing to point at, and naming it would
-emit a selector resolving to nothing -- which the caller cannot tell
-apart from a working one, and a reader cannot tell apart from a bug.
-  \subsection{Usage}{
-    \if{html}{\out{<div class="r">}}
-    \preformatted{Ggplot2PieLayerProcessor$find_wedge_container(grob)}
-    \if{html}{\out{</div>}}
-  }
-  \subsection{Arguments}{
-    \if{html}{\out{<div class="arguments">}}
-    \describe{
-      \item{\code{grob}}{Grob to search}
     }
     \if{html}{\out{</div>}}
   }

--- a/man/Ggplot2PieLayerProcessor.Rd
+++ b/man/Ggplot2PieLayerProcessor.Rd
@@ -4,11 +4,6 @@
 \alias{Ggplot2PieLayerProcessor}
 \title{Pie Layer Processor}
 \description{
-Pie Layer Processor
-
-Pie Layer Processor
-}
-\details{
 Processes the ggplot2 idiom for a pie chart: a \code{geom_col()} /
 \code{geom_bar()} layer drawn in polar coordinates with theta mapped to y,
 so the stack's segments become wedges. The payload is 1-D and flat -- one
@@ -25,47 +20,52 @@ declines them, and they stay bar / stacked / dodged as before.
 }
 \keyword{internal}
 \section{Super class}{
-\code{\link[maidr:LayerProcessor]{maidr::LayerProcessor}} -> \code{Ggplot2PieLayerProcessor}
+\code{\link[maidr:LayerProcessor]{LayerProcessor}} -> \code{Ggplot2PieLayerProcessor}
 }
 \section{Methods}{
 \subsection{Public methods}{
-\itemize{
-\item \href{#method-Ggplot2PieLayerProcessor-process}{\code{Ggplot2PieLayerProcessor$process()}}
-\item \href{#method-Ggplot2PieLayerProcessor-extract_data}{\code{Ggplot2PieLayerProcessor$extract_data()}}
-\item \href{#method-Ggplot2PieLayerProcessor-panel_built_data}{\code{Ggplot2PieLayerProcessor$panel_built_data()}}
-\item \href{#method-Ggplot2PieLayerProcessor-resolve_slice_mapping}{\code{Ggplot2PieLayerProcessor$resolve_slice_mapping()}}
-\item \href{#method-Ggplot2PieLayerProcessor-resolve_slice_labels}{\code{Ggplot2PieLayerProcessor$resolve_slice_labels()}}
-\item \href{#method-Ggplot2PieLayerProcessor-slice_categories}{\code{Ggplot2PieLayerProcessor$slice_categories()}}
-\item \href{#method-Ggplot2PieLayerProcessor-scale_labels}{\code{Ggplot2PieLayerProcessor$scale_labels()}}
-\item \href{#method-Ggplot2PieLayerProcessor-extract_pie_axes}{\code{Ggplot2PieLayerProcessor$extract_pie_axes()}}
-\item \href{#method-Ggplot2PieLayerProcessor-generate_selectors}{\code{Ggplot2PieLayerProcessor$generate_selectors()}}
-\item \href{#method-Ggplot2PieLayerProcessor-find_polygon_grob}{\code{Ggplot2PieLayerProcessor$find_polygon_grob()}}
-\item \href{#method-Ggplot2PieLayerProcessor-clone}{\code{Ggplot2PieLayerProcessor$clone()}}
+  \itemize{
+    \item \href{#method-Ggplot2PieLayerProcessor-process}{\code{Ggplot2PieLayerProcessor$process()}}
+    \item \href{#method-Ggplot2PieLayerProcessor-extract_data}{\code{Ggplot2PieLayerProcessor$extract_data()}}
+    \item \href{#method-Ggplot2PieLayerProcessor-panel_built_data}{\code{Ggplot2PieLayerProcessor$panel_built_data()}}
+    \item \href{#method-Ggplot2PieLayerProcessor-resolve_slice_mapping}{\code{Ggplot2PieLayerProcessor$resolve_slice_mapping()}}
+    \item \href{#method-Ggplot2PieLayerProcessor-resolve_slice_labels}{\code{Ggplot2PieLayerProcessor$resolve_slice_labels()}}
+    \item \href{#method-Ggplot2PieLayerProcessor-slice_categories}{\code{Ggplot2PieLayerProcessor$slice_categories()}}
+    \item \href{#method-Ggplot2PieLayerProcessor-scale_labels}{\code{Ggplot2PieLayerProcessor$scale_labels()}}
+    \item \href{#method-Ggplot2PieLayerProcessor-extract_pie_axes}{\code{Ggplot2PieLayerProcessor$extract_pie_axes()}}
+    \item \href{#method-Ggplot2PieLayerProcessor-generate_selectors}{\code{Ggplot2PieLayerProcessor$generate_selectors()}}
+    \item \href{#method-Ggplot2PieLayerProcessor-find_polygon_grob}{\code{Ggplot2PieLayerProcessor$find_polygon_grob()}}
+    \item \href{#method-Ggplot2PieLayerProcessor-find_named_polygon_grob}{\code{Ggplot2PieLayerProcessor$find_named_polygon_grob()}}
+    \item \href{#method-Ggplot2PieLayerProcessor-find_wedge_container}{\code{Ggplot2PieLayerProcessor$find_wedge_container()}}
+    \item \href{#method-Ggplot2PieLayerProcessor-holds_polygon}{\code{Ggplot2PieLayerProcessor$holds_polygon()}}
+    \item \href{#method-Ggplot2PieLayerProcessor-clone}{\code{Ggplot2PieLayerProcessor$clone()}}
+  }
 }
-}
-\if{html}{\out{
-<details><summary>Inherited methods</summary>
+\if{html}{\out{<details><summary>Inherited methods</summary>
 <ul>
-<li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="apply_scale_mapping"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-apply_scale_mapping'><code>maidr::LayerProcessor$apply_scale_mapping()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="augment_plot"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-augment_plot'><code>maidr::LayerProcessor$augment_plot()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="extract_layer_axes"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-extract_layer_axes'><code>maidr::LayerProcessor$extract_layer_axes()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="get_last_result"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-get_last_result'><code>maidr::LayerProcessor$get_last_result()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="get_layer_index"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-get_layer_index'><code>maidr::LayerProcessor$get_layer_index()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="initialize"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-initialize'><code>maidr::LayerProcessor$initialize()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="needs_augmentation"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-needs_augmentation'><code>maidr::LayerProcessor$needs_augmentation()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="needs_reordering"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-needs_reordering'><code>maidr::LayerProcessor$needs_reordering()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="reorder_layer_data"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-reorder_layer_data'><code>maidr::LayerProcessor$reorder_layer_data()</code></a></span></li>
-<li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="set_last_result"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-set_last_result'><code>maidr::LayerProcessor$set_last_result()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="apply_scale_mapping"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-apply_scale_mapping'><code>LayerProcessor$apply_scale_mapping()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="augment_plot"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-augment_plot'><code>LayerProcessor$augment_plot()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="extract_layer_axes"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-extract_layer_axes'><code>LayerProcessor$extract_layer_axes()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="find_layer_grob_tree"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-find_layer_grob_tree'><code>LayerProcessor$find_layer_grob_tree()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="get_last_result"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-get_last_result'><code>LayerProcessor$get_last_result()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="get_layer_built_data"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-get_layer_built_data'><code>LayerProcessor$get_layer_built_data()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="get_layer_index"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-get_layer_index'><code>LayerProcessor$get_layer_index()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="get_own_layer"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-get_own_layer'><code>LayerProcessor$get_own_layer()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="initialize"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-initialize'><code>LayerProcessor$initialize()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="needs_augmentation"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-needs_augmentation'><code>LayerProcessor$needs_augmentation()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="needs_reordering"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-needs_reordering'><code>LayerProcessor$needs_reordering()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="reorder_layer_data"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-reorder_layer_data'><code>LayerProcessor$reorder_layer_data()</code></a></span></li>
+  <li><span class="pkg-link" data-pkg="maidr" data-topic="LayerProcessor" data-id="set_last_result"><a href='../../maidr/html/LayerProcessor.html#method-LayerProcessor-set_last_result'><code>LayerProcessor$set_last_result()</code></a></span></li>
 </ul>
-</details>
-}}
+</details>}}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Ggplot2PieLayerProcessor-process"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2PieLayerProcessor-process}{}}}
-\subsection{Method \code{process()}}{
-Process the pie layer
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Ggplot2PieLayerProcessor$process(
+\subsection{\code{Ggplot2PieLayerProcessor$process()}}{
+  Process the pie layer
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Ggplot2PieLayerProcessor$process(
   plot,
   layout,
   built = NULL,
@@ -74,39 +74,33 @@ Process the pie layer
   grob_id = NULL,
   panel_id = NULL,
   panel_ctx = NULL
-)}\if{html}{\out{</div>}}
+)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{plot}}{The ggplot2 object}
+      \item{\code{layout}}{Layout information}
+      \item{\code{built}}{Built plot data (optional)}
+      \item{\code{gt}}{Gtable object (optional)}
+      \item{\code{scale_mapping}}{Scale mapping for faceted plots (optional)}
+      \item{\code{grob_id}}{Grob ID for faceted plots (optional)}
+      \item{\code{panel_id}}{Panel ID for faceted plots (optional)}
+      \item{\code{panel_ctx}}{Panel context for panel-scoped selectors (optional)}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List with data, selectors, title, axes and type
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{plot}}{The ggplot2 object}
-
-\item{\code{layout}}{Layout information}
-
-\item{\code{built}}{Built plot data (optional)}
-
-\item{\code{gt}}{Gtable object (optional)}
-
-\item{\code{scale_mapping}}{Scale mapping for faceted plots (optional)}
-
-\item{\code{grob_id}}{Grob ID for faceted plots (optional)}
-
-\item{\code{panel_id}}{Panel ID for faceted plots (optional)}
-
-\item{\code{panel_ctx}}{Panel context for panel-scoped selectors (optional)}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-List with data, selectors, title, axes and type
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Ggplot2PieLayerProcessor-extract_data"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2PieLayerProcessor-extract_data}{}}}
-\subsection{Method \code{extract_data()}}{
-Extract one point per wedge
+\subsection{\code{Ggplot2PieLayerProcessor$extract_data()}}{
+  Extract one point per wedge
 
 The magnitude is the segment's own extent, not the stacked \code{y}:
 \code{ymax - ymin} is what the wedge actually subtends, and it is the
@@ -127,80 +121,82 @@ percentage; laundering it here would leave that defence nothing to
 catch. Whether a producer should reject such a value outright is a
 separate question -- see xability/maidr#771 -- but no answer to it is
 served by destroying the sign first.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Ggplot2PieLayerProcessor$extract_data(plot, built = NULL, panel_id = NULL)}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Ggplot2PieLayerProcessor$extract_data(plot, built = NULL, panel_id = NULL)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{plot}}{The ggplot2 object}
+      \item{\code{built}}{Built plot data (optional)}
+      \item{\code{panel_id}}{Optional facet panel to restrict extraction to}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of \code{list(x, y)} points, one per wedge
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{plot}}{The ggplot2 object}
-
-\item{\code{built}}{Built plot data (optional)}
-
-\item{\code{panel_id}}{Optional facet panel to restrict extraction to}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-List of \code{list(x, y)} points, one per wedge
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Ggplot2PieLayerProcessor-panel_built_data"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2PieLayerProcessor-panel_built_data}{}}}
-\subsection{Method \code{panel_built_data()}}{
-Rows of this layer's built data, optionally one panel's
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Ggplot2PieLayerProcessor$panel_built_data(built, panel_id = NULL)}\if{html}{\out{</div>}}
+\subsection{\code{Ggplot2PieLayerProcessor$panel_built_data()}}{
+  Rows of this layer's built data, optionally one panel's
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Ggplot2PieLayerProcessor$panel_built_data(built, panel_id = NULL)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{built}}{Built plot data}
+      \item{\code{panel_id}}{Optional facet panel to restrict the rows to}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    data.frame of built rows for this layer
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{built}}{Built plot data}
-
-\item{\code{panel_id}}{Optional facet panel to restrict the rows to}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-data.frame of built rows for this layer
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Ggplot2PieLayerProcessor-resolve_slice_mapping"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2PieLayerProcessor-resolve_slice_mapping}{}}}
-\subsection{Method \code{resolve_slice_mapping()}}{
-Resolve the aesthetic whose categories name the wedges
+\subsection{\code{Ggplot2PieLayerProcessor$resolve_slice_mapping()}}{
+  Resolve the aesthetic whose categories name the wedges
 
 Fill is probed before x because the idiomatic pie maps x to the literal
 \code{""} and carries the categories on fill. A layer whose built rows
 do not each sit in their own group is not split by any aesthetic (every
 row shares group -1 or 1), so no aesthetic names its wedges.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Ggplot2PieLayerProcessor$resolve_slice_mapping(plot, built_data)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{plot}}{The ggplot2 object}
-
-\item{\code{built_data}}{This layer's built rows}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-list with \code{aes} (aesthetic name, or NULL) and
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Ggplot2PieLayerProcessor$resolve_slice_mapping(plot, built_data)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{plot}}{The ggplot2 object}
+      \item{\code{built_data}}{This layer's built rows}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    list with \code{aes} (aesthetic name, or NULL) and
 \code{column} (the mapped column name)
+  }
 }
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Ggplot2PieLayerProcessor-resolve_slice_labels"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2PieLayerProcessor-resolve_slice_labels}{}}}
-\subsection{Method \code{resolve_slice_labels()}}{
-Name each wedge after the category it draws
+\subsection{\code{Ggplot2PieLayerProcessor$resolve_slice_labels()}}{
+  Name each wedge after the category it draws
 
 \code{ggplot_build()} has already replaced the grouping column with
 integer group ids, assigned in the sorted order of that column's
@@ -209,30 +205,30 @@ labels BY the id, rather than by position among the ids present, is
 what stops a facet panel that is missing a category from shifting every
 remaining wedge's label by one. Wedges the scale cannot name fall back
 to their position.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Ggplot2PieLayerProcessor$resolve_slice_labels(plot, built, built_data)}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Ggplot2PieLayerProcessor$resolve_slice_labels(plot, built, built_data)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{plot}}{The ggplot2 object}
+      \item{\code{built}}{Built plot data}
+      \item{\code{built_data}}{This layer's built rows}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Character vector, one label per wedge
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{plot}}{The ggplot2 object}
-
-\item{\code{built}}{Built plot data}
-
-\item{\code{built_data}}{This layer's built rows}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-Character vector, one label per wedge
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Ggplot2PieLayerProcessor-slice_categories"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2PieLayerProcessor-slice_categories}{}}}
-\subsection{Method \code{slice_categories()}}{
-Categories of the aesthetic that splits the wedges
+\subsection{\code{Ggplot2PieLayerProcessor$slice_categories()}}{
+  Categories of the aesthetic that splits the wedges
 
 The scale is asked first, because a mapping written as an expression --
 \code{aes(fill = factor(cyl))} -- has no column to read. A discrete
@@ -240,52 +236,53 @@ POSITION scale keeps its labels in \code{panel_params} instead, and
 \code{coord_polar()} publishes none of those under x, so the mapped
 column is the fallback. Both list the categories in the same sorted
 order the group ids were assigned in.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Ggplot2PieLayerProcessor$slice_categories(plot, built, slice)}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Ggplot2PieLayerProcessor$slice_categories(plot, built, slice)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{plot}}{The ggplot2 object}
+      \item{\code{built}}{Built plot data}
+      \item{\code{slice}}{Slice mapping from \code{resolve_slice_mapping()}}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Character vector of categories, or NULL when neither source has any
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{plot}}{The ggplot2 object}
-
-\item{\code{built}}{Built plot data}
-
-\item{\code{slice}}{Slice mapping from \code{resolve_slice_mapping()}}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-Character vector of categories, or NULL when neither source has any
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Ggplot2PieLayerProcessor-scale_labels"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2PieLayerProcessor-scale_labels}{}}}
-\subsection{Method \code{scale_labels()}}{
-Break labels of the scale backing an aesthetic
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Ggplot2PieLayerProcessor$scale_labels(built, aes_name)}\if{html}{\out{</div>}}
+\subsection{\code{Ggplot2PieLayerProcessor$scale_labels()}}{
+  Break labels of the scale backing an aesthetic
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Ggplot2PieLayerProcessor$scale_labels(built, aes_name)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{built}}{Built plot data}
+      \item{\code{aes_name}}{Aesthetic whose scale to read}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Character vector of labels, or NULL when the scale has none
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{built}}{Built plot data}
-
-\item{\code{aes_name}}{Aesthetic whose scale to read}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-Character vector of labels, or NULL when the scale has none
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Ggplot2PieLayerProcessor-extract_pie_axes"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2PieLayerProcessor-extract_pie_axes}{}}}
-\subsection{Method \code{extract_pie_axes()}}{
-Build the canonical axes for a pie layer
+\subsection{\code{Ggplot2PieLayerProcessor$extract_pie_axes()}}{
+  Build the canonical axes for a pie layer
 
 \code{x} names what the wedge labels mean and \code{y} what their
 magnitudes measure. Since the labels come off the slice aesthetic, its
@@ -293,32 +290,31 @@ legend title is the x label -- resolved the same way the stacked bar
 layer resolves its z label. The y label is taken from the layout, which
 reads the BUILT plot's labels and so already carries a stat-derived
 name such as "count".
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Ggplot2PieLayerProcessor$extract_pie_axes(plot, layout, built, panel_id = NULL)}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Ggplot2PieLayerProcessor$extract_pie_axes(plot, layout, built, panel_id = NULL)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{plot}}{The ggplot2 object}
+      \item{\code{layout}}{Layout information}
+      \item{\code{built}}{Built plot data}
+      \item{\code{panel_id}}{Optional facet panel to restrict extraction to}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Canonical axes list with x and y
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{plot}}{The ggplot2 object}
-
-\item{\code{layout}}{Layout information}
-
-\item{\code{built}}{Built plot data}
-
-\item{\code{panel_id}}{Optional facet panel to restrict extraction to}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-Canonical axes list with x and y
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Ggplot2PieLayerProcessor-generate_selectors"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2PieLayerProcessor-generate_selectors}{}}}
-\subsection{Method \code{generate_selectors()}}{
-Generate the wedge selector for this layer
+\subsection{\code{Ggplot2PieLayerProcessor$generate_selectors()}}{
+  Generate the wedge selector for this layer
 
 In polar coordinates the whole layer is ONE \code{polygonGrob} named
 \code{geom_rect.polygon.<N>} whose sub-polygons are grouped by
@@ -327,64 +323,135 @@ draws. gridSVG exports it as \code{<g id="geom_rect.polygon.<N>.1">}
 with one \code{<polygon>} child per wedge, emitted in built-row order,
 so a single descendant selector resolves to the N elements in slice
 order.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Ggplot2PieLayerProcessor$generate_selectors(plot, gt = NULL, panel_ctx = NULL)}\if{html}{\out{</div>}}
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Ggplot2PieLayerProcessor$generate_selectors(plot, gt = NULL, panel_ctx = NULL)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{plot}}{The ggplot2 object}
+      \item{\code{gt}}{Gtable object (optional)}
+      \item{\code{panel_ctx}}{Panel context for panel-scoped selectors (optional)}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List holding one selector, or an empty list
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{plot}}{The ggplot2 object}
-
-\item{\code{gt}}{Gtable object (optional)}
-
-\item{\code{panel_ctx}}{Panel context for panel-scoped selectors (optional)}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-List holding one selector, or an empty list
-}
-}
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Ggplot2PieLayerProcessor-find_polygon_grob"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2PieLayerProcessor-find_polygon_grob}{}}}
-\subsection{Method \code{find_polygon_grob()}}{
-Find this layer's wedge polygon grob within a grob tree
-
-Matches on the \code{geom_rect.polygon} prefix, which the polar grill's
-own polygon (named \code{GRID.polygon.<N>} under \code{coord_radial()})
-does not carry.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Ggplot2PieLayerProcessor$find_polygon_grob(grob)}\if{html}{\out{</div>}}
+\subsection{\code{Ggplot2PieLayerProcessor$find_polygon_grob()}}{
+  
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Ggplot2PieLayerProcessor$find_polygon_grob(grob)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{grob}}{Grob to search}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Grob name, or NULL when the tree holds none
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{grob}}{Grob to search}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Ggplot2PieLayerProcessor-find_named_polygon_grob"></a>}}
+\if{latex}{\out{\hypertarget{method-Ggplot2PieLayerProcessor-find_named_polygon_grob}{}}}
+\subsection{\code{Ggplot2PieLayerProcessor$find_named_polygon_grob()}}{
+  Find a single grob holding every wedge, if there is one.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Ggplot2PieLayerProcessor$find_named_polygon_grob(grob)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{grob}}{Grob to search}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Grob name, or NULL
+  }
 }
-\if{html}{\out{</div>}}
+
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Ggplot2PieLayerProcessor-find_wedge_container"></a>}}
+\if{latex}{\out{\hypertarget{method-Ggplot2PieLayerProcessor-find_wedge_container}{}}}
+\subsection{\code{Ggplot2PieLayerProcessor$find_wedge_container()}}{
+  Find the layer tree whose polygon children are the wedges.
+
+Requires the tree to actually hold a polygon. A \code{geom_rect} gTree
+that drew none is a layer with nothing to point at, and naming it would
+emit a selector resolving to nothing -- which the caller cannot tell
+apart from a working one, and a reader cannot tell apart from a bug.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Ggplot2PieLayerProcessor$find_wedge_container(grob)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{grob}}{Grob to search}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Grob name, or NULL
+  }
 }
-\subsection{Returns}{
-Grob name, or NULL when the tree holds none
+
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Ggplot2PieLayerProcessor-holds_polygon"></a>}}
+\if{latex}{\out{\hypertarget{method-Ggplot2PieLayerProcessor-holds_polygon}{}}}
+\subsection{\code{Ggplot2PieLayerProcessor$holds_polygon()}}{
+  Whether a grob tree draws at least one polygon.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Ggplot2PieLayerProcessor$holds_polygon(grob)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{grob}}{Grob to search}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    TRUE when the tree holds a polygon grob
+  }
 }
-}
+
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Ggplot2PieLayerProcessor-clone"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2PieLayerProcessor-clone}{}}}
-\subsection{Method \code{clone()}}{
-The objects of this class are cloneable with this method.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Ggplot2PieLayerProcessor$clone(deep = FALSE)}\if{html}{\out{</div>}}
+\subsection{\code{Ggplot2PieLayerProcessor$clone()}}{
+  The objects of this class are cloneable with this method.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Ggplot2PieLayerProcessor$clone(deep = FALSE)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{deep}}{Whether to make a deep clone.}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{deep}}{Whether to make a deep clone.}
-}
-\if{html}{\out{</div>}}
-}
-}
 }

--- a/man/Ggplot2PieLayerProcessor.Rd
+++ b/man/Ggplot2PieLayerProcessor.Rd
@@ -34,6 +34,9 @@ declines them, and they stay bar / stacked / dodged as before.
     \item \href{#method-Ggplot2PieLayerProcessor-scale_labels}{\code{Ggplot2PieLayerProcessor$scale_labels()}}
     \item \href{#method-Ggplot2PieLayerProcessor-extract_pie_axes}{\code{Ggplot2PieLayerProcessor$extract_pie_axes()}}
     \item \href{#method-Ggplot2PieLayerProcessor-generate_selectors}{\code{Ggplot2PieLayerProcessor$generate_selectors()}}
+    \item \href{#method-Ggplot2PieLayerProcessor-resolve_layer_polygon_grob}{\code{Ggplot2PieLayerProcessor$resolve_layer_polygon_grob()}}
+    \item \href{#method-Ggplot2PieLayerProcessor-collect_polygon_grobs}{\code{Ggplot2PieLayerProcessor$collect_polygon_grobs()}}
+    \item \href{#method-Ggplot2PieLayerProcessor-find_own_polygon_grob}{\code{Ggplot2PieLayerProcessor$find_own_polygon_grob()}}
     \item \href{#method-Ggplot2PieLayerProcessor-find_polygon_grob}{\code{Ggplot2PieLayerProcessor$find_polygon_grob()}}
     \item \href{#method-Ggplot2PieLayerProcessor-find_named_polygon_grob}{\code{Ggplot2PieLayerProcessor$find_named_polygon_grob()}}
     \item \href{#method-Ggplot2PieLayerProcessor-find_wedge_container}{\code{Ggplot2PieLayerProcessor$find_wedge_container()}}
@@ -343,13 +346,61 @@ order.
 }
 
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Ggplot2PieLayerProcessor-find_polygon_grob"></a>}}
-\if{latex}{\out{\hypertarget{method-Ggplot2PieLayerProcessor-find_polygon_grob}{}}}
-\subsection{\code{Ggplot2PieLayerProcessor$find_polygon_grob()}}{
+\if{html}{\out{<a id="method-Ggplot2PieLayerProcessor-resolve_layer_polygon_grob"></a>}}
+\if{latex}{\out{\hypertarget{method-Ggplot2PieLayerProcessor-resolve_layer_polygon_grob}{}}}
+\subsection{\code{Ggplot2PieLayerProcessor$resolve_layer_polygon_grob()}}{
   
+
+
+  Pick the wedge container belonging to \emph{this} layer
+
+A panel can hold more than one polar \code{geom_rect} layer -- two
+\code{geom_col()}s under \code{coord_polar()} is an ordinary way to
+draw a ring over a pie -- and a search that takes the first match
+hands every layer the first layer's wedges. Those selectors resolve,
+and the payload looks healthy, and the outline is on the wrong marks.
+
+\code{LayerProcessor$find_layer_grob_tree()} cannot be reused for
+this: it matches on the geom's own class, and a \code{geom_col()}
+layer is \code{GeomCol} while the grob it draws is named after
+\code{geom_rect}. So the containers are collected in drawing order --
+which is layer order -- and indexed.
+
+When the counts do not line up the answer is no selector rather than
+a guess, for the reason \code{generate_selectors()} already gives: a
+wrong selector highlights another layer's wedges, and the caller can
+tell an empty list from a wrong one where a reader cannot.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{Ggplot2PieLayerProcessor$find_polygon_grob(grob)}
+    \preformatted{Ggplot2PieLayerProcessor$resolve_layer_polygon_grob(plot, roots)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{plot}}{The ggplot2 object, or NULL when the caller has none}
+      \item{\code{roots}}{Grobs to search, in drawing order}
+      \item{\code{grob}}{Grob to search}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Grob name, or NULL when the tree holds none
+  }
+}
+
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Ggplot2PieLayerProcessor-collect_polygon_grobs"></a>}}
+\if{latex}{\out{\hypertarget{method-Ggplot2PieLayerProcessor-collect_polygon_grobs}{}}}
+\subsection{\code{Ggplot2PieLayerProcessor$collect_polygon_grobs()}}{
+  Every wedge container in a grob tree, in drawing order
+
+One entry per layer that drew wedges. A match is not descended into:
+the container is the whole layer's wedges, and its children are the
+individual ones.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Ggplot2PieLayerProcessor$collect_polygon_grobs(grob)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
@@ -360,7 +411,40 @@ order.
     \if{html}{\out{</div>}}
   }
   \subsection{Returns}{
-    Grob name, or NULL when the tree holds none
+    Character vector of grob names, possibly empty
+  }
+}
+
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Ggplot2PieLayerProcessor-find_own_polygon_grob"></a>}}
+\if{latex}{\out{\hypertarget{method-Ggplot2PieLayerProcessor-find_own_polygon_grob}{}}}
+\subsection{\code{Ggplot2PieLayerProcessor$find_own_polygon_grob()}}{
+  Whether this grob is itself a wedge container
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Ggplot2PieLayerProcessor$find_own_polygon_grob(grob)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{grob}}{Grob to test}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Grob name, or NULL
+  }
+}
+
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Ggplot2PieLayerProcessor-find_polygon_grob"></a>}}
+\if{latex}{\out{\hypertarget{method-Ggplot2PieLayerProcessor-find_polygon_grob}{}}}
+\subsection{\code{Ggplot2PieLayerProcessor$find_polygon_grob()}}{
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Ggplot2PieLayerProcessor$find_polygon_grob(grob)}
+    \if{html}{\out{</div>}}
   }
 }
 

--- a/tests/testthat/test-ggplot2-pie-layer-processor.R
+++ b/tests/testthat/test-ggplot2-pie-layer-processor.R
@@ -813,12 +813,15 @@ test_that("two polar layers in one panel address different wedges", {
   testthat::expect_false(identical(selectors[[1]], selectors[[2]]))
 })
 
-test_that("an ambiguous panel gets no selector rather than a guess", {
+test_that("a label layer costs the rings nothing", {
   skip_if_no_ggplot2()
 
-  # Two containers and three layers: the drawing order no longer says which
-  # container belongs to which layer, and the third layer drew no wedges. A
-  # positional guess here lands on another layer's marks.
+  # Two rings and a geom_text() label layer. Counting containers against
+  # layers -- two of one, three of the other -- made this look ambiguous and
+  # took the selectors away from BOTH rings, though the correspondence is
+  # perfectly well defined: the text layer occupies a slot and draws no
+  # container. Slots are what the panel actually offers, so they are what is
+  # counted.
   df <- data.frame(fruit = c("Apples", "Bananas", "Cherries"), n = c(3, 5, 2))
   p <- ggplot2::ggplot(df, ggplot2::aes(x = "", y = n, fill = fruit)) +
     ggplot2::geom_col() +
@@ -827,7 +830,39 @@ test_that("an ambiguous panel gets no selector rather than a guess", {
     ggplot2::coord_polar("y")
   gt <- ggplot2::ggplot_gtable(ggplot2::ggplot_build(p))
 
-  processor <- maidr:::Ggplot2PieLayerProcessor$new(list(index = 1))
+  selectors <- lapply(seq_len(3), function(index) {
+    maidr:::Ggplot2PieLayerProcessor$new(
+      list(index = index)
+    )$generate_selectors(p, gt)
+  })
 
-  testthat::expect_equal(processor$generate_selectors(p, gt), list())
+  testthat::expect_length(selectors[[1]], 1L)
+  testthat::expect_length(selectors[[2]], 1L)
+  testthat::expect_false(identical(selectors[[1]], selectors[[2]]))
+  # The label layer drew no wedges, and must not be handed a ring's.
+  testthat::expect_equal(selectors[[3]], list())
+})
+
+test_that("a layer that drew nothing is not handed another layer's wedges", {
+  skip_if_no_ggplot2()
+
+  # The label layer first, so the one container in the panel is NOT in its
+  # slot. A search that fell back whenever the slot held no container would
+  # hand it the pie's wedges -- resolving, healthy-looking, and wrong.
+  df <- data.frame(fruit = c("Apples", "Bananas", "Cherries"), n = c(3, 5, 2))
+  p <- ggplot2::ggplot(df, ggplot2::aes(x = "", y = n, fill = fruit)) +
+    ggplot2::geom_text(ggplot2::aes(label = fruit), position = "stack") +
+    ggplot2::geom_col() +
+    ggplot2::coord_polar("y")
+  gt <- ggplot2::ggplot_gtable(ggplot2::ggplot_build(p))
+
+  first <- maidr:::Ggplot2PieLayerProcessor$new(
+    list(index = 1)
+  )$generate_selectors(p, gt)
+  second <- maidr:::Ggplot2PieLayerProcessor$new(
+    list(index = 2)
+  )$generate_selectors(p, gt)
+
+  testthat::expect_equal(first, list())
+  testthat::expect_length(second, 1L)
 })

--- a/tests/testthat/test-ggplot2-pie-layer-processor.R
+++ b/tests/testthat/test-ggplot2-pie-layer-processor.R
@@ -121,6 +121,24 @@ test_that("Ggplot2PieLayerProcessor handles a zero-row layer", {
     ggplot2::geom_col() +
     ggplot2::coord_polar("y")
 
+  # Some ggplot2 versions cannot build this plot at all -- 3.4.4 raises
+  # "replacement has length zero" from `expand_limits_discrete_trans()`,
+  # with or without the polar coord. That is upstream and reproduces on a
+  # bare `ggplot_build()` with no maidr in the picture, so there is nothing
+  # here for this processor to get right or wrong. Skipped by asking the
+  # question rather than by naming a version, because the version this was
+  # fixed in has not been bisected.
+  built <- tryCatch(
+    suppressWarnings(ggplot2::ggplot_build(p)),
+    error = function(condition) condition
+  )
+  if (inherits(built, "error")) {
+    testthat::skip(paste0(
+      "ggplot2 ", as.character(utils::packageVersion("ggplot2")),
+      " cannot build a zero-row discrete-x plot: ", conditionMessage(built)
+    ))
+  }
+
   processor <- maidr:::Ggplot2PieLayerProcessor$new(list(index = 1))
   data <- suppressWarnings(processor$extract_data(p))
 
@@ -585,9 +603,16 @@ test_that("Ggplot2PieLayerProcessor takes a stat-derived y label from the layout
 test_that("Ggplot2PieLayerProcessor selects the polygon grob, not the rect grob", {
   skip_if_no_ggplot2()
 
-  # In polar coordinates the whole layer is one polygonGrob whose sub-polygons
-  # are grouped by id; the geom_rect.rect.<N> the cartesian bar layers look
-  # for is never drawn.
+  # In polar coordinates the wedges are polygons; the geom_rect.rect.<N> the
+  # cartesian bar layers look for is never drawn.
+  #
+  # Which polygon grob depends on the ggplot2 version, and the difference is
+  # why #151 existed. Some versions draw one `geom_rect.polygon.<N>` holding
+  # every wedge grouped by id; ggplot2 3.4.4 draws a `geom_rect.gTree.<N>`
+  # holding one `geom_polygon.polygon.<N>` per wedge, and nothing named
+  # `geom_rect.polygon` anywhere. Either is a container whose `<polygon>`
+  # descendants are the wedges, which is what the selector addresses -- so
+  # this asserts the shape both produce rather than the name one of them has.
   p <- fruit_pie()
   gt <- ggplot2::ggplot_gtable(ggplot2::ggplot_build(p))
 
@@ -595,7 +620,28 @@ test_that("Ggplot2PieLayerProcessor selects the polygon grob, not the rect grob"
   selectors <- processor$generate_selectors(p, gt)
 
   testthat::expect_length(selectors, 1L)
-  testthat::expect_match(selectors[[1]], "^#geom_rect\\\\\\.polygon\\\\\\.[0-9]+\\\\\\.1 polygon$")
+  testthat::expect_match(
+    selectors[[1]],
+    "^#geom_rect\\\\\\.(polygon|gTree)\\\\\\.[0-9]+\\\\\\.1 polygon$"
+  )
+})
+
+test_that("a pie whose layer drew nothing gets no selector", {
+  skip_if_no_ggplot2()
+
+  # The gTree branch must require a polygon rather than settle for the tree.
+  # A `geom_rect` layer that drew no wedges has nothing to point at, and
+  # naming its tree would emit a selector resolving to nothing -- which the
+  # caller cannot tell from a working one.
+  p <- ggplot2::ggplot(
+    data.frame(fruit = c("Apples", "Bananas"), n = c(3, 5)),
+    ggplot2::aes(fruit, n)
+  ) + ggplot2::geom_point()
+  gt <- ggplot2::ggplot_gtable(ggplot2::ggplot_build(p))
+
+  processor <- maidr:::Ggplot2PieLayerProcessor$new(list(index = 1))
+
+  testthat::expect_equal(processor$generate_selectors(p, gt), list())
 })
 
 test_that("Ggplot2PieLayerProcessor scopes its selector to a facet panel", {

--- a/tests/testthat/test-ggplot2-pie-layer-processor.R
+++ b/tests/testthat/test-ggplot2-pie-layer-processor.R
@@ -786,3 +786,48 @@ test_that("the negative reaches the emitted payload, not just extract_data", {
 
   expect_match(html, "-40")
 })
+
+test_that("two polar layers in one panel address different wedges", {
+  skip_if_no_ggplot2()
+
+  # A ring drawn over a pie is two geom_col() layers under one coord_polar(),
+  # and a search that takes the first container hands both of them the first
+  # layer's wedges. Those selectors resolve, and the payload looks healthy,
+  # and the outline sits on the wrong marks -- which is worse than the empty
+  # list this issue was about.
+  df <- data.frame(fruit = c("Apples", "Bananas", "Cherries"), n = c(3, 5, 2))
+  p <- ggplot2::ggplot(df, ggplot2::aes(x = "", y = n, fill = fruit)) +
+    ggplot2::geom_col() +
+    ggplot2::geom_col(alpha = 0.3) +
+    ggplot2::coord_polar("y")
+  gt <- ggplot2::ggplot_gtable(ggplot2::ggplot_build(p))
+
+  selectors <- lapply(seq_len(2), function(index) {
+    maidr:::Ggplot2PieLayerProcessor$new(
+      list(index = index)
+    )$generate_selectors(p, gt)
+  })
+
+  testthat::expect_length(selectors[[1]], 1L)
+  testthat::expect_length(selectors[[2]], 1L)
+  testthat::expect_false(identical(selectors[[1]], selectors[[2]]))
+})
+
+test_that("an ambiguous panel gets no selector rather than a guess", {
+  skip_if_no_ggplot2()
+
+  # Two containers and three layers: the drawing order no longer says which
+  # container belongs to which layer, and the third layer drew no wedges. A
+  # positional guess here lands on another layer's marks.
+  df <- data.frame(fruit = c("Apples", "Bananas", "Cherries"), n = c(3, 5, 2))
+  p <- ggplot2::ggplot(df, ggplot2::aes(x = "", y = n, fill = fruit)) +
+    ggplot2::geom_col() +
+    ggplot2::geom_col(alpha = 0.3) +
+    ggplot2::geom_text(ggplot2::aes(label = fruit), position = "stack") +
+    ggplot2::coord_polar("y")
+  gt <- ggplot2::ggplot_gtable(ggplot2::ggplot_build(p))
+
+  processor <- maidr:::Ggplot2PieLayerProcessor$new(list(index = 1))
+
+  testthat::expect_equal(processor$generate_selectors(p, gt), list())
+})

--- a/tests/testthat/test-pie-selectors.R
+++ b/tests/testthat/test-pie-selectors.R
@@ -1,0 +1,141 @@
+# Pie selectors against the SVG they are meant to address (issue #151).
+#
+# The processor's own tests assert the selector string. This renders the whole
+# pipeline and asks the exported document whether that string finds the
+# wedges, which is the question the string exists to answer.
+#
+# It is the test that was missing. `generate_selectors()` returned an empty
+# list on ggplot2 3.4.4 -- a polar bar layer draws one `geom_polygon.polygon`
+# grob per wedge inside a `geom_rect.gTree`, where the lookup wanted a single
+# `geom_rect.polygon` -- so a pie highlighted nothing at all, while every
+# assertion about what a reader *hears* passed. Nine tests failed and were
+# recorded as "pre-existing" through two pull requests, because nothing said
+# which defect they were.
+
+skip_if_no_export <- function() {
+  testthat::skip_if_not_installed("ggplot2")
+  testthat::skip_if_not_installed("gridSVG")
+  testthat::skip_if_not_installed("xml2")
+  testthat::skip_if_not_installed("jsonlite")
+}
+
+#: Three wedges of visibly different size, so a selector that resolved to the
+#: wrong container could not coincide with the right one.
+FRUIT <- data.frame(
+  fruit = c("Apples", "Bananas", "Cherries"),
+  units = c(3, 5, 2)
+)
+
+pie_cache <- new.env(parent = emptyenv())
+
+pie_render <- function(plot, key) {
+  if (!is.null(pie_cache[[key]])) {
+    return(pie_cache[[key]])
+  }
+
+  file <- tempfile(fileext = ".html")
+  on.exit(unlink(file), add = TRUE)
+  suppressWarnings(save_html(plot, file))
+  html <- paste(readLines(file, warn = FALSE), collapse = "\n")
+
+  raw <- regmatches(
+    html, gregexpr('maidr-data="([^"]*)"', html, perl = TRUE)
+  )[[1]]
+  testthat::expect_gt(length(raw), 0)
+
+  json <- sub('"$', "", sub('^maidr-data="', "", raw[1]))
+  json <- gsub("&quot;", '"', json, fixed = TRUE)
+  json <- gsub("&lt;", "<", json, fixed = TRUE)
+  json <- gsub("&gt;", ">", json, fixed = TRUE)
+  json <- gsub("&amp;", "&", json, fixed = TRUE)
+
+  out <- list(data = jsonlite::fromJSON(json, simplifyVector = FALSE),
+              doc = xml2::read_html(html))
+  assign(key, out, envir = pie_cache)
+  out
+}
+
+# Resolve `#id descendant` the way a browser would. `selectr` is not a
+# dependency, and the pie emits only this one selector shape.
+pie_resolve <- function(payload, selector) {
+  testthat::expect_true(is.character(selector) && length(selector) == 1L)
+
+  parts <- strsplit(trimws(selector), " +")[[1]]
+  testthat::expect_length(parts, 2L)
+
+  id <- gsub("\\\\", "", sub("^#", "", parts[1]))
+  xml2::xml_find_all(
+    payload$doc,
+    sprintf("//*[@id='%s']//*[local-name()='%s']", id, parts[2])
+  )
+}
+
+pie_plot <- function() {
+  ggplot2::ggplot(FRUIT, ggplot2::aes(x = "", y = units, fill = fruit)) +
+    ggplot2::geom_col() +
+    ggplot2::coord_polar("y")
+}
+
+test_that("a pie's selector finds one element per wedge", {
+  skip_if_no_export()
+
+  payload <- pie_render(pie_plot(), "fruit")
+  layer <- payload$data$subplots[[1]][[1]]$layers[[1]]
+
+  testthat::expect_equal(layer$type, "pie")
+  testthat::expect_length(layer$selectors, 1)
+  testthat::expect_length(pie_resolve(payload, layer$selectors[[1]]), nrow(FRUIT))
+})
+
+test_that("the wedges arrive in the order the data was emitted", {
+  skip_if_no_export()
+
+  # The trace pairs element i with slice i, so an element list in another
+  # order highlights the wrong wedge -- silently, since every element it
+  # names is a real wedge. The areas are 3, 5 and 2 of ten, so the drawn
+  # extents pin the pairing.
+  payload <- pie_render(pie_plot(), "fruit")
+  layer <- payload$data$subplots[[1]][[1]]$layers[[1]]
+  nodes <- pie_resolve(payload, layer$selectors[[1]])
+
+  drawn <- vapply(nodes, function(node) {
+    points <- strsplit(trimws(xml2::xml_attr(node, "points")), "\\s+")[[1]]
+    length(points)
+  }, numeric(1))
+  magnitudes <- vapply(layer$data, function(point) as.numeric(point$y), numeric(1))
+
+  # A wider wedge is drawn with more points along its arc.
+  testthat::expect_equal(order(drawn), order(magnitudes))
+  testthat::expect_equal(which.max(drawn), which.max(magnitudes))
+})
+
+test_that("a faceted pie scopes each panel to its own wedges", {
+  skip_if_no_export()
+
+  # The failure this guards is not an empty selector but a shared one: every
+  # panel pointing at the first panel's wedges resolves, and looks healthy.
+  faceted <- rbind(
+    cbind(FRUIT, season = "Summer"),
+    cbind(FRUIT, season = "Winter")
+  )
+  payload <- pie_render(
+    ggplot2::ggplot(faceted, ggplot2::aes(x = "", y = units, fill = fruit)) +
+      ggplot2::geom_col() +
+      ggplot2::coord_polar("y") +
+      ggplot2::facet_wrap(~season),
+    "faceted"
+  )
+
+  layers <- lapply(payload$data$subplots[[1]], function(cell) cell$layers[[1]])
+  testthat::expect_length(layers, 2)
+
+  selectors <- vapply(layers, function(layer) {
+    testthat::expect_length(layer$selectors, 1)
+    layer$selectors[[1]]
+  }, character(1))
+
+  testthat::expect_false(identical(selectors[1], selectors[2]))
+  for (selector in selectors) {
+    testthat::expect_length(pie_resolve(payload, selector), nrow(FRUIT))
+  }
+})

--- a/tests/testthat/test-roxygen-orphans.R
+++ b/tests/testthat/test-roxygen-orphans.R
@@ -22,6 +22,17 @@ r_sources <- function() {
   )
 }
 
+# `R CMD check` runs the tests against an *installed* package, where `R/` holds
+# the lazy-load database rather than the sources -- so there is nothing to read
+# and this says so instead of failing. It runs on `devtools::test()` and
+# `testthat::test_dir()`, which is the loop the mistake is made in.
+skip_without_sources <- function() {
+  testthat::skip_if(
+    length(r_sources()) == 0L,
+    "R/ sources are not shipped with an installed package"
+  )
+}
+
 # Two roxygen blocks in a row: a line that is roxygen, then a line that starts
 # one, with only blank or roxygen-blank lines between. A block ends at the
 # first line that is neither, so anything else in between is code and the two
@@ -60,11 +71,15 @@ orphaned_blocks <- function(path) {
 }
 
 test_that("there are R sources to check", {
+  skip_without_sources()
+
   # A path that stopped resolving would make the case below vacuous.
   testthat::expect_gt(length(r_sources()), 20L)
 })
 
 test_that("no roxygen block carries two descriptions", {
+  skip_without_sources()
+
   reported <- character(0)
   for (path in r_sources()) {
     for (line in orphaned_blocks(path)) {

--- a/tests/testthat/test-roxygen-orphans.R
+++ b/tests/testthat/test-roxygen-orphans.R
@@ -1,0 +1,115 @@
+# No roxygen block may be immediately followed by another.
+#
+# Inserting a method next to a landmark without checking what the landmark is
+# attached to strands the block already there: roxygen glues the two comments
+# together, so the new method inherits the old one's @description, @param and
+# @return, and the old method is left with a bare Usage section naming
+# arguments that belong to something else.
+#
+# `tools::checkRd()` cannot see it -- the generated Rd is valid, it just
+# documents the wrong function. It happened in #152, where
+# `resolve_layer_polygon_grob(plot, roots)` was documented as taking a `grob`,
+# and it took a reviewer reading the man page to notice.
+#
+# The check is on the SOURCE rather than on man/, because man/ is regenerated
+# and this is about what the sources say.
+
+r_sources <- function() {
+  list.files(
+    testthat::test_path("..", "..", "R"),
+    pattern = "\\.R$",
+    full.names = TRUE
+  )
+}
+
+# Two roxygen blocks in a row: a line that is roxygen, then a line that starts
+# one, with only blank or roxygen-blank lines between. A block ends at the
+# first line that is neither, so anything else in between is code and the two
+# are separate blocks.
+orphaned_blocks <- function(path) {
+  lines <- readLines(path, warn = FALSE)
+  is_roxygen <- grepl("^\\s*#'", lines)
+  if (!any(is_roxygen)) {
+    return(integer(0))
+  }
+
+  # A `@description` after the first one in the same block is the signature:
+  # roxygen takes one per object, so a second means two blocks were merged.
+  starts <- which(grepl("^\\s*#'\\s*@description", lines))
+  offenders <- integer(0)
+  for (start in starts) {
+    # Walk back to the top of this contiguous roxygen block.
+    top <- start
+    while (top > 1L && is_roxygen[top - 1L]) {
+      top <- top - 1L
+    }
+    # `seq.int` counts backwards when the ends cross, so an empty range has
+    # to be excluded rather than iterated -- otherwise every block reports
+    # its own first description as a duplicate of itself.
+    if (top >= start) {
+      next
+    }
+    earlier <- which(
+      grepl("^\\s*#'\\s*@description", lines[seq.int(top, start - 1L)])
+    )
+    if (length(earlier) > 0L) {
+      offenders <- c(offenders, start)
+    }
+  }
+  offenders
+}
+
+test_that("there are R sources to check", {
+  # A path that stopped resolving would make the case below vacuous.
+  testthat::expect_gt(length(r_sources()), 20L)
+})
+
+test_that("no roxygen block carries two descriptions", {
+  reported <- character(0)
+  for (path in r_sources()) {
+    for (line in orphaned_blocks(path)) {
+      reported <- c(reported, paste0(basename(path), ":", line))
+    }
+  }
+
+  testthat::expect_equal(reported, character(0))
+})
+
+test_that("the check can see a stranded block", {
+  # Written to a temporary file rather than asserted against a real source,
+  # so the case keeps testing the check after the sources are all clean.
+  path <- tempfile(fileext = ".R")
+  on.exit(unlink(path), add = TRUE)
+  writeLines(
+    c(
+      "    #' @description The first one",
+      "    #' @param grob A grob",
+      "    #' @return Something",
+      "    #' @description The second one, stranding the first",
+      "    #' @return Something else",
+      "    only_one = function(x) x"
+    ),
+    path
+  )
+
+  testthat::expect_length(orphaned_blocks(path), 1L)
+})
+
+test_that("two separated blocks are not reported", {
+  path <- tempfile(fileext = ".R")
+  on.exit(unlink(path), add = TRUE)
+  writeLines(
+    c(
+      "    #' @description The first one",
+      "    #' @return Something",
+      "    first = function(x) x,",
+      "",
+      "    #' @description The second one",
+      "    #' @return Something else",
+      "    second = function(x) x"
+    ),
+    path
+  )
+
+  testthat::expect_length(orphaned_blocks(path), 0L)
+})


### PR DESCRIPTION
## Description

Closes #151.

`Ggplot2PieLayerProcessor$find_polygon_grob()` matched `geom_rect.polygon`, which is one layout of two. On ggplot2 3.4.4 a polar bar layer draws a `geom_rect.gTree` holding **one `geom_polygon.polygon` grob per wedge**, and nothing named `geom_rect.polygon` exists anywhere in the tree — so the lookup found nothing, `generate_selectors()` returned an empty list, and **a pie highlighted nothing at all** while sonifying, announcing and brailling correctly.

`DESCRIPTION` puts no version bound on ggplot2 and `R-CMD-check.yaml` installs `release`, so the older layout was never exercised.

## The part worth reviewing: nine failures nobody read

This is the second half of a story worth recording. #138 and #141 both ran the suite, both reported "9 failures, all in the pie tests", and both correctly called them pre-existing and out of scope. #150 did the same and confirmed the count and identity were unchanged by that branch. Three pull requests observed the same nine failures and none learned what they meant, because "pre-existing" is a true statement that ends the inquiry.

They meant a pie chart could not be highlighted.

## Changes Made

`find_polygon_grob()` splits into two lookups and prefers the one it already had:

- **`find_named_polygon_grob()`** — the original search for a single `geom_rect.polygon.<N>` holding every wedge grouped by id.
- **`find_wedge_container()`** — a `geom_rect.gTree.<N>` whose polygon descendants are the wedges. Verified against real `gridSVG::grid.export()` output:

  ```
  <g id="geom_rect.gTree.8.1">
    <g id="geom_polygon.polygon.2.1"><polygon id="geom_polygon.polygon.2.1.1" .../></g>
    <g id="geom_polygon.polygon.4.1"><polygon id="geom_polygon.polygon.4.1.1" .../></g>
    <g id="geom_polygon.polygon.6.1"><polygon id="geom_polygon.polygon.6.1.1" .../></g>
  </g>
  ```

  Either layout is a container whose `<polygon>` descendants are the wedges in slice order, so **the selector shape is unchanged** — `#<container>\.1 polygon` resolves against both, and only the lookup learns the second one.

- **`holds_polygon()`** gates the gTree branch. A `geom_rect` layer that drew no wedges has nothing to point at, and naming its tree would emit a selector resolving to nothing — which the caller cannot tell apart from a working one. That is the failure mode the existing comment on the empty-list return already argues against, and it applies to the new branch too.

## Testing

**`tests/testthat/test-pie-selectors.R` is new, and it is the test that was missing.** It renders through `save_html()` and resolves the emitted selector against the exported SVG, which is the only kind of assertion that can see this class of defect — the processor's own tests assert a *string*, and a string that finds nothing satisfies every one of them.

- a pie's selector finds exactly one element per wedge;
- the wedges arrive in the order the data was emitted — the areas are 3, 5 and 2 of ten, so the drawn arcs pin the pairing and a shuffle fails;
- a faceted pie scopes each panel to its own wedges, and the two selectors differ. That guards the failure that is *not* an empty list: every panel pointing at the first panel's wedges resolves, and looks healthy.

**`test-ggplot2-pie-layer-processor.R`** gains a case that a `geom_rect` layer drawing no polygons still gets no selector, and its selector-shape assertion now admits both containers rather than naming the one this ggplot2 does not draw.

**Verified they bite:** reverting `R/ggplot2_pie_layer_processor.R` produces **13 failures** across the two files.

## Screenshots (if applicable)

n/a — the change is in which element a selector addresses, pinned by test rather than by eye.

## Testing results

| Gate | Before | After |
|---|---|---|
| `testthat::test_dir("tests/testthat")` | 9 failed, 4850 passed | **0 failed, 4881 passed** |
| `tools::checkRd("man/Ggplot2PieLayerProcessor.Rd")` | — | clean |
| line lengths (`.lintr` limit 100) | — | clean |

The nine failures this repo has carried are gone. There are no known failing tests in this suite now.

## Notes

**One of the nine was not a selector problem, and is skipped rather than fixed.** `Ggplot2PieLayerProcessor handles a zero-row layer` fails because ggplot2 3.4.4 cannot *build* the plot — `expand_limits_discrete_trans()` raises `replacement has length zero`, and it reproduces on a bare `ggplot_build()` with no maidr in the picture and with or without the polar coord. There is nothing there for this processor to get right or wrong.

It is skipped by asking the question rather than by naming a version:

```r
built <- tryCatch(suppressWarnings(ggplot2::ggplot_build(p)), error = function(condition) condition)
if (inherits(built, "error")) testthat::skip(...)
```

I have not bisected which ggplot2 fixed it, and a version constant I cannot justify would be a worse record than the condition itself. The skip message names the installed version and the upstream error.

`man/Ggplot2PieLayerProcessor.Rd` is regenerated for this one class only, the same way #150 handled #143's roxygen mismatch: generated into a scratch copy, the single file copied across, `tools::checkRd()` clean. The wholesale regeneration stays #143's.

**Follow-up worth considering, not done here.** Two processors have now shipped a selector lookup that silently found nothing, and in both cases the gap was invisible until someone resolved the selector against a real export. Every processor that emits selectors could carry one export-level case asserting they resolve to the number of marks the layer claims. That is a small file each, and it is the only kind of test that sees this at all — I have noted it on #137.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_