### PR TITLE
fix(base-r): stop emitting a contour layer the core refuses

### DIFF
--- a/R/base_r_adapter.R
+++ b/R/base_r_adapter.R
@@ -221,7 +221,23 @@ BaseRAdapter <- R6::R6Class(
         "pie" = "pie",
         "image" = "heat",
         "heatmap" = "heat",
-        "contour" = "contour",
+        # `contour()` has no processor, and typing it "contour" put the gap in
+        # the *payload* rather than in the fallback: the layer came out typed
+        # "unknown" -- which `unsupported_layer_flags` only looks for on
+        # `layer$type`, so the static-image path never ran -- and the core's
+        # trace factory ends with `throw new Error("Invalid trace type: ...")`,
+        # so the figure never bound. An interactive shell answering no key,
+        # and no picture either (#214).
+        #
+        # Typed "unknown" here it takes the same fallback `dotchart` and
+        # `mosaicplot` take: a static image and a warning saying so. Worse
+        # than reading the chart, better than both of the above.
+        #
+        # Reading it properly is still open, and the type exists: the ggplot2
+        # adapter emits `contour` for `geom_contour()` (#198), and base R's
+        # `contour()` hands over the same `x`, `y`, `z` and `levels`. Adding
+        # the processor is what changes this line back.
+        "contour" = "unknown",
         "matplot" = "line",
         # quantmod::chartSeries() candlestick path. The `type` argument
         # defaults to "auto"; we accept the call as candlestick only when

--- a/R/base_r_processor_factory.R
+++ b/R/base_r_processor_factory.R
@@ -42,7 +42,6 @@ BaseRProcessorFactory <- R6::R6Class(
         "violin" = BaseRViolinLayerProcessor$new(layer_info),
         "pie" = BaseRPieLayerProcessor$new(layer_info),
         "heat" = BaseRHeatmapLayerProcessor$new(layer_info),
-        "contour" = BaseRUnknownLayerProcessor$new(layer_info),
         "candlestick" = BaseRCandlestickLayerProcessor$new(layer_info),
         # For unknown types, use the generic processor
         BaseRUnknownLayerProcessor$new(layer_info)
@@ -66,7 +65,20 @@ BaseRProcessorFactory <- R6::R6Class(
         "box",
         "pie",
         "heat",
-        "contour",
+        # `contour` is deliberately absent. `base_r_adapter` maps the call to
+        # that type and the factory had no processor for it, so the layer was
+        # emitted typed "unknown" -- and because the type was listed here, the
+        # unsupported-elements fallback that saves `dotchart` never ran. The
+        # core's factory ends its dispatch with
+        # `throw new Error("Invalid trace type: " + layer.type)`, so the figure
+        # never bound: an interactive shell answering no key, and no picture
+        # either. A static image with a warning is worse than reading the
+        # chart and better than both of those (#214).
+        #
+        # Reading it properly is still open. `contour` *is* a trace type --
+        # the ggplot2 side emits it for `geom_contour` (#198) -- and base R's
+        # `contour()` hands over the same `x`, `y`, `z` and `levels`. Adding
+        # the processor is what puts the type back on this list.
         "candlestick",
         "unknown"
       )

--- a/tests/testthat/test-base-r-contour-fallback.R
+++ b/tests/testthat/test-base-r-contour-fallback.R
@@ -1,0 +1,136 @@
+# Base R contour() shipped a layer the core refuses (#214)
+#
+# `base_r_adapter` mapped the call to the type "contour" and the processor
+# factory had no processor for it, so the generic one ran and the layer was
+# emitted typed **"unknown"**. Two things then compounded:
+#
+#   - `unsupported_layer_flags()` looks for "unknown" on `layer$type`, and the
+#     type here was "contour", so the static-image fallback never ran; and
+#   - the core's trace factory ends its dispatch with
+#     `throw new Error("Invalid trace type: " + layer.type)`.
+#
+# So the figure rendered interactively and then failed to construct: an
+# interactive-looking shell that answers no key, and no picture either.
+# Measured before the fix, `contour(matrix(1:12, nrow = 3))` gave
+# `types=[unknown]` with no fallback warning, while `dotchart()` -- unclaimed
+# by anything -- correctly gave a static image.
+#
+# Typed "unknown" at the adapter it takes that same path. Worse than reading
+# the chart and better than a figure that never binds. Reading it properly is
+# still open: `contour` *is* a trace type, the ggplot2 adapter emits it for
+# `geom_contour()` (#198), and base R hands over the same x, y, z and levels.
+
+skip_unless_jsonlite <- function() {
+  testthat::skip_if_not_installed("jsonlite")
+}
+
+# Every maidr-data payload in a rendered file.
+contour_payloads <- function(file) {
+  html <- paste(readLines(file, warn = FALSE), collapse = "\n")
+  matches <- regmatches(html, gregexpr('maidr-data="[^"]*"', html))[[1]]
+  lapply(matches, function(match) {
+    raw <- sub('"$', "", sub('^maidr-data="', "", match))
+    raw <- gsub("&quot;", '"', raw, fixed = TRUE)
+    raw <- gsub("&lt;", "<", raw, fixed = TRUE)
+    raw <- gsub("&gt;", ">", raw, fixed = TRUE)
+    raw <- gsub("&amp;", "&", raw, fixed = TRUE)
+    jsonlite::fromJSON(raw, simplifyVector = FALSE)
+  })
+}
+
+# Draw on an off-screen device, render as a user would, report what arrived.
+render_base_figure <- function(plot_fun) {
+  clear_all_device_storage()
+  file <- tempfile(fileext = ".html")
+  grDevices::pdf(NULL)
+  on.exit(
+    {
+      grDevices::dev.off()
+      unlink(file)
+      clear_all_device_storage()
+    },
+    add = TRUE
+  )
+
+  warnings_seen <- character(0)
+  withCallingHandlers(
+    {
+      plot_fun()
+      maidr::save_html(plot = NULL, file = file)
+    },
+    warning = function(w) {
+      warnings_seen <<- c(warnings_seen, conditionMessage(w))
+      invokeRestart("muffleWarning")
+    }
+  )
+
+  html <- paste(readLines(file, warn = FALSE), collapse = "\n")
+  types <- unlist(lapply(contour_payloads(file), function(payload) {
+    lapply(payload$subplots, function(row) {
+      lapply(row, function(cell) {
+        vapply(cell$layers, function(layer) as.character(layer$type), character(1))
+      })
+    })
+  }))
+
+  list(
+    types = if (is.null(types)) character(0) else as.character(types),
+    fell_back = grepl("base64", html, fixed = TRUE),
+    warned = any(grepl("unsupported elements", warnings_seen, fixed = TRUE))
+  )
+}
+
+
+test_that("a base R contour never emits a layer the core would refuse", {
+  skip_unless_jsonlite()
+
+  result <- render_base_figure(function() contour(matrix(1:12, nrow = 3)))
+
+  # The heart of it. "unknown" is not a trace type, and a payload carrying one
+  # makes the whole figure fail to construct.
+  expect_false("unknown" %in% result$types)
+})
+
+test_that("it falls back to a picture, and says so", {
+  skip_unless_jsonlite()
+
+  result <- render_base_figure(function() contour(matrix(1:12, nrow = 3)))
+
+  expect_true(result$fell_back)
+  expect_true(result$warned)
+})
+
+test_that("it takes the same path an unclaimed call takes", {
+  skip_unless_jsonlite()
+
+  # `dotchart` has no processor and nothing claims it does, so it has always
+  # degraded correctly. Asserted beside the contour so the two cannot drift.
+  result <- render_base_figure(function() dotchart(c(3, 7, 5)))
+
+  expect_true(result$fell_back)
+  expect_true(result$warned)
+})
+
+test_that("the charts beside it still read", {
+  skip_unless_jsonlite()
+
+  # The change is one line of the adapter's type map, so this pins that it did
+  # not reach the neighbouring entries -- `image` and `plot` sit either side.
+  expect_equal(
+    render_base_figure(function() image(matrix(1:12, nrow = 3)))$types,
+    "heat"
+  )
+  expect_equal(
+    render_base_figure(function() plot(1:10, (1:10)^2))$types,
+    "point"
+  )
+})
+
+test_that("the factory no longer claims contour among its supported types", {
+  # The other half of the contradiction: `get_supported_types()` listed
+  # "contour" while `create_processor()` handed it the generic processor.
+  factory <- BaseRProcessorFactory$new()
+
+  expect_false("contour" %in% factory$get_supported_types())
+  expect_true("heat" %in% factory$get_supported_types())
+})

--- a/tests/testthat/test-factories.R
+++ b/tests/testthat/test-factories.R
@@ -345,8 +345,15 @@ test_that("BaseRProcessorFactory get_supported_types returns expected types", {
   testthat::expect_true("step" %in% types)
   testthat::expect_true("dodged_bar" %in% types)
   testthat::expect_true("stacked_bar" %in% types)
-  testthat::expect_true("contour" %in% types)
   testthat::expect_true("unknown" %in% types)
+
+  # "contour" was on this list while `create_processor()` handed it the
+  # generic processor, so the layer came out typed "unknown" -- past the
+  # fallback check, which looks for that on `layer$type`, and into a payload
+  # the core's trace factory throws on. Claiming it here is what the type map
+  # in `base_r_adapter` was trusting (#214). It goes back when a processor
+  # exists; the type itself is real, and the ggplot2 side emits it (#198).
+  testthat::expect_false("contour" %in% types)
 })
 
 test_that("BaseRProcessorFactory supports_plot_type works correctly", {
@@ -355,8 +362,10 @@ test_that("BaseRProcessorFactory supports_plot_type works correctly", {
   testthat::expect_true(factory$supports_plot_type("bar"))
   testthat::expect_true(factory$supports_plot_type("point"))
   testthat::expect_true(factory$supports_plot_type("line"))
-  testthat::expect_true(factory$supports_plot_type("contour"))
   testthat::expect_true(factory$supports_plot_type("unknown"))
+  # See above: base R has no contour processor, and saying otherwise cost the
+  # chart both its reading and its fallback (#214).
+  testthat::expect_false(factory$supports_plot_type("contour"))
   testthat::expect_false(factory$supports_plot_type("unsupported_type"))
 })
 


### PR DESCRIPTION
Closes #214.

## What happens

`base_r_adapter` mapped `contour()` to the type `"contour"` and the processor factory had no processor for it, so the generic one ran and the layer was emitted typed **`"unknown"`**. Two things then compounded:

- `unsupported_layer_flags()` looks for `"unknown"` on `layer$type`, and the type here was `"contour"` — so the static-image fallback never ran; and
- the core's trace factory ends its dispatch with `throw new Error("Invalid trace type: " + layer.type)`.

So the figure rendered **interactively and then failed to construct**: an interactive-looking shell that answers no key, and no picture either. That is worse than both outcomes the package already has for a chart it cannot read.

Measured on `contour(matrix(1:12, nrow = 3))`, beside its neighbours in the same sweep:

| call | before |
| --- | --- |
| `contour(m)` | **interactive, `type: "unknown"`** — never binds, no warning |
| `dotchart(...)` | static image, "Plot contains unsupported elements" |
| `image(m)` | interactive, `heat` |
| `plot(x, y)` | interactive, `point` |

`dotchart` is what a call with no processor is supposed to do. `contour` was the only one of the sweep that did neither.

## Two lines that contradicted each other

`get_supported_types()` claimed it, one line above the branch that handed it the generic processor:

```r
"heat",
"contour",     # <- listed as supported
"candlestick",
```
```r
"heat" = BaseRHeatmapLayerProcessor$new(layer_info),
"contour" = BaseRUnknownLayerProcessor$new(layer_info),   # <- the fallback processor
```

Both are corrected: the adapter types it `"unknown"` so the fallback fires, and the factory no longer lists it or names it (the `default` branch two lines below returns the same processor, so the explicit line only made the omission look deliberate).

## Reading it properly is still open

The type is real. The ggplot2 adapter emits `contour` for `geom_contour()` / `geom_density_2d()` (#198), and base R's `contour()` hands over the same `x`, `y`, `z` and `levels` a `ContourPoint` describes. Adding the processor is what puts the type back on the list — recorded in the code beside both changed lines so the next reader finds it.

A static image with a warning is worse than reading the chart, and better than a figure that never binds.

## Tests

9 cases in `tests/testthat/test-base-r-contour-fallback.R`. Falsified with three mutations, each applied alone against a restored baseline:

| mutation | failures |
| --- | --- |
| type it `"contour"` again | 3 |
| let the factory claim it again | 1 |
| type `image` `"unknown"` as a scope check | 1 |

The scope check matters because the change is one line of a type map whose neighbours are `image` and `matplot`; a case asserts both still read as they did.

**Two existing tests were updated in place.** `test-factories.R` asserted both halves of the contradiction — `"contour" %in% types` and `supports_plot_type("contour")` — so they now assert the opposite, with the reason recorded beside them.

Full suite **6048 passing**, 0 failing (99 skips, all pre-existing — the candlestick files need `tidyquant`).

## How it was found, and what else the sweep says

By running every base R function the adapter classifies through `save_html()`, the way #211 came out of sweeping `geom_*`. Everything else read correctly:

```
barplot→bar  plot→point  plot(type="l")→line  plot(type="s")→step  hist→hist
boxplot→box  pie→pie  image→heat  matplot→line  curve→line  plot(ecdf(x))→point
```

`dotchart`, `stripchart`, `mosaicplot` and `assocplot` degrade gracefully to a picture. Seven more — `persp`, `sunflowerplot`, `fourfoldplot`, `spineplot`, `cdplot`, `qqnorm`, `filled.contour` — are not recorded at all, so `save_html()` *errors* with "No Base R plots detected" rather than falling back. #214 records both groups; neither is a wrong reading, so neither is touched here.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_