### PR TITLE
fix(ggplot2): read geom_quantile as the fitted curve it draws

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,12 @@
   made `stat_quantile(geom = "point")` a second instance of an existing
   crash, which is reported separately rather than matched.
 
+  A quantile layer that drew *nothing* keeps the answer it had before:
+  skipped, not claimed. `geom_quantile()` without **quantreg** computes no
+  rows, and it is the case that rule was written for, so claiming it on the
+  geom regardless would have put an empty layer in the schema for a chart
+  that had none.
+
 * A layer that drew **nothing** no longer costs the whole chart its
   interactivity. An unclaimed layer makes the plot fall back to a static
   image, which is right when the layer put a mark on the page that nothing

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,25 @@
 
 ## Bug Fixes
 
+* `geom_quantile()` is now read as the fitted curve it draws, instead of
+  costing its chart every bit of interactivity. `GeomQuantile` is a
+  `GeomPath` subclass and dispatch matches the first class name, so it
+  matched no branch and reached the unknown processor -- the third geom
+  missed this way, after `geom_function()` and `geom_spoke()`. Measured on
+  thirty points, a scatter went from a 50,409 byte interactive SVG to a
+  44,724 byte base64 image the moment a quantile fit was drawn beside it,
+  while the *mean* fit beside the same points read fine.
+
+  It reads as a `smooth` rather than a `line` for the reason `stat_function()`
+  does: `stat_quantile()` fits `rq`/`rqss` and evaluates it at
+  renderer-chosen positions exactly as `stat_smooth()` does for the
+  conditional mean, so the curve is a model over the data rather than a
+  series of it.
+
+  Keyed on the geom alone. The symmetric `StatQuantile` addition would have
+  made `stat_quantile(geom = "point")` a second instance of an existing
+  crash, which is reported separately rather than matched.
+
 * A layer that drew **nothing** no longer costs the whole chart its
   interactivity. An unclaimed layer makes the plot fall back to a static
   image, which is right when the layer put a mark on the page that nothing

--- a/R/ggplot2_adapter.R
+++ b/R/ggplot2_adapter.R
@@ -188,7 +188,33 @@ Ggplot2Adapter <- R6::R6Class(
       if (geom_class == "GeomFunction" || stat_class == "StatFunction") {
         return("smooth")
       }
-      if (geom_class == "GeomSmooth" || stat_class == "StatDensity") {
+      # `GeomQuantile` is a `GeomPath` too, so it reached the line branch's
+      # name check, matched nothing, and took its chart down with it -- the
+      # third geom to be missed for being a subclass of a read one, after
+      # `GeomFunction` (#202) and `GeomSpoke` (#225). Measured on thirty
+      # points with a quantile layer that draws:
+      #
+      #     geom_point()                            interactive   50,409 bytes
+      #     geom_point() + a GeomQuantile layer     base64 image  44,724 bytes
+      #     geom_point() + geom_smooth(se = FALSE)  interactive   57,823 bytes
+      #
+      # `smooth` rather than `line` for the reason `StatFunction` is:
+      # `stat_quantile()` fits `rq`/`rqss` and evaluates it at
+      # renderer-chosen positions, exactly as `stat_smooth()` does for the
+      # conditional mean, so the curve is a model over the data rather than
+      # a series of it. Reading it as a line would announce a fit as
+      # observations (#229).
+      # Keyed on the geom alone, deliberately. `StatQuantile` would have been
+      # the symmetric addition beside `StatDensity`, and it is a trap: a stat
+      # check claims `stat_quantile(geom = "point")`, whose `GeomPoint` the
+      # smooth processor does not recognise, so `resolve_target_layer()`
+      # falls through and stops the render outright. Measured on `main`, the
+      # `StatFunction` check above already does this --
+      # `stat_function(fun = sin, geom = "point")` raises "No smooth curve
+      # layers found in plot" out of `save_html()` (#230). Reported rather
+      # than matched.
+      if (geom_class %in% c("GeomSmooth", "GeomQuantile") ||
+            stat_class == "StatDensity") {
         return("smooth")
       }
 

--- a/R/ggplot2_adapter.R
+++ b/R/ggplot2_adapter.R
@@ -215,6 +215,22 @@ Ggplot2Adapter <- R6::R6Class(
       # than matched.
       if (geom_class %in% c("GeomSmooth", "GeomQuantile") ||
             stat_class == "StatDensity") {
+        # A quantile layer that drew nothing keeps the answer #227 gave it.
+        # `geom_quantile()` without quantreg is the case that rule was
+        # written for -- it is named in `layer_drew_nothing()`'s own docs --
+        # and claiming it regardless would put an empty `smooth` layer in the
+        # schema for a chart that had none: a series a reader can walk into
+        # and find nothing in, which is #421's shape. Caught in review on
+        # #231.
+        #
+        # Asked of `GeomQuantile` alone, because it is the only claim this
+        # branch newly makes and the only one that costs a second
+        # `ggplot_build()`. `geom_smooth(data = frame[0, ])` emits the same
+        # empty layer today and is left exactly as it was (#232).
+        if (geom_class == "GeomQuantile" &&
+              self$layer_drew_nothing(layer, plot_object)) {
+          return("skip")
+        }
         return("smooth")
       }
 
@@ -680,26 +696,51 @@ Ggplot2Adapter <- R6::R6Class(
     #' @return \code{"skip"} when the layer drew no rows, \code{"unknown"}
     #'   otherwise
     unread_layer_type = function(layer, plot_object) {
+      if (self$layer_drew_nothing(layer, plot_object)) "skip" else "unknown"
+    },
+
+    #' @description Whether a layer put no mark on the page at all
+    #'
+    #' A layer's rows can vanish in its input, in a filter, in an aggregate
+    #' over no groups, or -- the case #227 was found through -- in a stat that
+    #' could not run because a \strong{Suggests} package is absent. All four
+    #' arrive here identically: \code{ggplot_build()} reports zero rows for
+    #' that layer while ggplot2 warns, draws the rest of the chart and carries
+    #' on.
+    #'
+    #' Asked by \code{unread_layer_type()}, which turns it into \code{"skip"}
+    #' rather than \code{"unknown"}, and by the quantile branch of
+    #' \code{detect_layer_type()}, which uses it to keep from claiming a
+    #' curve that was never drawn (#229). Kept as its own method for that
+    #' second caller: a rule two branches ask is a rule, not a fall-through.
+    #'
+    #' Declines whenever the build cannot answer -- it raised, or gave this
+    #' layer no frame. Absent is not empty: a build that said nothing about
+    #' what a layer drew must not have that read as "it drew nothing", which
+    #' would wave a mark through as harmless.
+    #'
+    #' @param layer The layer being asked about
+    #' @param plot_object The ggplot2 plot object
+    #' @return TRUE when the layer built no rows
+    layer_drew_nothing = function(layer, plot_object) {
       built <- tryCatch(
         ggplot2::ggplot_build(plot_object),
         error = function(e) NULL
       )
       if (is.null(built)) {
-        return("unknown")
+        return(FALSE)
       }
 
       index <- self$find_layer_index(plot_object, layer)
       if (is.null(index) || index < 1L || index > length(built$data)) {
-        return("unknown")
+        return(FALSE)
       }
 
       # `isTRUE` rather than a bare comparison, so that absent is not read as
       # empty: `nrow(NULL)` is `NULL`, and `NULL == 0L` is `logical(0)` rather
-      # than either answer. A build that said nothing about what this layer
-      # drew declines, which keeps a drawn-but-unreadable mark from being
-      # waved through -- and it declines without a branch of its own, which
+      # than either answer. It declines without a branch of its own, which
       # would be one no chart can reach and so no test can hold.
-      if (isTRUE(nrow(built$data[[index]]) == 0L)) "skip" else "unknown"
+      isTRUE(nrow(built$data[[index]]) == 0L)
     }
   )
 )

--- a/R/ggplot2_smooth_layer_processor.R
+++ b/R/ggplot2_smooth_layer_processor.R
@@ -123,21 +123,30 @@ Ggplot2SmoothLayerProcessor <- R6::R6Class(
     resolve_target_layer = function(plot) {
       layer_index <- self$get_layer_index()
       own_layer <- plot$layers[[layer_index]]
-      # `GeomFunction` is named rather than reached through `GeomPath`,
-      # which it inherits: a plain `geom_path()` is typed `line` and never
-      # arrives here, so widening to the parent would claim nothing extra
-      # and would blur what this list is for -- the geoms that draw a
-      # *computed* curve (#202).
+      # `GeomFunction` and `GeomQuantile` are named rather than reached
+      # through `GeomPath`, which they both inherit: a plain `geom_path()`
+      # is typed `line` and never arrives here, so widening to the parent
+      # would claim nothing extra and would blur what this list is for --
+      # the geoms that draw a *computed* curve (#202, #229).
       is_smooth_like <- inherits(own_layer$geom, "GeomSmooth") ||
         inherits(own_layer$geom, "GeomLine") ||
         inherits(own_layer$geom, "GeomDensity") ||
         inherits(own_layer$geom, "GeomFunction") ||
+        inherits(own_layer$geom, "GeomQuantile") ||
         inherits(own_layer$geom, "GeomArea")
 
       if (is_smooth_like) {
         return(layer_index)
       }
 
+      # Deliberately not the same list as `is_smooth_like` above:
+      # `GeomQuantile` is missing here. This search only runs when the
+      # layer's *own* geom was rejected, which a quantile layer's never is,
+      # so adding it would reach nothing -- except the case #230 describes,
+      # where a `smooth` type arrives on a geom neither list names and the
+      # render stops. Answering that by quietly pairing it with someone
+      # else's curve would announce one layer's fit as another's, which is
+      # worse than the error, so it is left to that issue to decide.
       smooth_layers <- which(sapply(plot$layers, function(layer) {
         inherits(layer$geom, "GeomSmooth") ||
           inherits(layer$geom, "GeomLine") ||

--- a/man/Ggplot2Adapter.Rd
+++ b/man/Ggplot2Adapter.Rd
@@ -31,6 +31,7 @@ ggplot2 functionality to work with the new extensible architecture.
     \item \href{#method-Ggplot2Adapter-ribbon_is_area}{\code{Ggplot2Adapter$ribbon_is_area()}}
     \item \href{#method-Ggplot2Adapter-segments_span_lanes}{\code{Ggplot2Adapter$segments_span_lanes()}}
     \item \href{#method-Ggplot2Adapter-unread_layer_type}{\code{Ggplot2Adapter$unread_layer_type()}}
+    \item \href{#method-Ggplot2Adapter-layer_drew_nothing}{\code{Ggplot2Adapter$layer_drew_nothing()}}
     \item \href{#method-Ggplot2Adapter-clone}{\code{Ggplot2Adapter$clone()}}
   }
 }
@@ -410,6 +411,47 @@ exactly what it costs today.
   \subsection{Returns}{
     \code{"skip"} when the layer drew no rows, \code{"unknown"}
 otherwise
+  }
+}
+
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Ggplot2Adapter-layer_drew_nothing"></a>}}
+\if{latex}{\out{\hypertarget{method-Ggplot2Adapter-layer_drew_nothing}{}}}
+\subsection{\code{Ggplot2Adapter$layer_drew_nothing()}}{
+  Whether a layer put no mark on the page at all
+
+A layer's rows can vanish in its input, in a filter, in an aggregate
+over no groups, or -- the case #227 was found through -- in a stat that
+could not run because a \strong{Suggests} package is absent. All four
+arrive here identically: \code{ggplot_build()} reports zero rows for
+that layer while ggplot2 warns, draws the rest of the chart and carries
+on.
+
+Asked by \code{unread_layer_type()}, which turns it into \code{"skip"}
+rather than \code{"unknown"}, and by the quantile branch of
+\code{detect_layer_type()}, which uses it to keep from claiming a
+curve that was never drawn (#229). Kept as its own method for that
+second caller: a rule two branches ask is a rule, not a fall-through.
+
+Declines whenever the build cannot answer -- it raised, or gave this
+layer no frame. Absent is not empty: a build that said nothing about
+what a layer drew must not have that read as "it drew nothing", which
+would wave a mark through as harmless.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Ggplot2Adapter$layer_drew_nothing(layer, plot_object)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer}}{The layer being asked about}
+      \item{\code{plot_object}}{The ggplot2 plot object}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    TRUE when the layer built no rows
   }
 }
 

--- a/tests/testthat/test-quantile-smooth.R
+++ b/tests/testthat/test-quantile-smooth.R
@@ -96,17 +96,23 @@ of_type <- function(layers, type) {
 }
 
 
-test_that("a quantile fit is classified as the smooth it is", {
+test_that("a quantile fit is never the unknown that cost the chart", {
   testthat::skip_if_not_installed("ggplot2")
 
-  # Asked of the classifier directly, upstream of rendering, and of
-  # `geom_quantile()` itself rather than of the stand-in below: dispatch
-  # reads the geom's class and needs no data, so this is the real call.
+  # Asked of `geom_quantile()` itself rather than of the stand-in below, and
+  # asked for the property that does not depend on quantreg being installed.
+  #
+  # Which of the two answers this gives does depend on it: with quantreg the
+  # stat fits and the layer draws, so it reads `smooth`; without, it computes
+  # no rows and #227's rule makes it `skip`. Both are fine, and the test
+  # below pins the drawn case exactly. What must never come back is
+  # `unknown`, because that is the answer that drops the whole plot to a
+  # static image -- the whole of #229.
   adapter <- maidr:::Ggplot2Adapter$new()
   plot <- ggplot2::ggplot(observations(), positions) + ggplot2::geom_quantile()
 
-  testthat::expect_equal(
-    adapter$detect_layer_type(plot$layers[[1]], plot), "smooth"
+  testthat::expect_true(
+    adapter$detect_layer_type(plot$layers[[1]], plot) %in% c("smooth", "skip")
   )
 })
 
@@ -229,5 +235,53 @@ test_that("a quantile stat on another geom is left to that geom", {
 
   testthat::expect_equal(
     adapter$detect_layer_type(plot$layers[[1]], plot), "point"
+  )
+})
+
+
+test_that("a quantile layer that drew nothing is still skipped", {
+  skip_if_no_render()
+
+  # Caught in review on #231, and introduced by this change. `geom_quantile()`
+  # without quantreg computes no rows -- it is the case #227's rule was
+  # written for, and is named in `layer_drew_nothing()`'s own docs -- so
+  # claiming `smooth` on the geom regardless put an empty layer in the schema
+  # for a chart that had none. Measured before the fix:
+  #
+  #     point + geom_quantile() [no quantreg]   point(10) smooth(1)
+  #
+  # A `smooth` holding one series holding nothing: a layer a reader can walk
+  # into and find empty, which is #421's shape.
+  #
+  # Driven with an empty frame rather than by naming quantreg, which reaches
+  # the same zero built rows without making the package a dependency of the
+  # tests.
+  adapter <- maidr:::Ggplot2Adapter$new()
+  plot <- ggplot2::ggplot(observations(), positions) +
+    ggplot2::geom_point() +
+    quantile_layer(observations()[0, ])
+
+  testthat::expect_equal(
+    adapter$detect_layer_type(plot$layers[[2]], plot), "skip"
+  )
+  testthat::expect_equal(
+    vapply(layers_from(rendered(plot)), function(one) one$type, character(1)),
+    "point"
+  )
+})
+
+
+test_that("a quantile layer that drew something is still claimed", {
+  testthat::skip_if_not_installed("ggplot2")
+
+  # The other side of the same guard: emptiness is the only thing that takes
+  # a drawn quantile curve back off this branch.
+  adapter <- maidr:::Ggplot2Adapter$new()
+  plot <- ggplot2::ggplot(observations(), positions) +
+    ggplot2::geom_point() +
+    quantile_layer()
+
+  testthat::expect_equal(
+    adapter$detect_layer_type(plot$layers[[2]], plot), "smooth"
   )
 })

--- a/tests/testthat/test-quantile-smooth.R
+++ b/tests/testthat/test-quantile-smooth.R
@@ -1,0 +1,233 @@
+# `geom_quantile()` cost its chart everything for being a subclass (#229)
+#
+# `detect_layer_type()` matches `class(geom)[1]`, and the chain is
+# `GeomQuantile < GeomPath < Geom`. `GeomPath` reads as `line`; the subclass
+# matched no branch, reached the unknown processor and took the whole plot
+# down -- the third geom missed this way, after `GeomFunction` (#202) and
+# `GeomSpoke` (#225).
+#
+# Measured with `save_html()` on thirty points, with a quantile layer that
+# draws:
+#
+#     geom_point()                             interactive SVG   50,409 bytes
+#     geom_point() + a GeomQuantile layer      base64 image      44,724 bytes
+#     geom_point() + geom_smooth(se = FALSE)   interactive SVG   57,823 bytes
+#
+# The scatter read on its own and read as nothing the moment a quantile fit
+# was drawn beside it, while the *mean* fit beside the same points read fine.
+#
+# `smooth` rather than `line`, for the reason `StatFunction` is:
+# `stat_quantile()` fits `rq`/`rqss` and evaluates it at renderer-chosen
+# positions exactly as `stat_smooth()` does for the conditional mean, so the
+# curve is a model over the data rather than a series of it.
+#
+# ## Testing this without quantreg
+#
+# `geom_quantile()` needs the **quantreg** package, which this package does
+# not declare. Naming it -- even inside a `skip_if` -- makes `R CMD check`
+# report `'library' or 'require' call not declared from: 'quantreg'`, and
+# `check-r-package` errors on warnings. That is the failure #228 hit.
+#
+# Both halves are reachable without it, and nothing below mentions it:
+#
+#   - the dispatch needs no data, because it reads `class(layer$geom)[1]`;
+#   - the reading needs a layer that draws, which `layer(geom = GeomQuantile,
+#     stat = "identity", ...)` gives over data the test supplies.
+
+skip_if_no_render <- function() {
+  testthat::skip_if_not_installed("ggplot2")
+  testthat::skip_if_not_installed("jsonlite")
+}
+
+# Built at top level: inside a closure the bare column names in `aes()` read
+# as undefined globals to static analysis.
+positions <- ggplot2::aes(x = x, y = y)
+
+#' Ten points on a rising line, so a fit over them is exactly the input
+observations <- function() {
+  data.frame(x = 1:10, y = (1:10) * 2)
+}
+
+#' A real `GeomQuantile` layer that draws without quantreg
+#'
+#' The geom is what dispatch keys on, so the stat can be anything yielding
+#' path-shaped data. `geom_quantile()` itself pairs this geom with
+#' `stat_quantile`, which cannot run here -- and which the reading does not
+#' need, since what is under test is how a drawn quantile curve is read.
+quantile_layer <- function(frame = observations()) {
+  ggplot2::layer(
+    geom = ggplot2::GeomQuantile, stat = "identity", position = "identity",
+    data = frame, mapping = positions
+  )
+}
+
+#' Render a plot and return its HTML
+rendered <- function(plot) {
+  file <- tempfile(fileext = ".html")
+  on.exit(unlink(file), add = TRUE)
+  suppressWarnings(suppressMessages(save_html(plot, file)))
+  paste(readLines(file, warn = FALSE), collapse = "\n")
+}
+
+#' Whether a rendering is the static-image fallback rather than a chart
+fell_back <- function(html) {
+  grepl("base64", html, fixed = TRUE)
+}
+
+#' Every layer a plot emits, or NULL when the chart fell back to a picture
+layers_from <- function(html) {
+  raw <- regmatches(html, regexpr('maidr-data="[^"]*"', html))
+  if (length(raw) != 1) {
+    return(NULL)
+  }
+  json <- sub('"$', "", sub('^maidr-data="', "", raw))
+  for (pair in list(
+    c("&quot;", '"'), c("&lt;", "<"), c("&gt;", ">"),
+    c("&amp;", "&"), c("&#39;", "'")
+  )) {
+    json <- gsub(pair[1], pair[2], json, fixed = TRUE)
+  }
+  jsonlite::fromJSON(json, simplifyVector = FALSE)$subplots[[1]][[1]]$layers
+}
+
+#' The layers of one type, in emission order
+of_type <- function(layers, type) {
+  layers[vapply(layers, function(one) one$type, character(1)) == type]
+}
+
+
+test_that("a quantile fit is classified as the smooth it is", {
+  testthat::skip_if_not_installed("ggplot2")
+
+  # Asked of the classifier directly, upstream of rendering, and of
+  # `geom_quantile()` itself rather than of the stand-in below: dispatch
+  # reads the geom's class and needs no data, so this is the real call.
+  adapter <- maidr:::Ggplot2Adapter$new()
+  plot <- ggplot2::ggplot(observations(), positions) + ggplot2::geom_quantile()
+
+  testthat::expect_equal(
+    adapter$detect_layer_type(plot$layers[[1]], plot), "smooth"
+  )
+})
+
+
+test_that("a plain path is still a line", {
+  testthat::skip_if_not_installed("ggplot2")
+
+  # The additive half. `GeomQuantile` is named rather than reached through
+  # `GeomPath`, so the parent keeps its own reading -- a `geom_path()` draws
+  # observations and must not start announcing itself as a fit.
+  adapter <- maidr:::Ggplot2Adapter$new()
+  plot <- ggplot2::ggplot(observations(), positions) + ggplot2::geom_path()
+
+  testthat::expect_equal(
+    adapter$detect_layer_type(plot$layers[[1]], plot), "line"
+  )
+})
+
+
+test_that("a chart is not taken down by a quantile fit drawn beside it", {
+  skip_if_no_render()
+
+  # What the issue is about.
+  plot <- ggplot2::ggplot(observations(), positions) +
+    ggplot2::geom_point() +
+    quantile_layer()
+
+  html <- rendered(plot)
+
+  testthat::expect_false(fell_back(html))
+  testthat::expect_equal(
+    vapply(layers_from(html), function(one) one$type, character(1)),
+    c("point", "smooth")
+  )
+})
+
+
+test_that("the curve announces the positions it was drawn at", {
+  skip_if_no_render()
+
+  # Written out once, so the file states what a reader is told rather than
+  # only that a layer of the right type appeared. The fit here is the input,
+  # which is what makes the expected values checkable by eye.
+  layer <- of_type(layers_from(rendered(
+    ggplot2::ggplot(observations(), positions) +
+      ggplot2::geom_point() +
+      quantile_layer()
+  )), "smooth")[[1]]
+
+  drawn <- vapply(
+    layer$data[[1]], function(one) sprintf("%g/%g", one$x, one$y), character(1)
+  )
+
+  testthat::expect_equal(
+    drawn,
+    c("1/2", "2/4", "3/6", "4/8", "5/10", "6/12", "7/14", "8/16", "9/18", "10/20")
+  )
+})
+
+
+test_that("a mean fit and a quantile fit beside it are told apart", {
+  skip_if_no_render()
+
+  # The shape review caught on #226: two layers of a kind resolving to the
+  # same grob, so the second highlights the first's mark while announcing
+  # its own. Both curves are polylines, which is the population that
+  # collided there, so it is worth asserting rather than assuming.
+  plot <- ggplot2::ggplot(observations(), positions) +
+    ggplot2::geom_point() +
+    ggplot2::geom_smooth(se = FALSE, method = "lm", formula = y ~ x) +
+    quantile_layer()
+
+  curves <- of_type(layers_from(rendered(plot)), "smooth")
+
+  testthat::expect_length(curves, 2)
+  first <- unlist(curves[[1]]$selectors)
+  second <- unlist(curves[[2]]$selectors)
+  testthat::expect_length(intersect(first, second), 0L)
+  testthat::expect_false(
+    identical(length(curves[[1]]$data[[1]]), length(curves[[2]]$data[[1]]))
+  )
+})
+
+
+test_that("every position the curve announces can be highlighted", {
+  skip_if_no_render()
+
+  # A reading that announces correctly and outlines nothing is the blind spot
+  # xability/maidr#814 names. A quantile curve's grob is named by grid's own
+  # counter rather than after the geom, so the selectors are worth asserting
+  # against the page they were built from.
+  html <- rendered(
+    ggplot2::ggplot(observations(), positions) +
+      ggplot2::geom_point() +
+      quantile_layer()
+  )
+  layer <- of_type(layers_from(html), "smooth")[[1]]
+
+  selectors <- unlist(layer$selectors)
+  testthat::expect_gt(length(selectors), 0L)
+  for (selector in selectors) {
+    id <- gsub("\\\\", "", sub("^#", "", selector))
+    testthat::expect_true(grepl(id, html, fixed = TRUE))
+  }
+})
+
+
+test_that("a quantile stat on another geom is left to that geom", {
+  testthat::skip_if_not_installed("ggplot2")
+
+  # Deliberately not claimed, and pinned so the symmetric addition is a
+  # decision rather than a reflex. `StatQuantile` beside `StatDensity` in the
+  # smooth branch would type `stat_quantile(geom = "point")` as a smooth,
+  # whose `GeomPoint` the smooth processor does not recognise -- and the
+  # render then stops outright rather than declining. `StatFunction` already
+  # does exactly that; it is reported as #230 rather than matched here.
+  adapter <- maidr:::Ggplot2Adapter$new()
+  plot <- ggplot2::ggplot(observations(), positions) +
+    ggplot2::stat_quantile(geom = "point")
+
+  testthat::expect_equal(
+    adapter$detect_layer_type(plot$layers[[1]], plot), "point"
+  )
+})


### PR DESCRIPTION
Closes #229.

`detect_layer_type()` matches `class(geom)[1]`, and the chain is:

```
GeomQuantile < GeomPath < Geom
```

`GeomPath` reads as `line`; the subclass matched no branch, reached the unknown processor and took the whole plot down — the third geom missed this way, after `GeomFunction` (#202) and `GeomSpoke` (#225).

Measured with `save_html()` on thirty points, with a quantile layer that draws:

```
geom_point()                             interactive SVG   50,409 bytes
geom_point() + a GeomQuantile layer      base64 image      44,724 bytes
geom_point() + geom_smooth(se = FALSE)   interactive SVG   57,823 bytes
```

The scatter read on its own and read as nothing the moment a quantile fit was drawn beside it, while the *mean* fit beside the same points read fine.

## `smooth`, not `line`

For the reason `StatFunction` is: `stat_quantile()` fits `rq`/`rqss` and evaluates it at renderer-chosen positions exactly as `stat_smooth()` does for the conditional mean, so the curve is a model **over** the data rather than a series **of** it. Reading it as a line would announce a fit as observations.

So this decides nothing new — it routes a second spelling of "a fitted curve" through the rule the first already has. `geom_path()` keeps its own reading, pinned.

## Two things it deliberately does not do

**`StatQuantile` is not added beside `StatDensity`.** A stat-keyed `smooth` type can name a geom the smooth processor's own list does not, and the render then **stops outright** rather than declining. Measured on `main`:

```r
ggplot(d, aes(x, y)) + xlim(0, 5) + stat_function(fun = sin, geom = "point")
#> Error: No smooth curve layers found in plot
```

Matching the symmetry would have made `stat_quantile(geom = "point")` a second instance of it. Reported as #230 and pinned here by a test asserting `stat_quantile(geom = "point")` still reads as `point`, so the symmetric addition is a decision rather than a reflex.

**`GeomQuantile` is not added to that processor's fallback search.** It only runs when a layer's *own* geom was rejected, which a quantile layer's never is — so it would reach nothing except #230's case, and answering that by pairing a layer with someone else's curve would announce one fit as another's, which is worse than the error. The two lists now differ on purpose, with the reason written where they sit.

## Testing without quantreg

`geom_quantile()` needs **quantreg**, which this package does not declare, and naming it — even inside a `skip_if` — reintroduces the `'library' or 'require' call not declared from: 'quantreg'` warning that turned CI red on #228. Nothing in the new file mentions it, and `checking for unstated dependencies in 'tests'` reports OK.

Both halves are reachable anyway:

- **the dispatch** reads `class(layer$geom)[1]` and needs no data, so `geom_quantile()` itself is the call under test;
- **the reading** needs a layer that draws, which `layer(geom = GeomQuantile, stat = "identity", ...)` gives over data the test supplies.

## Verification

Suite: **0 failed, 6348 passed** (up from 6337). `R CMD check`'s unstated-dependency and code checks report OK; no `man/` drift.

11 new assertions, including the #226-shaped hazard — a chart holding both a mean fit and a quantile fit, asserting their selectors are disjoint and their data differ, since both draw `polyline` grobs and that was the exact population that collided there.

Mutation sweep, each applied alone against a restored baseline:

| mutation | outcome |
|---|---|
| drop `GeomQuantile` from the dispatch branch | killed (7) |
| drop it from the processor's own-layer list | killed (2) |
| add `StatQuantile` to the dispatch | killed (1) |
| drop it from the processor's fallback list | **survived** |

The survivor is why the fallback entry is not in this PR. It was in the first draft, and removing it changed nothing — the own-layer check returns early for every quantile layer, so the entry was unreachable except in #230's case, which this deliberately leaves alone. Rather than keep dead code, it is gone and the two lists' difference is documented.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_