### PR TITLE
refactor(ggplot2): stop reading a sibling's curve as an unreadable layer's own

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,29 @@
 
 ## Bug Fixes
 
+* The smooth processor no longer answers "which layer do I read?" with
+  *somebody else's*. When a layer's own geom was one it could not read, it
+  searched the plot's other layers for one drawing a curve and returned that
+  index -- so a bar layer beside a `geom_smooth()` came back with the
+  smooth's fitted values as its own data, announcing one layer's fit as
+  another's.
+
+  Unreachable through the dispatch since the previous release, which made the
+  classifier consult `smooth_reads_geom()` before typing a layer `smooth`, so
+  the processor is only ever built for a layer it can read. Measured before
+  removing it, instrumented on the full suite: the search was entered three
+  times, every one of them from a unit test handing the processor a bar plot
+  by hand. No render reached it.
+
+  It also carried a fourth thing worth losing -- its own list of four geoms,
+  a third copy beside `smooth_reads_geom()`'s six and the dispatch's, which
+  would have needed a matching edit each time the shared list grew. Widening
+  it to match would have been the wrong repair: the wider that list, the more
+  often the search *succeeds*, and succeeding is the failure mode.
+
+  A caller who constructs the processor against a layer it cannot read now
+  gets told so, and told which geom it was.
+
 * A layer whose stat says "smooth" but whose geom the smooth processor
   cannot read no longer stops the render. `stat_function()` was claimed on
   its stat, and a stat can name a geom the processor does not recognise --

--- a/R/ggplot2_smooth_layer_processor.R
+++ b/R/ggplot2_smooth_layer_processor.R
@@ -129,38 +129,29 @@ Ggplot2SmoothLayerProcessor <- R6::R6Class(
         return(layer_index)
       }
 
-      # Deliberately not `smooth_reads_geom`'s list -- and, since #230, not
-      # reached by any render at all.
+      # There used to be a search here for *some other* layer drawing a
+      # curve, taken when the own geom was rejected. It carried its own list
+      # of four geoms -- a third copy, next to `smooth_reads_geom`'s six and
+      # the dispatch's -- and #230 made it unreachable: a processor is built
+      # only for a layer the classifier typed, and the classifier now types
+      # `"smooth"` only when `smooth_reads_geom()` accepts the geom, so the
+      # early return above always fires first. Measured before removing it,
+      # instrumented on the full suite: entered three times, every one from
+      # the test below that hands this processor a bar plot by hand. No
+      # render reached it (#234).
       #
-      # This search runs only when the layer's own geom was rejected above,
-      # and the classifier now types a layer "smooth" only when
-      # `smooth_reads_geom()` accepts its geom, so the early return always
-      # fires first. Measured: instrumented on the full suite, the search is
-      # entered exactly three times, every one of them from
-      # `test-ggplot2-smooth-layer-processor.R:241`, which hands the
-      # processor a `GeomBar` plot directly to assert this `stop()`. No
-      # render reaches it.
-      #
-      # Left standing rather than deleted, because it is what a caller
-      # constructing the processor by hand meets, and an error is the right
-      # answer there. Widening it to match `smooth_reads_geom` would only
-      # change which unreachable branch runs; taking it out is a separate
-      # change with its own reasoning (#234).
-      #
-      # What it must *not* become is a search that succeeds for a layer the
-      # processor could not read: pairing one layer's data with another's
-      # curve announces one fit as another's, which is worse than the error.
-      smooth_layers <- which(sapply(plot$layers, function(layer) {
-        inherits(layer$geom, "GeomSmooth") ||
-          inherits(layer$geom, "GeomLine") ||
-          inherits(layer$geom, "GeomDensity") ||
-          inherits(layer$geom, "GeomFunction")
-      }))
-
-      if (length(smooth_layers) == 0) {
-        stop("No smooth curve layers found in plot")
-      }
-      smooth_layers[1]
+      # What it could never be allowed to become is the reason it is gone
+      # rather than widened. Succeeding here means pairing one layer's data
+      # with a sibling's curve, which announces one layer's fit as another's
+      # -- worse than the error, and the wider its list the likelier it got
+      # there. A caller who constructs this processor against a layer it
+      # cannot read is asking a question with no honest answer, and now gets
+      # told so directly.
+      stop(
+        "No smooth curve layers found in plot: ",
+        class(own_layer$geom)[[1]],
+        " is not a geom this processor can read"
+      )
     },
 
     #' @description Built data for this layer, restricted to one facet panel.

--- a/tests/testthat/test-ggplot2-smooth-layer-processor.R
+++ b/tests/testthat/test-ggplot2-smooth-layer-processor.R
@@ -242,6 +242,33 @@ test_that("Ggplot2SmoothLayerProcessor errors when no smooth layer found", {
     processor$extract_data(p),
     "No smooth curve layers found"
   )
+  # The geom is named, so a caller who reached this by hand can see which
+  # layer it was asked about (#234).
+  testthat::expect_error(processor$extract_data(p), "GeomBar")
+})
+
+
+test_that("a sibling's curve is not read as an unreadable layer's own", {
+  testthat::skip_if_not_installed("ggplot2")
+
+  # #234. This used to search the *other* layers for one drawing a curve and
+  # return its index, so a bar layer beside a `geom_smooth()` came back with
+  # the smooth's fitted values as its own data -- one layer's fit announced
+  # as another's. Unreachable through the dispatch, which only builds this
+  # processor for a layer it typed `"smooth"`, but the honest answer to a
+  # question with no answer is to say so.
+  frame <- data.frame(x = c(1, 2, 3, 4, 5), y = c(2, 4, 5, 4, 6))
+  p <- ggplot2::ggplot(frame, ggplot2::aes(x = x, y = y)) +
+    ggplot2::geom_col() +
+    ggplot2::geom_smooth(method = "lm", formula = y ~ x, se = FALSE)
+
+  # Index 1 is the bar, which this processor cannot read; index 2 is the
+  # smooth, which it can.
+  bar <- maidr:::Ggplot2SmoothLayerProcessor$new(list(index = 1))
+  smooth <- maidr:::Ggplot2SmoothLayerProcessor$new(list(index = 2))
+
+  testthat::expect_error(bar$extract_data(p), "No smooth curve layers found")
+  testthat::expect_type(smooth$extract_data(p), "list")
 })
 
 test_that("Ggplot2SmoothLayerProcessor polyline collection is recursive", {


### PR DESCRIPTION
Closes #234, measured while reviewing #233.

`resolve_target_layer()` had a fallback: when a layer's own geom was one the smooth processor could not read, it searched the plot's **other** layers for one drawing a curve and returned that index. So a bar layer beside a `geom_smooth()` came back with the smooth's fitted values as its own data — one layer's fit announced as another's.

## Why it can go

#233 made it unreachable. A processor is built only for a layer the classifier typed, and the classifier now types a layer `"smooth"` only when `smooth_reads_geom()` accepts its geom, so the early return above always fires first.

Measured before removing it, `cat()` at the top of the search on the full suite:

```
FALLBACK own=GeomBar all=GeomBar
FALLBACK own=GeomBar all=GeomBar
FALLBACK own=GeomBar all=GeomBar
```

Three entries, all three from `test-ggplot2-smooth-layer-processor.R:241`, which constructs the processor by hand against a bar plot to assert its `stop()`. **No render reached it.**

## Why removed rather than widened

The review on #233 flagged the search as a **third, partial copy** of the geom list — four entries beside `smooth_reads_geom()`'s six — that would silently need a matching edit each time the shared list grew. That is right, and deriving it from `smooth_reads_geom()` would have been the wrong repair for two reasons: it only changes which unreachable branch runs, and the wider that list, the more often the search **succeeds** — and succeeding is the failure mode. Pairing one layer's data with a sibling's curve is worse than the error.

A caller who constructs the processor against a layer it cannot read now gets told so, and told which geom it was.

## Verification

Full suite: **6381 passed, 0 failed, 0 errors, 99 skipped**. `roxygenise()` clean (the change is inside an R6 method body, so `man/` is untouched).

Two tests. The existing error test now also asserts the geom is named. A new one pins the behaviour the removal changes:

```r
geom_col() + geom_smooth(method = "lm")
  index 1 (the bar)    -> error, not the smooth's fitted values
  index 2 (the smooth) -> reads, unchanged
```

Mutations, each alone against a restored baseline:

| mutation | outcome |
|---|---|
| return the own index instead of raising | killed (3 failed) |
| drop the geom name from the message | killed (1 error) |

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_