### PR TITLE
fix(base-r): decline a plot that draws nothing

### DIFF
--- a/R/base_r_adapter.R
+++ b/R/base_r_adapter.R
@@ -169,8 +169,25 @@ BaseRAdapter <- R6::R6Class(
             # gridGraphics gives them, so they are addressable rather than
             # unpointable. Reaching here positionally is new, so
             # `plot(x, y, "s")` is described for the first time.
+            #
+            # `type = "n"` is the one that draws nothing at all: it sets up
+            # the axes and plots no points and no lines, which is how a custom
+            # chart is started before `segments`, `polygon` or `rect` add the
+            # marks. The catch-all below claimed it as a line, so an empty
+            # panel was announced as a full series of the values `plot()` was
+            # handed and deliberately did not draw -- ten points to walk and
+            # sonify, where a sighted reader sees nothing (#237).
+            #
+            # Worse than being unread, for the reason #572 gives about
+            # `triplot`: the data is real, the axes are real, and the only
+            # false thing is the claim that any of it was drawn. Declined, so
+            # the figure falls back to a picture of the empty panel it is --
+            # which is what the shapes drawn over it already get, since they
+            # contribute no layer of their own.
             plot_type <- args$type
-            if (is.null(plot_type) || plot_type[1] %in% c("p", "b")) {
+            if (is.character(plot_type) && identical(plot_type[1], "n")) {
+              "unknown"
+            } else if (is.null(plot_type) || plot_type[1] %in% c("p", "b")) {
               "point"
             } else if (is_step_plot_type(plot_type)) {
               # type = "s" / "S" draw stairsteps. This test must precede the

--- a/tests/testthat/test-base-r-empty-plot-type.R
+++ b/tests/testthat/test-base-r-empty-plot-type.R
@@ -1,0 +1,104 @@
+# `plot(type = "n")` draws nothing and was announced as a line (#237)
+#
+# `type = "n"` means: set up the axes, plot no points and no lines. It is how
+# a custom chart is started -- establish the coordinate system, then add the
+# marks with `segments`, `polygon` or `rect`.
+#
+# `base_r_adapter`'s catch-all claimed it as a line, so the panel came out
+# carrying the values `plot()` was handed and deliberately did not draw.
+# Measured before the fix, on ten observations:
+#
+#     plot(type='p')    point   n=10  x=[1,2,3,4,5,6] y=[3,5,2,8,4,6]
+#     plot(type='l')    line    n=10  x=[1,2,3,4,5,6] y=[3,5,2,8,4,6]
+#     plot(type='n')    line    n=10  x=[1,2,3,4,5,6] y=[3,5,2,8,4,6]
+#
+# A sighted reader sees an empty panel; a MAIDR reader was handed ten points
+# to walk and sonify. Worse than being unread, for the reason #572 gives
+# about `triplot`: the data is real, the axes are real, and the only false
+# thing is the claim that any of it was drawn.
+#
+# The shapes drawn over such a panel were never the problem -- they
+# contribute no layer of their own, which the last case here pins.
+
+X <- 1:10
+Y <- c(3, 5, 2, 8, 4, 6, 7, 1, 9, 5)
+
+#' The layers a base R drawing produces, read straight from the orchestrator
+#'
+#' @param draw A function that draws on the current device
+#' @return The layers of the first cell, possibly empty
+drawn_layers <- function(draw) {
+  grDevices::pdf(NULL)
+  on.exit(grDevices::dev.off(), add = TRUE)
+  device_id <- grDevices::dev.cur()
+  if (maidr:::has_device_calls(device_id)) {
+    maidr:::clear_device_storage(device_id)
+  }
+  draw()
+  schema <- maidr:::BaseRPlotOrchestrator$new(device_id)$generate_maidr_data()
+  schema$subplots[[1]][[1]]$layers
+}
+
+#' The trace types a base R drawing produces
+#'
+#' @param draw A function that draws on the current device
+#' @return One type per layer, in order
+drawn_types <- function(draw) {
+  vapply(drawn_layers(draw), function(layer) as.character(layer$type), character(1))
+}
+
+
+test_that("a plot that draws nothing announces nothing", {
+  # The whole of #237. Not "reads as an empty line" -- reads as no layer, so
+  # the figure falls back to a picture of the empty panel it is.
+  expect_length(drawn_types(function() plot(X, Y, type = "n")), 0)
+})
+
+
+test_that("the type is read positionally too", {
+  # `plot(x, y, "n")` is the same call. A check that only looked at a named
+  # `type =` would leave the commoner spelling announcing a series.
+  expect_length(drawn_types(function() plot(X, Y, "n")), 0)
+})
+
+
+test_that("every type that does draw is untouched", {
+  # The guard on the change: declining one draw type must not decline its
+  # neighbours. These are the readings measured before the fix, unchanged.
+  expect_equal(drawn_types(function() plot(X, Y)), "point")
+  expect_equal(drawn_types(function() plot(X, Y, type = "p")), "point")
+  expect_equal(drawn_types(function() plot(X, Y, type = "l")), "line")
+  expect_equal(drawn_types(function() plot(X, Y, type = "b")), "point")
+  expect_equal(drawn_types(function() plot(X, Y, type = "o")), "line")
+  expect_equal(drawn_types(function() plot(X, Y, type = "s")), "step")
+})
+
+
+test_that("a shape drawn over an empty panel adds no layer of its own", {
+  # The half that was already right, and worth pinning: `segments`,
+  # `polygon`, `arrows` and `rect` contribute nothing. Every one of them
+  # appeared to read as a line in the first sweep, and every one of those
+  # readings was the `plot()` call's layer being reported, not the shape's.
+  expect_length(
+    drawn_types(function() {
+      plot(X, Y, type = "n")
+      segments(1, 1, 9, 9)
+      polygon(c(1, 5, 9), c(1, 9, 1))
+      rect(1, 1, 5, 5)
+    }),
+    0
+  )
+})
+
+
+test_that("a shape over a real chart leaves that chart's reading alone", {
+  # The same shapes over a scatter: the scatter still reads, and the
+  # annotation still adds nothing.
+  expect_equal(
+    drawn_types(function() {
+      plot(X, Y)
+      segments(1, 1, 9, 9)
+    }),
+    "point"
+  )
+})


### PR DESCRIPTION
Closes #237.

## What was wrong

`plot(x, y, type = "n")` sets up the axes and draws no marks. It is how a custom chart begins before `segments`, `polygon` or `rect` add them, and it is the one `type` value that puts nothing on the panel.

The adapter's `type` ladder ends in a catch-all that returns `"line"`, so `"n"` fell into it. Driven through `BaseRPlotOrchestrator` on a `pdf(NULL)` device, the four types read like this before the change:

```
  plot(type='p')    point   n=10   x=[1,2,3,4,5,6]  y=[3,5,2,8,4,6]
  plot(type='l')    line    n=10   x=[1,2,3,4,5,6]  y=[3,5,2,8,4,6]
  plot(type='s')    step    n=10   x=[1,2,3,4,5,6]  y=[3,5,2,8,4,6]
  plot(type='n')    line    n=10   x=[1,2,3,4,5,6]  y=[3,5,2,8,4,6]   <- draws nothing
```

An empty panel was announced as a full series of the values `plot()` was handed and deliberately did not draw: ten points to walk and sonify where a sighted reader sees nothing.

This is not a small mislabel, because the shapes drawn over such a panel contribute no layer of their own. `plot(x, y, type = "n"); segments(...)` produced exactly one layer, and it came entirely from the call that drew nothing — so the whole reading of a hand-built chart was the invisible data.

## What this does

Return `"unknown"` — the adapter's existing decline — so the figure falls back to a picture of the empty panel it is.

That is the right trade for the reason #572 gives about `triplot`: the data is real and the axes are real, and the only false thing is the claim that any of it was drawn. Unread is recoverable; wrongly read is not.

```r
plot_type <- args$type
if (is.character(plot_type) && identical(plot_type[1], "n")) {
  "unknown"
} else if (is.null(plot_type) || plot_type[1] %in% c("p", "b")) {
```

The test placement matters: it sits above the `is.null(plot_type)` test, so it cannot be reached by a call that passed no `type` at all, and above `is_step_plot_type`, which is unaffected.

## Tests

`tests/testthat/test-base-r-empty-plot-type.R` — 5 tests, 10 assertions:

1. a plot that draws nothing announces nothing
2. the type is read positionally too (`plot(X, Y, "n")`)
3. **control** — every type that does draw is untouched (`p`→point, `l`→line, `b`→point, `o`→line, `s`→step)
4. a shape drawn over an empty panel adds no layer of its own
5. **control** — a shape over a real chart leaves that chart's reading alone (`plot(X, Y)` + `segments` still reads `point`)

Reverting the `"n"` branch alone against a restored baseline fails tests 1, 2 and 4 and leaves both controls passing, which is the split the change should produce.

Full suite: `[ FAIL 0 | WARN 9 | SKIP 100 | PASS 6401 ]`. The skips are the usual optional-dependency ones (`tidyquant`, `quantmod`, `vioplot`); none is in a file this touches.

## Not in scope

The same sweep turned up two other base R gaps, recorded on #237 rather than fixed here: `dotchart` and `mosaicplot` register nothing despite `DOT` and `MOSAIC` existing in the grammar, and `type = "h"` reads as a line rather than the spikes it draws.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_