### PR TITLE
feat(ggplot2): read geom_spoke through the rule geom_segment already has

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,18 @@
 
 ## New Features
 
+* `geom_spoke()` is now read as the gantt chart it draws, where it draws one.
+  A spoke is `geom_segment()` reparameterised -- an angle and a radius rather
+  than an endpoint -- and ggplot2 turns the pair into the same `xend`/`yend`
+  the segment reading already uses, so the two spellings of one mark now reach
+  one rule and answer it alike. A flat spoke is a lane per `y` running from `x`
+  to `x + radius`; an angled one is a vector field rather than a schedule and
+  is still declined, exactly as the segment spelling of the same chart would
+  be. What this fixes is what a decline used to cost: an unclaimed layer makes
+  the whole plot fall back to a static image, so a thirty-point scatter with a
+  spoke layer beside it went from an interactive SVG to a base64 image and lost
+  every one of its points.
+
 * A Base R `contour()` is now read as the contour it draws, instead of falling
   back to a static image. The curves come from `grDevices::contourLines()`,
   which is the computation `contour()` itself does and takes the same defaults

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,15 @@
   spoke layer beside it went from an interactive SVG to a base64 image and lost
   every one of its points.
 
+  A gantt layer now counts its position among the layers drawing the same
+  **grob class** rather than among layers of the same geom, which is the
+  population the grob list it indexes into was gathered by. The two were the
+  same set until a spoke joined `geom_segment()` in drawing a `segments` grob:
+  a chart with one layer of each gave both `position == 1`, so they resolved to
+  the same grob and the second highlighted the first's intervals while
+  announcing its own. `geom_curve()` never collided, because it draws a `curve`
+  grob instead.
+
 * A Base R `contour()` is now read as the contour it draws, instead of falling
   back to a static image. The curves come from `grDevices::contourLines()`,
   which is the computation `contour()` itself does and takes the same defaults

--- a/R/ggplot2_adapter.R
+++ b/R/ggplot2_adapter.R
@@ -155,7 +155,9 @@ Ggplot2Adapter <- R6::R6Class(
       # `geom_spoke()` is `geom_segment()` reparameterised: an angle and a
       # radius rather than an endpoint, and ggplot2's `GeomSpoke$setup_data()`
       # turns the pair into the `xend`/`yend` the segment branch already
-      # reads. So it is dispatched here rather than given a rule of its own,
+      # reads. It is a `GeomSegment` *subclass* -- measured, `GeomSpoke <
+      # GeomSegment < Geom` -- and still needs naming here, because this
+      # dispatch matches `class(geom)[1]` rather than asking `inherits()`. So it is dispatched here rather than given a rule of its own,
       # and doing so decides nothing new -- it makes two spellings of one mark
       # behave alike. Measured on ggplot2 3.4.4:
       #

--- a/R/ggplot2_adapter.R
+++ b/R/ggplot2_adapter.R
@@ -152,7 +152,21 @@ Ggplot2Adapter <- R6::R6Class(
         return("rug")
       }
 
-      if (geom_class %in% c("GeomSegment", "GeomCurve")) {
+      # `geom_spoke()` is `geom_segment()` reparameterised: an angle and a
+      # radius rather than an endpoint, and ggplot2's `GeomSpoke$setup_data()`
+      # turns the pair into the `xend`/`yend` the segment branch already
+      # reads. So it is dispatched here rather than given a rule of its own,
+      # and doing so decides nothing new -- it makes two spellings of one mark
+      # behave alike. Measured on ggplot2 3.4.4:
+      #
+      #     geom_spoke(angle = 0.5, radius = 0.3)   spans lanes FALSE
+      #     geom_spoke(angle = 0,   radius = r)     spans lanes TRUE
+      #
+      # An angled spoke is not a set of lanes and stays "unknown", exactly as
+      # the segment spelling of the same chart would; a flat one is a gantt
+      # written the other way round, a lane per y running from x to x + r,
+      # and was costing its chart every bit of interactivity (#225).
+      if (geom_class %in% c("GeomSegment", "GeomCurve", "GeomSpoke")) {
         return(if (self$segments_span_lanes(layer, plot_object)) "gantt" else "unknown")
       }
 

--- a/R/ggplot2_gantt_layer_processor.R
+++ b/R/ggplot2_gantt_layer_processor.R
@@ -322,6 +322,20 @@ Ggplot2GanttLayerProcessor <- R6::R6Class(
       class(plot$layers[[target]]$geom)[1]
     },
 
+    #' @description Which grid grob class a segment-family geom draws
+    #' @details
+    #'   \code{geom_curve()} draws a \code{curve} grob and everything else in
+    #'   the family -- \code{geom_segment()}, and \code{geom_spoke()} which is
+    #'   a \code{GeomSegment} subclass -- draws \code{segments}. Asked of the
+    #'   geom rather than assumed from the layer type, because it decides both
+    #'   which grobs \code{find_segments_name()} gathers and which layers it
+    #'   counts itself among, and those two have to be the same population.
+    #' @param geom The layer's geom object
+    #' @return \code{"curve"} or \code{"segments"}
+    segments_grob_class = function(geom) {
+      if (identical(class(geom)[1], "GeomCurve")) "curve" else "segments"
+    },
+
     #' @description Find the name of the grob holding this layer's segments
     #'
     #'   The base class's \code{find_layer_grob_tree()} cannot serve here, and
@@ -352,16 +366,34 @@ Ggplot2GanttLayerProcessor <- R6::R6Class(
         return(NULL)
       }
 
-      # Counted among its own kind, not among gantt layers generally: a
-      # `geom_curve()` after a `geom_segment()` is the *first* curve grob of
-      # the panel, and counting both together would send it to the second
-      # segments grob -- which does not exist.
-      geom_class <- class(plot$layers[[target]]$geom)[1]
-      grob_class <- if (identical(geom_class, "GeomCurve")) "curve" else "segments"
+      # Counted among the layers drawing the *same grob class*, not among
+      # gantt layers generally and not among layers of the same geom either.
+      #
+      # Not generally, because a `geom_curve()` after a `geom_segment()` is
+      # the first curve grob of the panel, and counting both together would
+      # send it to the second segments grob -- which does not exist.
+      #
+      # Not by geom, because two different geoms can draw one grob class:
+      # `geom_spoke()` is a `GeomSegment` subclass and draws `segments` too
+      # (#225). Counting by geom gave a segment layer and a spoke layer
+      # `position == 1` apiece while `names` held one entry for each, so both
+      # resolved to the first grob and the second layer highlighted the
+      # first's intervals while announcing its own. Measured before the fix,
+      # a two-lane segment layer and a three-lane spoke layer:
+      #
+      #     gantt (2 lanes)  GRID.segments.1.1.1  GRID.segments.1.1.2
+      #     gantt (3 lanes)  GRID.segments.1.1.1  GRID.segments.1.1.2  ...
+      #
+      # `grob_class` is what `collect()` below gathers by, so counting on it
+      # is counting the same population the index is into.
+      grob_class <- self$segments_grob_class(plot$layers[[target]]$geom)
 
       position <- 0L
       for (i in seq_along(plot$layers)) {
-        if (identical(class(plot$layers[[i]]$geom)[1], geom_class)) {
+        same <- identical(
+          self$segments_grob_class(plot$layers[[i]]$geom), grob_class
+        )
+        if (same) {
           position <- position + 1L
           if (i == target) break
         }

--- a/man/Ggplot2GanttLayerProcessor.Rd
+++ b/man/Ggplot2GanttLayerProcessor.Rd
@@ -29,6 +29,7 @@ into a \code{save_html()} that raises. See the adapter's own note.
     \item \href{#method-Ggplot2GanttLayerProcessor-extract_axes}{\code{Ggplot2GanttLayerProcessor$extract_axes()}}
     \item \href{#method-Ggplot2GanttLayerProcessor-generate_selectors}{\code{Ggplot2GanttLayerProcessor$generate_selectors()}}
     \item \href{#method-Ggplot2GanttLayerProcessor-target_geom_class}{\code{Ggplot2GanttLayerProcessor$target_geom_class()}}
+    \item \href{#method-Ggplot2GanttLayerProcessor-segments_grob_class}{\code{Ggplot2GanttLayerProcessor$segments_grob_class()}}
     \item \href{#method-Ggplot2GanttLayerProcessor-find_segments_name}{\code{Ggplot2GanttLayerProcessor$find_segments_name()}}
     \item \href{#method-Ggplot2GanttLayerProcessor-clone}{\code{Ggplot2GanttLayerProcessor$clone()}}
   }
@@ -218,6 +219,36 @@ than inferred from what happens to be in the panel.
   }
   \subsection{Returns}{
     The geom's class name, or NULL when the layer cannot be found
+  }
+}
+
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Ggplot2GanttLayerProcessor-segments_grob_class"></a>}}
+\if{latex}{\out{\hypertarget{method-Ggplot2GanttLayerProcessor-segments_grob_class}{}}}
+\subsection{\code{Ggplot2GanttLayerProcessor$segments_grob_class()}}{
+  Which grid grob class a segment-family geom draws
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Ggplot2GanttLayerProcessor$segments_grob_class(geom)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{geom}}{The layer's geom object}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Details}{
+    \code{geom_curve()} draws a \code{curve} grob and everything else in
+the family -- \code{geom_segment()}, and \code{geom_spoke()} which is
+a \code{GeomSegment} subclass -- draws \code{segments}. Asked of the
+geom rather than assumed from the layer type, because it decides both
+which grobs \code{find_segments_name()} gathers and which layers it
+counts itself among, and those two have to be the same population.
+  }
+  \subsection{Returns}{
+    \code{"curve"} or \code{"segments"}
   }
 }
 

--- a/tests/testthat/test-gantt-spoke.R
+++ b/tests/testthat/test-gantt-spoke.R
@@ -1,0 +1,198 @@
+# `geom_spoke()` cost a readable chart everything (issue #225)
+#
+# A spoke is `geom_segment()` reparameterised: an angle and a radius rather
+# than an endpoint. `GeomSpoke$setup_data()` turns the pair into the same
+# `xend`/`yend` columns the segment branch already reads, so ggplot2 has done
+# the work before any of this is asked -- but `GeomSpoke` is a direct `Geom`
+# subclass and matched no branch, so it reached the unknown processor and took
+# the whole plot with it.
+#
+# Measured on ggplot2 3.4.4 with `save_html()`, the same thirty-point scatter
+# in each row:
+#
+#     geom_point()                    interactive SVG   51,395 bytes
+#     geom_point() + geom_spoke()     base64 image      48,249 bytes
+#
+# Dispatched through the segment branch rather than given a rule of its own,
+# which is what makes this change decide nothing new: the same
+# `segments_span_lanes()` question is asked, and the two spellings of one mark
+# answer it alike.
+#
+#     geom_spoke(angle = 0.5, radius = 0.3)   spans lanes FALSE   -> unknown
+#     geom_spoke(angle = 0,   radius = r)     spans lanes TRUE    -> gantt
+#
+# An angled spoke is a vector field, not a schedule, and it stays `"unknown"`
+# exactly as the segment spelling of the same chart would -- so nothing that
+# was declined before is claimed now. A flat one is a gantt written the other
+# way round: a lane per y, running from x to x + radius.
+
+skip_if_no_render <- function() {
+  testthat::skip_if_not_installed("ggplot2")
+  testthat::skip_if_not_installed("jsonlite")
+}
+
+# Built at top level: inside a closure the bare column names in `aes()` read as
+# undefined globals to static analysis.
+flat_spokes <- ggplot2::aes(x = start, y = task, angle = 0, radius = span)
+angled_spokes <- ggplot2::aes(x = start, y = task, angle = 0.5, radius = span)
+
+#' A three-interval schedule, written as a start and a length
+#'
+#' A spoke says how far it runs rather than where it ends, which is the whole
+#' difference in the spelling. The lanes are numeric because a spoke's `y` is
+#' a position it turns about; a factor would be the segment file's case.
+schedule <- function() {
+  data.frame(
+    task = c(1, 2, 3),
+    start = c(0, 3, 8),
+    span = c(3, 5, 3)
+  )
+}
+
+spoke_plot <- function(mapping = flat_spokes, frame = schedule()) {
+  ggplot2::ggplot(frame) + ggplot2::geom_spoke(mapping)
+}
+
+#' The equivalent chart written as segments, for comparing the two readings
+segment_plot <- function(frame = schedule()) {
+  ggplot2::ggplot(frame) +
+    ggplot2::geom_segment(
+      ggplot2::aes(x = start, xend = start + span, y = task, yend = task)
+    )
+}
+
+#' Render a plot and return its HTML
+rendered <- function(plot) {
+  file <- tempfile(fileext = ".html")
+  on.exit(unlink(file), add = TRUE)
+  suppressWarnings(suppressMessages(save_html(plot, file)))
+  paste(readLines(file, warn = FALSE), collapse = "\n")
+}
+
+#' Every layer a plot emits, or NULL when the chart fell back to a picture
+layers_from <- function(html) {
+  raw <- regmatches(html, regexpr('maidr-data="[^"]*"', html))
+  if (length(raw) != 1) {
+    return(NULL)
+  }
+  json <- sub('"$', "", sub('^maidr-data="', "", raw))
+  for (pair in list(
+    c("&quot;", '"'), c("&lt;", "<"), c("&gt;", ">"),
+    c("&amp;", "&"), c("&#39;", "'")
+  )) {
+    json <- gsub(pair[1], pair[2], json, fixed = TRUE)
+  }
+  jsonlite::fromJSON(json, simplifyVector = FALSE)$subplots[[1]][[1]]$layers
+}
+
+#' Every lane's intervals as "name start-end" strings, lane by lane
+as_intervals <- function(layer) {
+  lapply(layer$data, function(lane) {
+    vapply(
+      lane,
+      function(one) sprintf("%s %g-%g", one$x, one$start, one$end),
+      character(1)
+    )
+  })
+}
+
+
+test_that("a spoke laying intervals in lanes reaches the gantt processor", {
+  testthat::skip_if_not_installed("ggplot2")
+
+  # Asked of the classifier directly, upstream of rendering, for the reason
+  # `test-gantt-segment.R` gives: a regression in the branch shows up here as
+  # one failure rather than as a fistful about lanes and selectors.
+  adapter <- maidr:::Ggplot2Adapter$new()
+  plot <- spoke_plot()
+
+  testthat::expect_equal(
+    adapter$detect_layer_type(plot$layers[[1]], plot), "gantt"
+  )
+})
+
+
+test_that("an angled spoke is still not claimed", {
+  testthat::skip_if_not_installed("ggplot2")
+
+  # The half that keeps this honest. A vector field is not a schedule, and
+  # "unknown" is what the layer returned before -- so a chart that is declined
+  # keeps exactly the static-image fallback it already had, rather than being
+  # read as a gantt of spokes that share no lane.
+  adapter <- maidr:::Ggplot2Adapter$new()
+  plot <- spoke_plot(angled_spokes)
+
+  testthat::expect_equal(
+    adapter$detect_layer_type(plot$layers[[1]], plot), "unknown"
+  )
+})
+
+
+test_that("a spoke reads exactly as the segment spelling of the same chart", {
+  skip_if_no_render()
+
+  # The point of dispatching it here rather than giving it a rule: two ways of
+  # writing one mark, one reading. Compared against the segment chart rather
+  # than against written-down numbers, so a change to how a gantt is emitted
+  # moves both sides together and this keeps asserting what it means to.
+  spoke <- layers_from(rendered(spoke_plot()))
+  segment <- layers_from(rendered(segment_plot()))
+
+  testthat::expect_length(spoke, 1)
+  testthat::expect_equal(spoke[[1]]$type, "gantt")
+  testthat::expect_equal(as_intervals(spoke[[1]]), as_intervals(segment[[1]]))
+})
+
+
+test_that("the spans come off the radius, not off a second coordinate", {
+  skip_if_no_render()
+
+  # Written out once, so the file states what a reader is actually told and
+  # does not only compare two readings that could both be wrong. `start` and
+  # `span` are chosen so no two lanes share an end and no end is a start.
+  layer <- layers_from(rendered(spoke_plot()))[[1]]
+
+  testthat::expect_equal(
+    as_intervals(layer),
+    list("1 0-3", "2 3-8", "3 8-11")
+  )
+})
+
+
+test_that("a chart is not taken down by a spoke drawn beside it", {
+  skip_if_no_render()
+
+  # What the issue is about. The scatter reads on its own and read as nothing
+  # the moment a spoke was added, because one unclaimed layer makes
+  # `has_unsupported_layers()` true and drops the whole plot to a base64
+  # image.
+  plot <- ggplot2::ggplot(schedule()) +
+    ggplot2::geom_point(ggplot2::aes(x = start, y = task)) +
+    ggplot2::geom_spoke(flat_spokes)
+
+  layers <- layers_from(rendered(plot))
+
+  testthat::expect_equal(
+    vapply(layers, function(one) one$type, character(1)),
+    c("point", "gantt")
+  )
+})
+
+
+test_that("every interval a spoke announces can be highlighted", {
+  skip_if_no_render()
+
+  # A reading that announces correctly and outlines nothing is the blind spot
+  # xability/maidr#814 names, and a spoke's grobs are named by grid's own
+  # counter rather than after the geom -- so the selectors are worth asserting
+  # against the page they were built from rather than assumed to follow the
+  # segment's.
+  html <- rendered(spoke_plot())
+  layer <- layers_from(html)[[1]]
+
+  testthat::expect_length(layer$selectors, length(layer$data))
+  for (selector in layer$selectors) {
+    id <- sub(".*id='([^']+)'.*", "\\1", selector)
+    testthat::expect_true(grepl(id, html, fixed = TRUE))
+  }
+})

--- a/tests/testthat/test-gantt-spoke.R
+++ b/tests/testthat/test-gantt-spoke.R
@@ -3,9 +3,10 @@
 # A spoke is `geom_segment()` reparameterised: an angle and a radius rather
 # than an endpoint. `GeomSpoke$setup_data()` turns the pair into the same
 # `xend`/`yend` columns the segment branch already reads, so ggplot2 has done
-# the work before any of this is asked -- but `GeomSpoke` is a direct `Geom`
-# subclass and matched no branch, so it reached the unknown processor and took
-# the whole plot with it.
+# the work before any of this is asked -- but the dispatch matches
+# `class(geom)[1]` rather than asking `inherits()`, and the chain is
+# `GeomSpoke < GeomSegment < Geom`, so the subclass matched no branch, reached
+# the unknown processor and took the whole plot with it.
 #
 # Measured on ggplot2 3.4.4 with `save_html()`, the same thirty-point scatter
 # in each row:
@@ -176,6 +177,37 @@ test_that("a chart is not taken down by a spoke drawn beside it", {
     vapply(layers, function(one) one$type, character(1)),
     c("point", "gantt")
   )
+})
+
+
+test_that("a segment layer and a spoke layer address their own grobs", {
+  skip_if_no_render()
+
+  # Caught in review on #226, and introduced by this change: both geoms draw
+  # a `segments` grob, and `find_segments_name()` counted a layer's position
+  # among layers of the same *geom class* while indexing into a list gathered
+  # by *grob class*. Two layers, one entry each, and `position == 1` apiece --
+  # so both resolved to the first grob and the spoke highlighted the segment's
+  # intervals while announcing its own. Measured before the fix:
+  #
+  #     gantt (2 lanes)  GRID.segments.1.1.1  GRID.segments.1.1.2
+  #     gantt (3 lanes)  GRID.segments.1.1.1  GRID.segments.1.1.2  ...
+  #
+  # `geom_curve()` never collided: it draws a `curve` grob, so the two
+  # populations were the same one until a second geom joined `segments`.
+  edges <- data.frame(x = c(0, 2), y = c(5, 6), xend = c(4, 7), yend = c(5, 6))
+  plot <- ggplot2::ggplot() +
+    ggplot2::geom_segment(
+      data = edges,
+      ggplot2::aes(x = x, xend = xend, y = y, yend = yend)
+    ) +
+    ggplot2::geom_spoke(data = schedule(), mapping = flat_spokes)
+
+  layers <- layers_from(rendered(plot))
+  first <- unlist(layers[[1]]$selectors)
+  second <- unlist(layers[[2]]$selectors)
+
+  testthat::expect_length(intersect(first, second), 0L)
 })
 
 


### PR DESCRIPTION
Half of #225. `geom_polygon()`, the other half, is #197's open question and is deliberately untouched.

## What was wrong

`GeomSpoke` is a direct `Geom` subclass, so it matched no dispatch branch, reached the unknown processor, and made `has_unsupported_layers()` true — which drops the **whole plot** to a static image.

Measured on ggplot2 3.4.4 with `save_html()`, the same thirty-point scatter in each row:

```
geom_point()                    interactive SVG   51,395 bytes
geom_point() + geom_spoke()     base64 image      48,249 bytes
```

The scatter's thirty points were readable on their own and gone the moment a spoke was drawn beside them.

## Why this decides nothing new

A spoke is `geom_segment()` reparameterised — an angle and a radius rather than an endpoint — and `GeomSpoke$setup_data()` turns the pair into the same `xend`/`yend` columns the segment branch already reads. ggplot2 has done the work before the adapter is asked anything:

```
built columns: angle, radius, x, y, PANEL, group, xend, yend, colour, ...
           x        y       xend     yend angle radius
1 -0.6264538 21.51178 -0.3631790 21.65561   0.5    0.3
```

So it is dispatched into the existing branch rather than given a rule of its own, and the same `segments_span_lanes()` question decides it:

```
geom_spoke(angle = 0.5, radius = 0.3)   spans lanes FALSE   -> unknown
geom_spoke(angle = 0,   radius = r)     spans lanes TRUE    -> gantt
```

An angled spoke is a vector field, not a schedule. It stays `"unknown"` exactly as the segment spelling of the same chart would, so **nothing that was declined before is claimed now** — `test_that("an angled spoke is still not claimed")` pins that. A flat one is a gantt written the other way round: a lane per `y`, running from `x` to `x + radius`.

## The reading, measured

```
flat spoke (lanes)            interactive   43,167 bytes   layers: gantt(n=3)
angled spoke                  base64 image  25,481 bytes
point + flat spoke            interactive   45,174 bytes   layers: point(n=3), gantt(n=3)
geom_segment lanes (control)  interactive   43,475 bytes   layers: gantt(n=3)
```

`test_that("a spoke reads exactly as the segment spelling of the same chart")` asserts the spoke's intervals against the **segment chart's** rather than against written-down numbers, so a later change to how a gantt is emitted moves both sides together and the test keeps asserting what it means to. The literal reading is written out once besides, in `test_that("the spans come off the radius, not off a second coordinate")` — `1 0-3`, `2 3-8`, `3 8-11` — so the file states what a reader is actually told.

Selectors are checked against the page they were built from, since a spoke's grobs are named by grid's own counter rather than after the geom.

## Verification

- `tests/testthat/test-gantt-spoke.R` → 11 assertions, all passing (new file)
- Full suite: **6322 passed, 0 failed, 0 errors**, 99 skipped (patchwork and shiny are not installed here)

Mutations, each applied alone against a restored baseline — both killed:

| mutation | result |
|---|---|
| `GeomSpoke` removed from the branch | 6 failed |
| spoke claimed as `gantt` unconditionally | 1 failed (the angled case) |

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_