### PR TITLE
test(base-r): stop the device idiom leaking into the next file

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -231,3 +231,62 @@ expect_valid_maidr_widget <- function(widget) {
   testthat::expect_s3_class(widget, "maidr")
   testthat::expect_true("x" %in% names(widget))
 }
+
+# Drawing a base R chart on a throwaway device and reading its layers back.
+#
+# Shared because four test files had grown their own copy of it, and two of
+# those copies cleared the device on the way *in* and not on the way out.
+# That is a leak rather than an untidiness: the recorded calls outlive the
+# device that made them, and R reuses device numbers, so the next file to
+# draw **without opening a device of its own** gets a fresh device 2 still
+# carrying the previous file's chart and reads it as its own.
+#
+# It is not hypothetical. `test-base-r-spike-plot-type.R` sorts immediately
+# before `test-base-r-step-layer-processor.R`, which reads `dev.cur()`
+# directly -- and the step file read the spike file's last control chart,
+# failing three assertions in a file whose author had touched nothing
+# (#241). Alphabetical order decides which pair collides, so the trap is
+# armed by *adding a file*, and it springs somewhere else.
+#
+# The same reason `helper-render.R` exists: one copy of a thing several
+# files depend on agreeing about.
+
+#' Draw a base R chart on a throwaway device and return its layers
+#'
+#' @param draw A function that draws one base R chart
+#' @return The layers of the first cell's schema
+base_r_layers <- function(draw) {
+  grDevices::pdf(NULL)
+  device_id <- grDevices::dev.cur()
+  on.exit(
+    {
+      clear_base_r_device(device_id)
+      grDevices::dev.off()
+    },
+    add = TRUE
+  )
+  clear_base_r_device(device_id)
+
+  draw()
+  schema <- maidr:::BaseRPlotOrchestrator$new(device_id)$generate_maidr_data()
+  schema$subplots[[1]][[1]]$layers
+}
+
+#' One trace type per layer a base R drawing produces
+#'
+#' @param draw A function that draws one base R chart
+#' @return A character vector, empty when the chart is declined
+base_r_layer_types <- function(draw) {
+  vapply(base_r_layers(draw), function(layer) layer$type, character(1))
+}
+
+#' Drop a device's recorded calls, if it has any
+#'
+#' @param device_id The device number
+#' @return NULL
+clear_base_r_device <- function(device_id) {
+  if (maidr:::has_device_calls(device_id)) {
+    maidr:::clear_device_storage(device_id)
+  }
+  invisible(NULL)
+}

--- a/tests/testthat/test-base-r-bar-orientation.R
+++ b/tests/testthat/test-base-r-bar-orientation.R
@@ -18,20 +18,8 @@
 # combination #184 was about, so setting the key alone would have turned a
 # wrong announcement into a silent chart.
 
-bar_layers <- function(draw) {
-  grDevices::pdf(NULL)
-  on.exit(grDevices::dev.off(), add = TRUE)
-  device_id <- grDevices::dev.cur()
-  if (maidr:::has_device_calls(device_id)) {
-    maidr:::clear_device_storage(device_id)
-  }
-  draw()
-  schema <- maidr:::BaseRPlotOrchestrator$new(device_id)$generate_maidr_data()
-  schema$subplots[[1]][[1]]$layers
-}
-
 bar_layer <- function(draw) {
-  bar_layers(draw)[[1]]
+  base_r_layers(draw)[[1]]
 }
 
 FRUIT <- local({

--- a/tests/testthat/test-base-r-device-helper.R
+++ b/tests/testthat/test-base-r-device-helper.R
@@ -1,0 +1,68 @@
+# The shared base R device idiom has to leave nothing behind (#241).
+#
+# The recorded calls outlive the device that made them -- `dev.off()` closes
+# the device and drops none of its storage -- and R reuses device numbers.
+# So a helper that clears on the way *in* and not on the way out hands its
+# chart to the next caller that draws **without opening a device of its
+# own**, and that caller reads it as its own.
+#
+# It happened: `test-base-r-spike-plot-type.R` sorts immediately before
+# `test-base-r-step-layer-processor.R`, which reads `dev.cur()` directly,
+# and the step file read the spike file's last control chart -- three
+# failures in a file whose author had touched nothing.
+#
+# Asserted here directly rather than left to file order. Order is what
+# *triggers* the leak, and it is decided by alphabet: a test that relied on
+# a collision would pass or fail according to which files happen to exist,
+# and would stop testing anything the moment a name sorted between them.
+
+test_that("the shared idiom leaves no recorded calls behind", {
+  # The regression guard. Before the fix this device still held the chart.
+  layers <- base_r_layers(function() plot(1:5, c(2, 4, 1, 5, 3)))
+  testthat::expect_length(layers, 1)
+
+  grDevices::pdf(NULL)
+  device_id <- grDevices::dev.cur()
+  on.exit(
+    {
+      clear_base_r_device(device_id)
+      grDevices::dev.off()
+    },
+    add = TRUE
+  )
+
+  testthat::expect_false(maidr:::has_device_calls(device_id))
+})
+
+test_that("the shared idiom clears what a previous caller left", {
+  # The other half. Both guards are needed: clearing only on exit would
+  # still read whatever a caller *outside* this idiom had left on the
+  # device, and clearing only on entry is the defect above.
+  grDevices::pdf(NULL)
+  stray <- grDevices::dev.cur()
+  plot(1:20, (1:20)^2)
+  grDevices::dev.off()
+
+  layers <- base_r_layers(function() barplot(c(a = 1, b = 2)))
+
+  testthat::expect_equal(vapply(layers, function(l) l$type, ""), "bar")
+  testthat::expect_equal(length(layers[[1]]$data), 2)
+  testthat::expect_false(maidr:::has_device_calls(stray))
+})
+
+test_that("the idiom still reads the chart it drew", {
+  # The control. A helper that cleared everything and read nothing would
+  # pass both tests above.
+  testthat::expect_equal(
+    base_r_layer_types(function() plot(1:5, c(2, 4, 1, 5, 3))),
+    "point"
+  )
+  testthat::expect_equal(
+    base_r_layer_types(function() barplot(c(a = 1, b = 2))),
+    "bar"
+  )
+  testthat::expect_length(
+    base_r_layer_types(function() plot(1:5, 1:5, type = "n")),
+    0
+  )
+})

--- a/tests/testthat/test-base-r-dotchart.R
+++ b/tests/testthat/test-base-r-dotchart.R
@@ -20,29 +20,10 @@
 #     every group's dots into one shared grob with a header per group in the
 #     left margin, and a flat `dot` layer has nowhere to carry the grouping.
 
-dot_layers <- function(draw) {
-  grDevices::pdf(NULL)
-  device_id <- grDevices::dev.cur()
-  on.exit(
-    {
-      if (maidr:::has_device_calls(device_id)) {
-        maidr:::clear_device_storage(device_id)
-      }
-      grDevices::dev.off()
-    },
-    add = TRUE
-  )
-  if (maidr:::has_device_calls(device_id)) {
-    maidr:::clear_device_storage(device_id)
-  }
-  draw()
-  schema <- maidr:::BaseRPlotOrchestrator$new(device_id)$generate_maidr_data()
-  schema$subplots[[1]][[1]]$layers
-}
-
-dot_types <- function(draw) {
-  vapply(dot_layers(draw), function(layer) layer$type, character(1))
-}
+# `base_r_layers` and `base_r_layer_types` live in `helper.R` (#241). The
+# local names stay so the tests read in this file's own words.
+dot_layers <- base_r_layers
+dot_types <- base_r_layer_types
 
 FRUIT <- local({
   v <- c(30, 70, 50, 20)

--- a/tests/testthat/test-base-r-empty-plot-type.R
+++ b/tests/testthat/test-base-r-empty-plot-type.R
@@ -23,29 +23,11 @@
 X <- 1:10
 Y <- c(3, 5, 2, 8, 4, 6, 7, 1, 9, 5)
 
-#' The layers a base R drawing produces, read straight from the orchestrator
-#'
-#' @param draw A function that draws on the current device
-#' @return The layers of the first cell, possibly empty
-drawn_layers <- function(draw) {
-  grDevices::pdf(NULL)
-  on.exit(grDevices::dev.off(), add = TRUE)
-  device_id <- grDevices::dev.cur()
-  if (maidr:::has_device_calls(device_id)) {
-    maidr:::clear_device_storage(device_id)
-  }
-  draw()
-  schema <- maidr:::BaseRPlotOrchestrator$new(device_id)$generate_maidr_data()
-  schema$subplots[[1]][[1]]$layers
-}
-
-#' The trace types a base R drawing produces
-#'
-#' @param draw A function that draws on the current device
-#' @return One type per layer, in order
-drawn_types <- function(draw) {
-  vapply(drawn_layers(draw), function(layer) as.character(layer$type), character(1))
-}
+# `base_r_layers` and `base_r_layer_types` live in `helper.R`; this file's
+# own copies of them are gone (#241). The local names stay so the tests read
+# in this file's own words.
+drawn_layers <- base_r_layers
+drawn_types <- base_r_layer_types
 
 
 test_that("a plot that draws nothing announces nothing", {

--- a/tests/testthat/test-base-r-spike-plot-type.R
+++ b/tests/testthat/test-base-r-spike-plot-type.R
@@ -18,36 +18,10 @@
 # lollipop conventionally carries is the only difference from what base R
 # draws, and it is not something a reader hears.
 
-# The device is cleared on the way out as well as on the way in. R reuses
-# device numbers, and the recorded calls outlive the device that made them --
-# so a file that only clears on entry hands its leftovers to the next file
-# that draws without opening a device of its own. That is not hypothetical:
-# `test-base-r-step-layer-processor.R` sorts immediately after this one and
-# reads `dev.cur()` directly, and it read this file's last control chart
-# instead of its own stairstep.
-spike_layers <- function(draw) {
-  grDevices::pdf(NULL)
-  device_id <- grDevices::dev.cur()
-  on.exit(
-    {
-      if (maidr:::has_device_calls(device_id)) {
-        maidr:::clear_device_storage(device_id)
-      }
-      grDevices::dev.off()
-    },
-    add = TRUE
-  )
-  if (maidr:::has_device_calls(device_id)) {
-    maidr:::clear_device_storage(device_id)
-  }
-  draw()
-  schema <- maidr:::BaseRPlotOrchestrator$new(device_id)$generate_maidr_data()
-  schema$subplots[[1]][[1]]$layers
-}
-
-spike_types <- function(draw) {
-  vapply(spike_layers(draw), function(layer) layer$type, character(1))
-}
+# `base_r_layers` and `base_r_layer_types` live in `helper.R` (#241). The
+# local names stay so the tests read in this file's own words.
+spike_layers <- base_r_layers
+spike_types <- base_r_layer_types
 
 X <- 1:6
 Y <- c(3, 5, 2, 8, 4, 6)


### PR DESCRIPTION
Closes #241.

## The leak

Four test files had grown their own copy of the `pdf(NULL)` + orchestrator idiom, and two of them cleared the device on the way **in** and not on the way out. Two facts make that a leak rather than an untidiness:

- the recorded calls outlive the device that made them — `dev.off()` closes the device and drops none of its storage;
- R reuses device numbers, so the next `pdf(NULL)` is device 2 again.

A file that opens its own device is safe, because it clears on entry. A file that draws **without** opening one is not: it gets a fresh device 2 carrying the previous file's chart and reads it as its own.

It is not hypothetical. `test-base-r-spike-plot-type.R` sorts immediately before `test-base-r-step-layer-processor.R`, which reads `dev.cur()` directly, and the step file read the spike file's last control chart:

```
Failure ('test-base-r-step-layer-processor.R:373:3')
layer$type not equal to "step".   actual: "line"

Failure ('test-base-r-step-layer-processor.R:374:3')
layer$stepDirection not equal to "hv".   actual is NULL
```

Neither file is wrong on its own. Alphabetical order decides which pair collides, so the trap is armed by *adding a file* and it springs somewhere else.

## Correcting the issue's scope

#241 listed ten files as carrying the leak. That was measured at the wrong level — I grepped for `pdf(NULL)` without checking what each file does on exit. Classifying them properly:

| file | reads the orchestrator | clears on exit |
|---|---|---|
| `test-base-r-bar-orientation.R` | yes | **no — leaked** |
| `test-base-r-empty-plot-type.R` | yes | **no — leaked** |
| `test-base-r-dotchart.R` | yes | yes |
| `test-base-r-spike-plot-type.R` | yes | yes |
| `test-base-r-positional-args.R` | — | yes, via `setup_positional()` |
| the other six | — | yes, via `clear_all_device_storage()` |

So the live leak was **two** files, not ten. The other copies already carried the stronger cleanup. Worth stating plainly because the overcount would have made this look like a much larger refactor than it is.

## What this does

One `base_r_layers` in `helper.R`, clearing on both sides, with the four copies gone. The two leaking files stop leaking; the two already-correct ones stop being a second and third place the rule has to be remembered. Each file keeps its own local name (`bar_layer`, `drawn_types`, `spike_layers`, `dot_types`) so its tests still read in its own words.

The same reason `helper-render.R` exists, and its comment already says it: *"Two HTML parsers that are supposed to agree and cannot be seen together is the drift this removes."*

## Tests

`test-base-r-device-helper.R` asserts the two guards **directly** rather than leaving them to file order. Order is what *triggers* the leak and it is decided by alphabet, so a test that relied on a collision would pass or fail according to which files happen to exist, and would stop testing anything the moment a name sorted between them.

Three tests: the idiom leaves no recorded calls behind (the regression guard), it clears what a previous caller left (the entry guard — both are needed, and for different reasons), and a control that it still reads the chart it drew, which a helper that cleared everything and read nothing would fail.

Mutation-swept:

```
M1  exit clear dropped (the original defect)   FAIL 2  PASS 6
M2  entry clear dropped                        FAIL 2  PASS 6
M3  clears but reads nothing                   FAIL 4  PASS 2  ERROR 1
```

Full suite: `[ FAIL 0 | WARN 9 | SKIP 100 | PASS 6450 ]` — 6442 before the new file, so the consolidation changed no behaviour and the eight new assertions are the difference.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_