### PR TITLE
fix(ggplot2): stop a layer that drew nothing from costing the whole chart

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,29 @@
 # maidr (development version)
 
+## Bug Fixes
+
+* A layer that drew **nothing** no longer costs the whole chart its
+  interactivity. An unclaimed layer makes the plot fall back to a static
+  image, which is right when the layer put a mark on the page that nothing
+  describes -- a reader told the chart was complete would be told wrong -- and
+  wrong when it drew nothing at all, because then there is no mark and the
+  chart pays everything to protect the reader from an absence. Measured on
+  thirty points, `geom_point() + geom_polygon(data = frame[0, ])` was a 27,368
+  byte base64 image where `geom_point() + geom_point(data = frame[0, ])` was a
+  51,313 byte interactive SVG: the same chart in every way a reader could
+  tell, and only one of them accessible, because one empty layer happened to
+  be of a *kind* the adapter names.
+
+  The case this turns up in is a missing **Suggests** package.
+  `geom_quantile()` without **quantreg** warns, computes no rows and draws
+  nothing; ggplot2 carries on and the figure silently stopped being
+  accessible, with no second warning connecting the two.
+
+  Nothing here changes which geoms are readable. A `geom_polygon()` with data
+  in it is still declined and still costs its chart exactly what it cost
+  before, and a plot made only of empty unclaimed layers still falls back
+  rather than announcing itself as an interactive chart with nothing in it.
+
 ## New Features
 
 * `geom_spoke()` is now read as the gantt chart it draws, where it draws one.

--- a/R/ggplot2_adapter.R
+++ b/R/ggplot2_adapter.R
@@ -169,7 +169,10 @@ Ggplot2Adapter <- R6::R6Class(
       # written the other way round, a lane per y running from x to x + r,
       # and was costing its chart every bit of interactivity (#225).
       if (geom_class %in% c("GeomSegment", "GeomCurve", "GeomSpoke")) {
-        return(if (self$segments_span_lanes(layer, plot_object)) "gantt" else "unknown")
+        if (self$segments_span_lanes(layer, plot_object)) {
+          return("gantt")
+        }
+        return(self$unread_layer_type(layer, plot_object))
       }
 
       if (geom_class %in% c("GeomLine", "GeomPath", "GeomMA")) {
@@ -378,7 +381,7 @@ Ggplot2Adapter <- R6::R6Class(
         return("skip")
       }
 
-      "unknown"
+      self$unread_layer_type(layer, plot_object)
     },
 
     #' @description Check if a bar layer is drawn as pie wedges
@@ -604,6 +607,73 @@ Ggplot2Adapter <- R6::R6Class(
       }
 
       !is.null(segment_lane_axis(built$data[[index]]))
+    },
+
+    #' @description The answer for a layer no branch above claimed
+    #'
+    #' \code{"unknown"} is what makes \code{has_unsupported_layers()} true and
+    #' drops the whole plot to a static image. That is right for a layer
+    #' carrying marks nothing describes: a filled \code{geom_polygon()} is
+    #' drawn, and a reader told the chart was complete would be told wrong.
+    #'
+    #' It is not right for a layer that drew nothing. Then there is no mark,
+    #' so there is nothing the reader is missing, and the chart pays
+    #' everything to protect them from an absence. Measured with
+    #' \code{save_html()} on thirty points:
+    #'
+    #' \preformatted{
+    #' geom_point()                                interactive   50,406 bytes
+    #' geom_point() + geom_point(data = d[0, ])    interactive   51,313 bytes
+    #' geom_point() + geom_polygon(data = d[0, ])  base64 image  27,368 bytes
+    #' geom_point() + geom_polygon()               base64 image  31,848 bytes
+    #' }
+    #'
+    #' Rows two and three are the same chart in every way a reader could tell
+    #' -- thirty points and a layer of nothing -- and only one of them was
+    #' interactive, because its empty layer happened to be of a \emph{kind}
+    #' this function names. Row four is the case the fallback exists for, and
+    #' it keeps falling back.
+    #'
+    #' The case this turns up in is not contrived: a missing \strong{Suggests}
+    #' package. \code{geom_quantile()} without \pkg{quantreg} warns, computes
+    #' no rows and draws nothing; ggplot2 carries on and r-maidr turned the
+    #' whole figure into a picture, with no second warning connecting the two
+    #' (#227).
+    #'
+    #' A plot made only of such layers still falls back, for the reason #176
+    #' gives: \code{has_unsupported_layers()} is true when \emph{every} layer
+    #' is \code{"skip"} as well, so "nothing unsupported" cannot quietly come
+    #' to mean "nothing at all".
+    #'
+    #' Nothing here decides which geoms are readable. A \code{geom_polygon()}
+    #' with data in it is still \code{"unknown"} and still costs its chart
+    #' exactly what it costs today.
+    #'
+    #' @param layer The layer being classified
+    #' @param plot_object The ggplot2 plot object
+    #' @return \code{"skip"} when the layer drew no rows, \code{"unknown"}
+    #'   otherwise
+    unread_layer_type = function(layer, plot_object) {
+      built <- tryCatch(
+        ggplot2::ggplot_build(plot_object),
+        error = function(e) NULL
+      )
+      if (is.null(built)) {
+        return("unknown")
+      }
+
+      index <- self$find_layer_index(plot_object, layer)
+      if (is.null(index) || index < 1L || index > length(built$data)) {
+        return("unknown")
+      }
+
+      # `isTRUE` rather than a bare comparison, so that absent is not read as
+      # empty: `nrow(NULL)` is `NULL`, and `NULL == 0L` is `logical(0)` rather
+      # than either answer. A build that said nothing about what this layer
+      # drew declines, which keeps a drawn-but-unreadable mark from being
+      # waved through -- and it declines without a branch of its own, which
+      # would be one no chart can reach and so no test can hold.
+      if (isTRUE(nrow(built$data[[index]]) == 0L)) "skip" else "unknown"
     }
   )
 )

--- a/man/Ggplot2Adapter.Rd
+++ b/man/Ggplot2Adapter.Rd
@@ -30,6 +30,7 @@ ggplot2 functionality to work with the new extensible architecture.
     \item \href{#method-Ggplot2Adapter-is_patchwork}{\code{Ggplot2Adapter$is_patchwork()}}
     \item \href{#method-Ggplot2Adapter-ribbon_is_area}{\code{Ggplot2Adapter$ribbon_is_area()}}
     \item \href{#method-Ggplot2Adapter-segments_span_lanes}{\code{Ggplot2Adapter$segments_span_lanes()}}
+    \item \href{#method-Ggplot2Adapter-unread_layer_type}{\code{Ggplot2Adapter$unread_layer_type()}}
     \item \href{#method-Ggplot2Adapter-clone}{\code{Ggplot2Adapter$clone()}}
   }
 }
@@ -347,6 +348,68 @@ missing a quarter of its chart.
   }
   \subsection{Returns}{
     TRUE when the layer's segments lay intervals in lanes
+  }
+}
+
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Ggplot2Adapter-unread_layer_type"></a>}}
+\if{latex}{\out{\hypertarget{method-Ggplot2Adapter-unread_layer_type}{}}}
+\subsection{\code{Ggplot2Adapter$unread_layer_type()}}{
+  The answer for a layer no branch above claimed
+
+\code{"unknown"} is what makes \code{has_unsupported_layers()} true and
+drops the whole plot to a static image. That is right for a layer
+carrying marks nothing describes: a filled \code{geom_polygon()} is
+drawn, and a reader told the chart was complete would be told wrong.
+
+It is not right for a layer that drew nothing. Then there is no mark,
+so there is nothing the reader is missing, and the chart pays
+everything to protect them from an absence. Measured with
+\code{save_html()} on thirty points:
+
+\preformatted{
+geom_point()                                interactive   50,406 bytes
+geom_point() + geom_point(data = d[0, ])    interactive   51,313 bytes
+geom_point() + geom_polygon(data = d[0, ])  base64 image  27,368 bytes
+geom_point() + geom_polygon()               base64 image  31,848 bytes
+}
+
+Rows two and three are the same chart in every way a reader could tell
+-- thirty points and a layer of nothing -- and only one of them was
+interactive, because its empty layer happened to be of a \emph{kind}
+this function names. Row four is the case the fallback exists for, and
+it keeps falling back.
+
+The case this turns up in is not contrived: a missing \strong{Suggests}
+package. \code{geom_quantile()} without \pkg{quantreg} warns, computes
+no rows and draws nothing; ggplot2 carries on and r-maidr turned the
+whole figure into a picture, with no second warning connecting the two
+(#227).
+
+A plot made only of such layers still falls back, for the reason #176
+gives: \code{has_unsupported_layers()} is true when \emph{every} layer
+is \code{"skip"} as well, so "nothing unsupported" cannot quietly come
+to mean "nothing at all".
+
+Nothing here decides which geoms are readable. A \code{geom_polygon()}
+with data in it is still \code{"unknown"} and still costs its chart
+exactly what it costs today.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Ggplot2Adapter$unread_layer_type(layer, plot_object)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer}}{The layer being classified}
+      \item{\code{plot_object}}{The ggplot2 plot object}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    \code{"skip"} when the layer drew no rows, \code{"unknown"}
+otherwise
   }
 }
 

--- a/tests/testthat/test-empty-unknown-layer.R
+++ b/tests/testthat/test-empty-unknown-layer.R
@@ -1,0 +1,248 @@
+# A layer that drew nothing still cost the whole chart its interactivity (#227)
+#
+# An unclaimed layer makes `has_unsupported_layers()` true and drops the plot
+# to a base64 image. That is right when the layer put a mark on the page that
+# nothing describes -- a reader told the chart is complete would be told
+# wrong. It is not right when the layer drew *nothing*: there is no mark, so
+# there is nothing the reader is missing, and the chart pays everything to
+# protect them from an absence.
+#
+# Measured with `save_html()` on ggplot2 3.4.4, thirty points in each row:
+#
+#     geom_point()                                interactive   50,406 bytes
+#     geom_point() + geom_point(data = d[0, ])    interactive   51,313 bytes
+#     geom_point() + geom_polygon(data = d[0, ])  base64 image  27,368 bytes
+#     geom_point() + geom_polygon()               base64 image  31,848 bytes
+#
+# Rows two and three are the same chart in every way a reader could tell --
+# thirty points and a layer of nothing -- and only one was interactive,
+# because its empty layer happened to be of a *kind* the adapter names. Row
+# four is the case the fallback exists for and keeps.
+#
+# The case it turns up in is not contrived: a missing Suggests package.
+# `geom_quantile()` without quantreg warns, computes no rows and draws
+# nothing. ggplot2 carries on; r-maidr turned the whole figure into a picture
+# with no second warning connecting the two.
+
+skip_if_no_render <- function() {
+  testthat::skip_if_not_installed("ggplot2")
+  testthat::skip_if_not_installed("jsonlite")
+}
+
+# Built at top level: inside a closure the bare column names in `aes()` read
+# as undefined globals to static analysis.
+positions <- ggplot2::aes(x = x, y = y)
+diagonals <- ggplot2::aes(x = x, xend = x + 1, y = y, yend = y + 1)
+missing_column <- ggplot2::aes(x = no_such_column, y = y)
+
+#' Thirty points on a rising diagonal
+observations <- function() {
+  data.frame(x = seq_len(30), y = seq_len(30) + 0.5)
+}
+
+#' The same frame with every row removed
+#'
+#' An empty `data =` is one of several ways to reach a layer that draws
+#' nothing; a stat that filters everything out and a stat whose computation
+#' failed are the others, and all three arrive here as zero built rows.
+nothing <- function() {
+  observations()[0, ]
+}
+
+#' Render a plot and return its HTML
+rendered <- function(plot) {
+  file <- tempfile(fileext = ".html")
+  on.exit(unlink(file), add = TRUE)
+  suppressWarnings(suppressMessages(save_html(plot, file)))
+  paste(readLines(file, warn = FALSE), collapse = "\n")
+}
+
+#' Whether a rendering is the static-image fallback rather than a chart
+fell_back <- function(html) {
+  grepl("base64", html, fixed = TRUE)
+}
+
+#' Every layer a plot emits, or NULL when the chart fell back to a picture
+layers_from <- function(html) {
+  raw <- regmatches(html, regexpr('maidr-data="[^"]*"', html))
+  if (length(raw) != 1) {
+    return(NULL)
+  }
+  json <- sub('"$', "", sub('^maidr-data="', "", raw))
+  for (pair in list(
+    c("&quot;", '"'), c("&lt;", "<"), c("&gt;", ">"),
+    c("&amp;", "&"), c("&#39;", "'")
+  )) {
+    json <- gsub(pair[1], pair[2], json, fixed = TRUE)
+  }
+  jsonlite::fromJSON(json, simplifyVector = FALSE)$subplots[[1]][[1]]$layers
+}
+
+
+test_that("an unclaimed layer that drew nothing is skipped, not unknown", {
+  testthat::skip_if_not_installed("ggplot2")
+
+  # Asked of the classifier directly, upstream of rendering, so a regression
+  # here shows up as one failure rather than as a fistful about fallbacks.
+  adapter <- maidr:::Ggplot2Adapter$new()
+  plot <- ggplot2::ggplot(observations(), positions) +
+    ggplot2::geom_point() +
+    ggplot2::geom_polygon(data = nothing())
+
+  testthat::expect_equal(
+    adapter$detect_layer_type(plot$layers[[2]], plot), "skip"
+  )
+})
+
+
+test_that("an unclaimed layer that drew something is still unknown", {
+  testthat::skip_if_not_installed("ggplot2")
+
+  # The half that keeps this honest. A filled polygon is drawn and nothing
+  # announces it, so declining the chart is what protects the reader -- and
+  # this change must not touch it.
+  adapter <- maidr:::Ggplot2Adapter$new()
+  plot <- ggplot2::ggplot(observations(), positions) +
+    ggplot2::geom_point() +
+    ggplot2::geom_polygon(alpha = 0.2)
+
+  testthat::expect_equal(
+    adapter$detect_layer_type(plot$layers[[2]], plot), "unknown"
+  )
+})
+
+
+test_that("a chart is not taken down by a layer with nothing in it", {
+  skip_if_no_render()
+
+  html <- rendered(
+    ggplot2::ggplot(observations(), positions) +
+      ggplot2::geom_point() +
+      ggplot2::geom_polygon(data = nothing())
+  )
+
+  testthat::expect_false(fell_back(html))
+  testthat::expect_equal(
+    vapply(layers_from(html), function(one) one$type, character(1)), "point"
+  )
+})
+
+
+test_that("a chart is still taken down by a layer with something in it", {
+  skip_if_no_render()
+
+  testthat::expect_true(fell_back(rendered(
+    ggplot2::ggplot(observations(), positions) +
+      ggplot2::geom_point() +
+      ggplot2::geom_polygon(alpha = 0.2)
+  )))
+})
+
+
+test_that("a plot made only of empty unclaimed layers still falls back", {
+  skip_if_no_render()
+
+  # The trap #176 named, from the other side: "nothing unsupported" must not
+  # quietly come to mean "nothing at all". A chart announcing itself as
+  # interactive with no layers in it is worse than an image, because an image
+  # at least says what it is. `has_unsupported_layers()` catches it because
+  # every layer now reads "skip".
+  testthat::expect_true(fell_back(rendered(
+    ggplot2::ggplot(observations(), positions) +
+      ggplot2::geom_polygon(data = nothing())
+  )))
+})
+
+
+test_that("the segment branch declines through the same answer", {
+  testthat::skip_if_not_installed("ggplot2")
+
+  # `geom_segment()` has a rule of its own and returns "unknown" when its
+  # segments lay no lanes (#194). That decline is the same decline, so an
+  # empty segment layer must skip and a drawn one that spans no lanes must
+  # not -- otherwise the fix would hold at one of the two places the adapter
+  # says "unknown" and not the other.
+  adapter <- maidr:::Ggplot2Adapter$new()
+
+  empty <- ggplot2::ggplot(observations(), positions) +
+    ggplot2::geom_point() +
+    ggplot2::geom_segment(data = nothing(), mapping = diagonals)
+  drawn <- ggplot2::ggplot(observations(), positions) +
+    ggplot2::geom_point() +
+    ggplot2::geom_segment(mapping = diagonals)
+
+  testthat::expect_equal(
+    adapter$detect_layer_type(empty$layers[[2]], empty), "skip"
+  )
+  testthat::expect_equal(
+    adapter$detect_layer_type(drawn$layers[[2]], drawn), "unknown"
+  )
+})
+
+
+test_that("a layer the build says nothing about is declined", {
+  testthat::skip_if_not_installed("ggplot2")
+
+  # Absent is not empty. A layer that is not in this plot has no frame in
+  # this build, and answering "skip" for it would wave through a mark that
+  # may well have been drawn -- so the conservative answer is the one that
+  # keeps costing what it costs.
+  adapter <- maidr:::Ggplot2Adapter$new()
+  plot <- ggplot2::ggplot(observations(), positions) + ggplot2::geom_point()
+  stranger <- ggplot2::ggplot(observations(), positions) +
+    ggplot2::geom_polygon()
+
+  testthat::expect_equal(
+    adapter$unread_layer_type(stranger$layers[[1]], plot), "unknown"
+  )
+  testthat::expect_equal(adapter$detect_layer_type(NULL, plot), "unknown")
+})
+
+
+test_that("a stat whose computation failed does not cost the chart everything", {
+  skip_if_no_render()
+  testthat::skip_if(
+    requireNamespace("quantreg", quietly = TRUE),
+    "quantreg is installed, so stat_quantile() computes rows"
+  )
+
+  # The case #227 was actually found through, and the reason this is worth
+  # more than an argument about empty data frames. `stat_quantile()` needs a
+  # Suggests package; without it ggplot2 warns, computes no rows, draws the
+  # rest of the chart and carries on. Measured before the fix, the same
+  # thirty points:
+  #
+  #     geom_point()                    interactive SVG   50,406 bytes
+  #     geom_point() + geom_quantile()  base64 image      27,368 bytes
+  #
+  # No second warning said the figure had stopped being accessible, and
+  # nothing connected the two.
+  plot <- ggplot2::ggplot(observations(), positions) +
+    ggplot2::geom_point() +
+    ggplot2::geom_quantile()
+
+  html <- rendered(plot)
+
+  testthat::expect_false(fell_back(html))
+  testthat::expect_equal(
+    vapply(layers_from(html), function(one) one$type, character(1)), "point"
+  )
+})
+
+
+test_that("a plot that cannot be built is declined rather than skipped", {
+  testthat::skip_if_not_installed("ggplot2")
+
+  # The emptiness is read off the built data, so a build that raises has said
+  # nothing about what any layer drew. Answering "skip" there would wave
+  # through marks that may well have been drawn -- and a plot broken enough
+  # not to build is the last one to guess about.
+  adapter <- maidr:::Ggplot2Adapter$new()
+  broken <- ggplot2::ggplot(observations(), missing_column) +
+    ggplot2::geom_polygon()
+
+  testthat::expect_error(suppressWarnings(ggplot2::ggplot_build(broken)))
+  testthat::expect_equal(
+    adapter$detect_layer_type(broken$layers[[1]], broken), "unknown"
+  )
+})

--- a/tests/testthat/test-empty-unknown-layer.R
+++ b/tests/testthat/test-empty-unknown-layer.R
@@ -199,27 +199,38 @@ test_that("a layer the build says nothing about is declined", {
 })
 
 
-test_that("a stat whose computation failed does not cost the chart everything", {
+test_that("a stat that computed nothing does not cost the chart everything", {
   skip_if_no_render()
-  testthat::skip_if(
-    requireNamespace("quantreg", quietly = TRUE),
-    "quantreg is installed, so stat_quantile() computes rows"
-  )
 
-  # The case #227 was actually found through, and the reason this is worth
-  # more than an argument about empty data frames. `stat_quantile()` needs a
-  # Suggests package; without it ggplot2 warns, computes no rows, draws the
-  # rest of the chart and carries on. Measured before the fix, the same
-  # thirty points:
+  # The shape #227 was actually found through, and the reason this is worth
+  # more than an argument about empty data frames. A layer's rows can vanish
+  # in the *stat* rather than in its input: a filter that matched nothing, an
+  # aggregate over no groups, or -- the measured case -- a stat that could
+  # not run because a Suggests package is absent. `stat_quantile()` without
+  # quantreg warns, computes no rows, and ggplot2 draws the rest of the chart
+  # and carries on. Measured before the fix, the same thirty points:
   #
   #     geom_point()                    interactive SVG   50,406 bytes
   #     geom_point() + geom_quantile()  base64 image      27,368 bytes
   #
-  # No second warning said the figure had stopped being accessible, and
-  # nothing connected the two.
+  # No second warning said the figure had stopped being accessible.
+  #
+  # Written with a stat of its own rather than by calling `geom_quantile()`:
+  # naming quantreg here makes `R CMD check` report it as an unstated
+  # dependency of the tests, and declaring it to satisfy that would install
+  # it in CI and stop the case from arising at all. The stat below reaches
+  # the same state the classifier sees -- a layer with zero built rows,
+  # arrived at by computation rather than by an empty input.
+  nothing_at_all <- ggplot2::ggproto(
+    "StatNothingAtAll", ggplot2::Stat,
+    compute_group = function(data, scales) data[0, , drop = FALSE]
+  )
   plot <- ggplot2::ggplot(observations(), positions) +
     ggplot2::geom_point() +
-    ggplot2::geom_quantile()
+    ggplot2::layer(
+      stat = nothing_at_all, geom = "polygon", position = "identity",
+      data = observations(), mapping = positions
+    )
 
   html <- rendered(plot)
 


### PR DESCRIPTION
Closes #227.

An unclaimed layer makes `has_unsupported_layers()` true and drops the plot to a base64 image. That is right when the layer put a mark on the page nothing describes — a reader told the chart is complete would be told wrong. It is not right when the layer drew **nothing at all**: there is no mark, so there is nothing the reader is missing, and the chart pays everything to protect them from an absence.

Measured with `save_html()` on ggplot2 3.4.4, thirty points in each row:

| chart | before | after |
|---|---|---|
| `geom_point()` | interactive, 50,406 B | unchanged |
| `geom_point() + geom_point(data = d[0, ])` | interactive, 51,313 B | unchanged |
| `geom_point() + geom_polygon(data = d[0, ])` | **base64 image, 27,368 B** | **interactive** |
| `geom_point() + geom_quantile()` | **base64 image, 27,368 B** | **interactive** |
| `geom_point() + geom_polygon()` | base64 image, 31,848 B | unchanged |

Rows two and three were the same chart in every way a reader could tell — thirty points and a layer of nothing — and only one of them was accessible, because its empty layer happened to be of a *kind* the adapter names. Row five is the case the fallback exists for, and it keeps falling back.

## The case this turns up in

Row four was not contrived. It is what a missing **Suggests** package does:

```
Warning: Computation failed in `stat_quantile()`
Caused by error in `compute_group()`:
! The package "quantreg" is required for `stat_quantile()`
```

`ggplot_build()` reports `30, 0` rows. ggplot2 warns, draws the rest and carries on; r-maidr turned the whole figure into a picture, with no second warning saying the chart had stopped being accessible and nothing connecting the two.

## What changed

Both places the adapter answers `"unknown"` — the fall-through and the `geom_segment()` decline (#194) — now route through one `unread_layer_type()` that asks the built data first and returns `"skip"` when the layer drew no rows. Routing both matters: fixing only the fall-through would leave an empty `geom_segment()` layer still costing its chart everything, and the two declines mean the same thing.

Emptiness is read off `ggplot_build()` for the reason `segments_span_lanes()` reads it there: a mapping expression cannot say how many rows survived a stat, and by build time ggplot2 has resolved it.

## What did not change

- A `geom_polygon()` **with data in it** is still `"unknown"` and still costs its chart exactly what it cost before. This decides nothing new about which geoms are readable.
- A plot made **only** of empty unclaimed layers still falls back, because `has_unsupported_layers()` is also true when every layer is `"skip"` — the trap #176 named, that "nothing unsupported" must not quietly come to mean "nothing at all".
- A plot that cannot be built at all declines rather than skipping: a build that raised has said nothing about what any layer drew.

## Not in scope

`geom_quantile()` deserves a reading of its own. `GeomQuantile` is a `GeomPath` subclass, so `class(geom)[1]` dispatch misses it the way it missed `GeomFunction` (#202) and `GeomSpoke` (#225), and a quantile-regression fit is a `smooth` rather than a `line` for the reason `StatFunction` is. Verifying that reading end to end needs **quantreg** installed, so it belongs in its own issue — and it is not what makes the chart fall back today, since without that package the layer draws nothing at all.

## Verification

`testthat::test_dir("tests/testthat")` — **6337 passed, 0 failed, 0 errors**, up from 6323. `man/Ggplot2Adapter.Rd` regenerated with roxygen2.

14 new assertions. Mutation sweep, each change applied alone against a restored baseline:

| mutation | outcome |
|---|---|
| never skip an empty layer | killed (6) |
| always skip, drawn or not | killed (3) |
| segment branch declines plainly again | killed (1) |
| a build failure skips | killed (1) |
| fall-through declines plainly again | killed (5) |
| a layer not in this plot skips | killed (1) |
| `isTRUE(...)` → `!isFALSE(...)` | **survived** |

The survivor is reported rather than papered over. The two spellings differ only when `nrow()` returns `NULL`, which an in-range index into a built plot's data cannot produce — so it is a defensive *spelling*, not a branch, and the comment beside it says exactly that. The first sweep also had a `!is.data.frame(rows)` branch guarding the same thing; that one *was* an unreachable branch, and it was removed rather than left as untestable code with a comment claiming a distinction no chart can reach.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_