### PR TITLE
fix(iframe): check that the page actually took focus before calling it done

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,13 @@
 
 ## Bug Fixes
 
+* The chart could still strand a reader in a Shiny app. Handing focus back to
+  the page assumed that asking an element to take it worked, and an element
+  with no rendered box refuses silently -- Shiny wraps every output in a
+  `display: contents` div, and a chart's frame sits directly inside one. The
+  page now reads the outcome back and walks on up the ancestors until one
+  actually takes focus, leaving no `tabindex` behind on the ones that refuse.
+
 * A chart in a Quarto `revealjs` slide swallowed every key, with no way back to
   the deck. Charts are embedded in an iframe, and keyboard events do not cross
   a frame boundary, so while a reader is inside a chart the slide around it

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,10 @@
   `display: contents` div, and a chart's frame sits directly inside one. The
   page now reads the outcome back and walks on up the ancestors until one
   actually takes focus, leaving no `tabindex` behind on the ones that refuse.
+  The tab stop before the frame is checked the same way, since one of those can
+  be a `display: contents` element too, and every candidate is asked as it
+  stands before being given a `tabindex` --- so a tab stop the page already
+  owns is never taken out of its own tab order.
 
 * A chart in a Quarto `revealjs` slide swallowed every key, with no way back to
   the deck. Charts are embedded in an iframe, and keyboard events do not cross

--- a/R/svg_utils.R
+++ b/R/svg_utils.R
@@ -1493,6 +1493,19 @@ maidr_iframe_host_script <- function() {
     "var s = window.getComputedStyle(el);",
     "return s.display !== \"none\" && s.visibility !== \"hidden\";",
     "}",
+    # Asking an element to take focus is not enough. `focus()` on an element
+    # with no rendered box -- a `display: contents` wrapper, which is what
+    # Shiny puts around every output -- is a silent no-op, so the outcome has
+    # to be read back. A tabindex this added is removed again when the element
+    # refuses, rather than leaving it claiming it can hold focus.
+    "function takeFocus(el) {",
+    "var added = !el.hasAttribute(\"tabindex\");",
+    "if (added) el.setAttribute(\"tabindex\", \"-1\");",
+    "el.focus();",
+    "if (document.activeElement === el) return true;",
+    "if (added) el.removeAttribute(\"tabindex\");",
+    "return false;",
+    "}",
     "function stopBefore(frame) {",
     "var stops = document.querySelectorAll(TABBABLE);",
     "var found = null;",
@@ -1513,11 +1526,12 @@ maidr_iframe_host_script <- function() {
     "frame.style.height = e.data.height + \"px\";",
     "} else if (e.data.type === \"maidr:frame-focus-escape\") {",
     "var target = stopBefore(frame);",
-    "if (!target) {",
-    "target = frame.closest(CONTAINER) || frame.parentElement || document.body;",
-    "if (!target.hasAttribute(\"tabindex\")) target.setAttribute(\"tabindex\", \"-1\");",
+    "if (target) { target.focus(); return; }",
+    "var section = frame.closest(CONTAINER);",
+    "if (section && takeFocus(section)) return;",
+    "for (var el = frame.parentElement; el; el = el.parentElement) {",
+    "if (el !== section && takeFocus(el)) return;",
     "}",
-    "target.focus();",
     "}",
     "});",
     "})();</script>"

--- a/R/svg_utils.R
+++ b/R/svg_utils.R
@@ -1454,11 +1454,19 @@ create_maidr_iframe <- function(svg_content, width = "100%", height = "450px", p
 #' Focus goes to the tab stop before the frame where this page has a reachable
 #' one, which is what the browser would have done. Where it has none, focus
 #' lands on the element holding the frame --- a reveal.js slide is a
-#' `<section>`, so on a slide deck that is the slide itself --- given
-#' `tabindex="-1"` so it can take focus without joining the tab order.
+#' `<section>`, so on a slide deck that is the slide itself.
+#'
 #' Reachability is checked rather than assumed: reveal.js leaves the slides on
 #' either side of the current one rendered, so a chart on the previous slide is
 #' a tab stop in document order even though it is marked hidden.
+#'
+#' So is the handoff itself. Asking an element to take focus is not the same as
+#' it taking focus --- `focus()` on an element with no rendered box is a silent
+#' no-op, and Shiny wraps every output in a `display: contents` div --- so the
+#' outcome is read back and the ancestors are walked until one actually holds
+#' it. An element is asked as it stands before being given `tabindex="-1"`, so
+#' a tab stop this page already owns is never taken out of the tab order, and a
+#' `tabindex` added to one that still refuses is removed again.
 #'
 #' Registered at most once per document (guarded by a window flag), no
 #' matter how many iframes embed it.
@@ -1499,11 +1507,15 @@ maidr_iframe_host_script <- function() {
     # to be read back. A tabindex this added is removed again when the element
     # refuses, rather than leaving it claiming it can hold focus.
     "function takeFocus(el) {",
-    "var added = !el.hasAttribute(\"tabindex\");",
-    "if (added) el.setAttribute(\"tabindex\", \"-1\");",
+    # As it stands first. A tab stop this page already owns is focusable as it
+    # is, and giving it `tabindex="-1"` would take it out of the tab order.
     "el.focus();",
     "if (document.activeElement === el) return true;",
-    "if (added) el.removeAttribute(\"tabindex\");",
+    "if (el.hasAttribute(\"tabindex\")) return false;",
+    "el.setAttribute(\"tabindex\", \"-1\");",
+    "el.focus();",
+    "if (document.activeElement === el) return true;",
+    "el.removeAttribute(\"tabindex\");",
     "return false;",
     "}",
     "function stopBefore(frame) {",
@@ -1526,7 +1538,7 @@ maidr_iframe_host_script <- function() {
     "frame.style.height = e.data.height + \"px\";",
     "} else if (e.data.type === \"maidr:frame-focus-escape\") {",
     "var target = stopBefore(frame);",
-    "if (target) { target.focus(); return; }",
+    "if (target && takeFocus(target)) return;",
     "var section = frame.closest(CONTAINER);",
     "if (section && takeFocus(section)) return;",
     "for (var el = frame.parentElement; el; el = el.parentElement) {",

--- a/inst/htmlwidgets/maidr.js
+++ b/inst/htmlwidgets/maidr.js
@@ -92,12 +92,16 @@
   // back. A tabindex this added is removed again when the element refuses,
   // rather than leaving it claiming it can hold focus.
   function takeFocus(el) {
-    var added = !el.hasAttribute("tabindex");
-    // tabindex="-1" takes focus without joining this page's tab order.
-    if (added) el.setAttribute("tabindex", "-1");
+    // As it stands first. A tab stop this page already owns is focusable as it
+    // is, and giving it tabindex="-1" would take it out of the tab order.
     el.focus();
     if (document.activeElement === el) return true;
-    if (added) el.removeAttribute("tabindex");
+    if (el.hasAttribute("tabindex")) return false;
+    // tabindex="-1" takes focus without joining this page's tab order.
+    el.setAttribute("tabindex", "-1");
+    el.focus();
+    if (document.activeElement === el) return true;
+    el.removeAttribute("tabindex");
     return false;
   }
 
@@ -109,7 +113,7 @@
       if (frames[i].contentWindow !== event.source) continue;
 
       var target = stopBefore(frames[i]);
-      if (target) { target.focus(); return; }
+      if (target && takeFocus(target)) return;
 
       var section = frames[i].closest(CONTAINER);
       if (section && takeFocus(section)) return;

--- a/inst/htmlwidgets/maidr.js
+++ b/inst/htmlwidgets/maidr.js
@@ -86,6 +86,21 @@
     return found;
   }
 
+  // Asking an element to take focus is not enough. focus() on an element with
+  // no rendered box -- a `display: contents` wrapper, which is what Shiny puts
+  // around every output -- is a silent no-op, so the outcome has to be read
+  // back. A tabindex this added is removed again when the element refuses,
+  // rather than leaving it claiming it can hold focus.
+  function takeFocus(el) {
+    var added = !el.hasAttribute("tabindex");
+    // tabindex="-1" takes focus without joining this page's tab order.
+    if (added) el.setAttribute("tabindex", "-1");
+    el.focus();
+    if (document.activeElement === el) return true;
+    if (added) el.removeAttribute("tabindex");
+    return false;
+  }
+
   window.addEventListener("message", function(event) {
     if (!event.data || event.data.type !== "maidr:frame-focus-escape") return;
 
@@ -94,12 +109,13 @@
       if (frames[i].contentWindow !== event.source) continue;
 
       var target = stopBefore(frames[i]);
-      if (!target) {
-        target = frames[i].closest(CONTAINER) || frames[i].parentElement || document.body;
-        // tabindex="-1" takes focus without joining this page's tab order.
-        if (!target.hasAttribute("tabindex")) target.setAttribute("tabindex", "-1");
+      if (target) { target.focus(); return; }
+
+      var section = frames[i].closest(CONTAINER);
+      if (section && takeFocus(section)) return;
+      for (var el = frames[i].parentElement; el; el = el.parentElement) {
+        if (el !== section && takeFocus(el)) return;
       }
-      target.focus();
       return;
     }
   });

--- a/man/maidr_iframe_host_script.Rd
+++ b/man/maidr_iframe_host_script.Rd
@@ -32,11 +32,19 @@ for the handoff instead of performing it.
 Focus goes to the tab stop before the frame where this page has a reachable
 one, which is what the browser would have done. Where it has none, focus
 lands on the element holding the frame --- a reveal.js slide is a
-\verb{<section>}, so on a slide deck that is the slide itself --- given
-\code{tabindex="-1"} so it can take focus without joining the tab order.
+\verb{<section>}, so on a slide deck that is the slide itself.
+
 Reachability is checked rather than assumed: reveal.js leaves the slides on
 either side of the current one rendered, so a chart on the previous slide is
 a tab stop in document order even though it is marked hidden.
+
+So is the handoff itself. Asking an element to take focus is not the same as
+it taking focus --- \code{focus()} on an element with no rendered box is a silent
+no-op, and Shiny wraps every output in a \code{display: contents} div --- so the
+outcome is read back and the ancestors are walked until one actually holds
+it. An element is asked as it stands before being given \code{tabindex="-1"}, so
+a tab stop this page already owns is never taken out of the tab order, and a
+\code{tabindex} added to one that still refuses is removed again.
 
 Registered at most once per document (guarded by a window flag), no
 matter how many iframes embed it.

--- a/tests/testthat/test-svg-utils.R
+++ b/tests/testthat/test-svg-utils.R
@@ -476,8 +476,30 @@ test_that("maidr_iframe_host_script checks that focus actually landed", {
   )
   # An element that refuses is not left claiming it can hold focus.
   testthat::expect_true(
-    grepl('if (added) el.removeAttribute("tabindex");', script, fixed = TRUE)
+    grepl('el.removeAttribute("tabindex");', script, fixed = TRUE)
   )
+})
+
+test_that("maidr_iframe_host_script checks the tab stop it found as well", {
+  script <- maidr:::maidr_iframe_host_script()
+
+  # `stopBefore()` returns whatever matched the tabbable selector, and a
+  # `display: contents` element with a tabindex matches it while still being
+  # unable to hold focus. Trusting that one would strand the reader exactly as
+  # trusting the container did.
+  testthat::expect_true(grepl("if (target && takeFocus(target)) return;", script, fixed = TRUE))
+})
+
+test_that("maidr_iframe_host_script asks an element before it writes to it", {
+  script <- maidr:::maidr_iframe_host_script()
+
+  # A tab stop this page already owns is focusable as it stands, and giving it
+  # `tabindex="-1"` would take it out of the page's tab order. So the call
+  # comes first and the attribute only follows a refusal.
+  focus_first <- regexpr("el.focus();", script, fixed = TRUE)
+  writes_after <- regexpr('el.setAttribute("tabindex", "-1");', script, fixed = TRUE)
+  testthat::expect_gt(focus_first, 0)
+  testthat::expect_gt(writes_after, focus_first)
 })
 
 test_that("create_maidr_iframe attaches the host script to the frame", {

--- a/tests/testthat/test-svg-utils.R
+++ b/tests/testthat/test-svg-utils.R
@@ -460,6 +460,26 @@ test_that("maidr_iframe_host_script uses a height only once it is one", {
   testthat::expect_true(grepl("e.data.height < 50", script, fixed = TRUE))
 })
 
+test_that("maidr_iframe_host_script checks that focus actually landed", {
+  script <- maidr:::maidr_iframe_host_script()
+
+  # Asking is not enough: focus() on an element with no rendered box -- a
+  # `display: contents` wrapper, which is what Shiny puts around every output
+  # -- is a silent no-op. Without reading the outcome back, the handoff would
+  # leave the reader inside the chart with nothing to show for the keypress.
+  testthat::expect_true(
+    grepl("if (document.activeElement === el) return true;", script, fixed = TRUE)
+  )
+  # And it walks on to the next ancestor rather than stopping at the refusal.
+  testthat::expect_true(
+    grepl("for (var el = frame.parentElement; el; el = el.parentElement)", script, fixed = TRUE)
+  )
+  # An element that refuses is not left claiming it can hold focus.
+  testthat::expect_true(
+    grepl('if (added) el.removeAttribute("tabindex");', script, fixed = TRUE)
+  )
+})
+
 test_that("create_maidr_iframe attaches the host script to the frame", {
   html <- maidr:::create_maidr_iframe("<svg></svg>", plot_id = "test-plot")
 


### PR DESCRIPTION
## Description

The focus handoff added in #208 assumed that calling `focus()` on an element moved focus there. It does not always: an element with no rendered box refuses silently, and `display: contents` is the case that bites.

Shiny wraps **every** output in a `display: contents` div, and a chart's frame sits directly inside one with no sectioning element above it. So the handoff picked that wrapper, called `focus()`, got nothing, and returned as though it had succeeded — leaving the reader inside the chart with nothing to show for the keypress. That is the very failure the handoff exists to prevent, reproduced in a different host.

## Changes Made

Both copies of the parent-side listener — `maidr_iframe_host_script()` in **`R/svg_utils.R`** and the widget binding's own copy in **`inst/htmlwidgets/maidr.js`** — gain a `takeFocus()` helper, and every candidate now goes through it:

- it asks the element to take focus and reads the outcome back (`document.activeElement === el`) rather than trusting the call, walking on up the ancestor chain until one actually takes it, the sectioning element still being tried first;
- it asks an element **as it stands** before giving it anything, so a tab stop the page already owns is never pulled into `tabindex="-1"` to hold focus it could already hold;
- and a `tabindex` it did add is **removed again** when the element still refuses, so a wrapper that cannot hold focus is not left carrying an attribute claiming it can.

The tab stop found by `stopBefore()` goes through the same check as the container. It has to: `stopBefore()` returns whatever matched the tabbable selector, and a `display: contents` element carrying a `tabindex` matches it and passes `reachable()` while still being unable to hold focus, so trusting that one strands the reader exactly as trusting the container did.

The roxygen block described only the pre-fix behaviour, so it now says what the function does, and `man/` is regenerated from it. Three cases in **`tests/testthat/test-svg-utils.R`** pin the contract, including the ordering of the `focus()` call against the `setAttribute()` so a flip would be caught.

## Related

- [`xability/maidr#1121`](https://github.com/xability/maidr/pull/1121) is the engine half, which had the same assumption and the same fix. Merged as `67f2a85`.
- Follow-up to #208, which introduced the handoff. Shiny was not among the hosts checked before that merged — this is the gap.

## Verification

`testthat::test_local()` clean — no failures, no errors. The generated script still parses under `node --check`, and `node --check` passes on the widget binding.

Driven in Chromium against a real py-shiny app, sampling the host document after one Shift + Tab out of the chart:

```
before                                    after
t=  50ms  top=iframe#…  frameHasFocus=1   t=  50ms  top=div.container-fluid  frameHasFocus=0
t=2000ms  top=iframe#…  frameHasFocus=1   t=2000ms  top=div.container-fluid  frameHasFocus=0

tabindex written on: div.shiny-html-output    tabindex written on: div.container-fluid
                     (display:contents,                            (the one that took it)
                      never took focus)
```

Walking that page's ancestor chain, measured rather than assumed:

```
div#first_chart.shiny-html-output   display=contents   takesFocus=false
div.container-fluid                 display=block      takesFocus=true
body                                display=block      takesFocus=true
```

Re-checked afterwards, and again after the second commit, that the hosts #208 was verified against are unchanged: a three-slide Quarto 1.10.18 `revealjs` deck with a ggplot2 chart on each slide still lands on the current slide with Space advancing on every slide, and a JupyterLab notebook and an nbconvert export still keep their native tab order with nothing written into them.

## Note

The tests here match the generated script's text rather than exercising a real DOM, as every other test in this file does — there is no JS test harness in this repo, and adding one is a larger change than this should carry. Browser runs cover the behaviour instead.