### PR TITLE
feat(ggplot2): skip a layer that draws nothing instead of leaving it unknown

### DIFF
--- a/R/ggplot2_adapter.R
+++ b/R/ggplot2_adapter.R
@@ -287,7 +287,34 @@ Ggplot2Adapter <- R6::R6Class(
         return(if (self$ribbon_is_area(layer, plot_object)) "area" else "error_bar")
       }
 
-      if (geom_class == "GeomText") {
+      # `geom_label()` is `geom_text()` with a rounded rectangle behind it --
+      # the same annotation, drawn twice over. But `GeomLabel` is a *sibling*
+      # of `GeomText` rather than a subclass, both direct `Geom` children, so
+      # matching the one name missed the other entirely and left it "unknown".
+      # Measured on ggplot2 3.4.4 with `save_html()`, the same three-bar chart
+      # in each row:
+      #
+      #     geom_col()                                interactive   39,116 bytes
+      #     geom_col() + geom_text(aes(label = v))    interactive   41,339 bytes
+      #     geom_col() + geom_label(aes(label = v))   base64 image  17,220 bytes
+      #
+      # Which of the two spellings the author reached for decided whether the
+      # chart kept any interactivity at all (#211). Whether either should be
+      # *read* -- as the JS core now reads a standalone `Plot.text`
+      # (xability/maidr#1106) -- is a separate question; what this settles is
+      # that they cost the same.
+      if (geom_class %in% c("GeomText", "GeomLabel")) {
+        return("skip")
+      }
+
+      # `geom_blank()` draws nothing at all. It exists to force a scale limit
+      # -- `geom_blank(aes(y = 0))` to include zero, `geom_blank(data = ...)`
+      # to give facets a shared range -- so it is added to charts that are
+      # otherwise entirely readable, and left "unknown" it took every one of
+      # them down to a picture: 39,116 bytes interactive against 13,380 as a
+      # base64 image, measured the same way (#211). There is no reading
+      # question in a layer with no marks.
+      if (geom_class == "GeomBlank") {
         return("skip")
       }
 

--- a/tests/testthat/test-ggplot2-drawless-layers.R
+++ b/tests/testthat/test-ggplot2-drawless-layers.R
@@ -1,0 +1,122 @@
+# A layer with nothing to announce still cost the whole chart (#211)
+#
+# `detect_layer_type()` returning "unknown" is what makes
+# `has_unsupported_layers()` true, which drops the **whole plot** to a static
+# image -- the cost #176 measured for a reference line and #197 for an
+# annotation, both since answered with "skip". Two more layers were paying it,
+# and neither carries an observation to lose.
+#
+# Measured on ggplot2 3.4.4 through `save_html()`, the same three-bar chart in
+# every row:
+#
+#     geom_col()                                interactive   39,116 bytes
+#     geom_col() + geom_text(aes(label = v))    interactive   41,339 bytes
+#     geom_col() + geom_label(aes(label = v))   base64 image  17,220 bytes
+#     geom_col() + geom_blank()                 base64 image  13,380 bytes
+#
+# `geom_label()` is `geom_text()` with a rounded rectangle behind it, and
+# `GeomText` was already skipped -- but `GeomLabel` is a *sibling* of it, both
+# direct `Geom` children, so the exact class test missed it. Which of the two
+# spellings the author happened to reach for decided whether the chart kept
+# any interactivity.
+#
+# `geom_blank()` draws nothing whatsoever. It is how one forces a scale limit,
+# so it lands on charts that are otherwise entirely readable.
+#
+# What these cases pin is both halves: that the two are skipped, and that
+# skipping them does not invent a reading for a plot which has nothing else in
+# it.
+
+skip_unless_ggplot2 <- function() {
+  testthat::skip_if_not_installed("ggplot2")
+}
+
+bars_frame <- function() {
+  data.frame(g = c("a", "b", "c"), v = c(3, 7, 5), stringsAsFactors = FALSE)
+}
+
+detected <- function(plot, index) {
+  maidr:::Ggplot2Adapter$new()$detect_layer_type(plot$layers[[index]], plot)
+}
+
+# Render through `save_html()` and report what a reader actually receives.
+rendered <- function(plot) {
+  file <- tempfile(fileext = ".html")
+  on.exit(unlink(file), add = TRUE)
+  warnings_seen <- character(0)
+  withCallingHandlers(
+    maidr::save_html(plot, file = file),
+    warning = function(w) {
+      warnings_seen <<- c(warnings_seen, conditionMessage(w))
+      invokeRestart("muffleWarning")
+    }
+  )
+  html <- paste(readLines(file, warn = FALSE), collapse = "\n")
+  list(
+    interactive = grepl("<svg", html, fixed = TRUE) &&
+      !grepl("base64", html, fixed = TRUE),
+    fell_back = any(grepl("static image", warnings_seen, fixed = TRUE))
+  )
+}
+
+bar_with <- function(extra) {
+  ggplot2::ggplot(bars_frame(), ggplot2::aes(g, v)) +
+    ggplot2::geom_col() +
+    extra
+}
+
+
+test_that("a text label is skipped whichever geom drew it", {
+  skip_unless_ggplot2()
+
+  text <- bar_with(ggplot2::geom_text(ggplot2::aes(label = v)))
+  label <- bar_with(ggplot2::geom_label(ggplot2::aes(label = v)))
+
+  # The asymmetry itself: the same annotation, the same answer.
+  testthat::expect_equal(detected(text, 2), "skip")
+  testthat::expect_equal(detected(label, 2), "skip")
+})
+
+test_that("a layer that draws nothing is skipped", {
+  skip_unless_ggplot2()
+
+  testthat::expect_equal(detected(bar_with(ggplot2::geom_blank()), 2), "skip")
+})
+
+test_that("the bar beside them is still read as a bar", {
+  skip_unless_ggplot2()
+
+  # Skipping must take the layer out of the way, not out of the chart. If the
+  # first layer stopped being read, the cases above would pass while the
+  # reader lost the very thing they were meant to keep.
+  testthat::expect_equal(detected(bar_with(ggplot2::geom_label(ggplot2::aes(label = v))), 1), "bar")
+  testthat::expect_equal(detected(bar_with(ggplot2::geom_blank()), 1), "bar")
+})
+
+test_that("neither layer costs the chart its interactivity any more", {
+  skip_unless_ggplot2()
+
+  for (extra in list(
+    ggplot2::geom_label(ggplot2::aes(label = v)),
+    ggplot2::geom_blank()
+  )) {
+    result <- rendered(bar_with(extra))
+    testthat::expect_true(result$interactive)
+    testthat::expect_false(result$fell_back)
+  }
+})
+
+test_that("a plot that is nothing but a drawless layer still falls back", {
+  skip_unless_ggplot2()
+
+  # The other half, and the one a "skip" can get wrong: a chart whose every
+  # layer is skipped has no data to announce, and must fall back rather than
+  # present itself as an empty but navigable chart. It falls back because it
+  # reads as no layers at all, not because of a rule about geoms -- the same
+  # reasoning #197 recorded for a plot made only of annotations.
+  plot <- ggplot2::ggplot(bars_frame(), ggplot2::aes(g, v)) +
+    ggplot2::geom_blank()
+
+  testthat::expect_equal(detected(plot, 1), "skip")
+  testthat::expect_false(rendered(plot)$interactive)
+})


### PR DESCRIPTION
Closes #211.

## What happens

`detect_layer_type()` returning `"unknown"` is what makes `has_unsupported_layers()` true, which drops the **whole plot** to a static image — the cost #176 measured for a reference line and #197 for an annotation. Two more layers were paying it, and neither carries an observation to lose.

Measured on ggplot2 3.4.4 through `save_html()`, the same three-bar chart in every row:

| plot | before | after |
| --- | --- | --- |
| `geom_col()` | interactive, 39,116 B | unchanged |
| `geom_col() + geom_text(aes(label = v))` | interactive, 41,339 B | unchanged |
| `geom_col() + geom_label(aes(label = v))` | **base64 image**, 17,220 B | interactive, 46,486 B |
| `geom_col() + geom_blank()` | **base64 image**, 13,380 B | interactive, 39,391 B |

## Why each was missed

**`geom_label()` is `geom_text()` with a rounded rectangle behind it** — the same annotation, drawn twice over. `GeomText` was already skipped, but `GeomLabel` is a *sibling* of it rather than a subclass:

```
GeomText   GeomText < Geom < ggproto < gg
GeomLabel  GeomLabel < Geom < ggproto < gg
```

so `geom_class == "GeomText"` missed it entirely. Which of the two spellings the author happened to reach for decided whether the chart kept any interactivity at all. This is the same shape of miss as #193 (`GeomRaster`) and #202 (`GeomFunction`), with the difference that neither of those two is decoration.

**`geom_blank()` draws nothing whatsoever.** It exists to force a scale limit — `geom_blank(aes(y = 0))` to include zero, `geom_blank(data = ...)` to give facets a shared range — so it is added to charts that are otherwise entirely readable, and took every one of them down. There is no reading question in a layer with no marks.

## The other half

A `"skip"` can be got wrong in the opposite direction, so the tests pin that too: a plot whose **only** layer is skipped still falls back, because it then reads as no layers at all rather than as an empty but navigable chart. That is the same reasoning #197 recorded for a plot made only of annotations, and it is asserted rather than assumed.

The bar layer beside the skipped one is asserted to still read as a bar — otherwise the skip assertions would pass while the reader lost the thing they were meant to keep.

## Tests

`tests/testthat/test-ggplot2-drawless-layers.R`, 11 assertions across 5 cases. Falsified with three mutations, each applied alone against a restored baseline:

| mutation | failures |
| --- | --- |
| drop `GeomLabel` from the text branch | 3 |
| drop the `GeomBlank` branch | 4 |
| read a blank layer as points instead of skipping | 3 |

Baseline restored at 11/11. Full suite **6039 passing, 0 failing** (99 skips, all pre-existing — the candlestick files need `tidyquant`).

## Not in scope

Whether a text layer should be **read** rather than skipped — the JS core reads a standalone `Plot.text` as a labelled scatter (xability/maidr#1106) — is a separate question with a real answer either way. This settles only that the two spellings of one annotation cost the same.

#211 also records the rest of the sweep that found these: `geom_quantile` and `geom_spoke` miss branches they belong to by inheritance, and `geom_polygon`, `geom_rug` and the filled contours are unread. Each needs its own reading decision and none is touched here.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_