### PR TITLE
fix(base-r): look a recorded argument up by its exact name

### DIFF
--- a/R/base_r_adapter.R
+++ b/R/base_r_adapter.R
@@ -81,10 +81,9 @@ is_grouped_dotchart <- function(args) {
   if (!is.null(args$groups)) {
     return(TRUE)
   }
-  x <- args$x
-  if (is.null(x) && length(args) >= 1) {
-    x <- args[[1]]
-  }
+  # `resolve_xy_args()` rather than `args$x`, which partial-matches `xlab`
+  # and friends -- see #245.
+  x <- resolve_xy_args(args)$x
   is.matrix(x) || is.data.frame(x)
 }
 

--- a/R/base_r_candlestick_layer_processor.R
+++ b/R/base_r_candlestick_layer_processor.R
@@ -83,10 +83,7 @@ BaseRCandlestickLayerProcessor <- R6::R6Class(
         return(NULL)
       }
       args <- layer_info$plot_call$args
-      x <- args$x
-      if (is.null(x) && length(args) > 0) {
-        x <- args[[1]]
-      }
+      x <- resolve_xy_args(args)$x
       if (is.null(x)) {
         return(NULL)
       }
@@ -182,11 +179,9 @@ BaseRCandlestickLayerProcessor <- R6::R6Class(
         return(list())
       }
       args <- layer_info$plot_call$args
-      x <- args$x
-      if (is.null(x) && length(args) > 0) {
-        # chartSeries first positional argument is x
-        x <- args[[1]]
-      }
+      # `resolve_xy_args()` rather than `args$x`, which partial-matches any
+      # `x`-prefixed argument when the first is recorded unnamed -- see #245.
+      x <- resolve_xy_args(args)$x
       if (is.null(x)) {
         return(list())
       }
@@ -425,10 +420,7 @@ BaseRCandlestickLayerProcessor <- R6::R6Class(
         return(as.character(args$main))
       }
       # Fall back to series name from xts colnames if available
-      x <- args$x
-      if (is.null(x) && length(args) > 0) {
-        x <- args[[1]]
-      }
+      x <- resolve_xy_args(args)$x
       if (!is.null(x)) {
         cn <- tryCatch(colnames(x), error = function(e) NULL)
         if (!is.null(cn) && length(cn) > 0) {

--- a/R/base_r_dotchart_layer_processor.R
+++ b/R/base_r_dotchart_layer_processor.R
@@ -79,10 +79,11 @@ BaseRDotchartLayerProcessor <- R6::R6Class(
       }
       args <- layer_info$plot_call$args
 
-      values <- args$x
-      if (is.null(values)) {
-        values <- if (length(args) >= 1) args[[1]] else NULL
-      }
+      # `resolve_xy_args()` rather than `args$x`: `$` partial-matches, so a
+      # call whose first argument is recorded unnamed hands back `xlab` when
+      # the author wrote one -- `dotchart(v, xlab = "Value")` read "Value" as
+      # its values and emitted an empty layer (#245).
+      values <- resolve_xy_args(args)$x
       if (is.null(values) || is.language(values) || !is.numeric(values)) {
         return(list())
       }

--- a/tests/testthat/test-base-r-recorded-arg-matching.R
+++ b/tests/testthat/test-base-r-recorded-arg-matching.R
@@ -1,0 +1,139 @@
+# A recorded argument is looked up by name, and `$` on a list partial-matches
+# (#245).
+#
+# Every Base R processor resolving its data with `args$x` was asking for an
+# element named `x`, and R hands back `xlab` when there is no exact `x`:
+#
+#   args <- list(c(a = 1, b = 2), xlab = "Value")
+#   args$x      #> "Value"
+#   args[["x"]] #> NULL
+#
+# `match_recorded_args()` deliberately leaves the dispatch argument exactly
+# as the user wrote it, so a positional first argument stays unnamed and the
+# partial match is what a lookup finds. `dotchart(v, xlab = "Value")` read
+# "Value" as its values, `is.numeric()` rejected it, and the chart rendered
+# with a `dot` layer holding no points -- typed, titled, and empty.
+#
+# `resolve_xy_args()` already existed for this: exact `args[["x"]]`, then the
+# first *unnamed* argument. These tests drive the arguments that trip the
+# partial match rather than the helper, so a site that goes back to `args$x`
+# fails here.
+
+# `base_r_layers` and `base_r_layer_types` live in `helper.R` (#241).
+arg_layers <- base_r_layers
+arg_types <- base_r_layer_types
+
+FRUIT <- local({
+  v <- c(30, 70, 50, 20)
+  names(v) <- c("apple", "banana", "cherry", "date")
+  v
+})
+
+test_that("a dot chart given an xlab still reads its values", {
+  # The reported case. `xlab` is the ordinary way to name that axis, so this
+  # is not an exotic call -- it is the documented one.
+  layer <- arg_layers(function() dotchart(FRUIT, xlab = "Value"))[[1]]
+
+  testthat::expect_length(layer$data, 4)
+  testthat::expect_equal(
+    vapply(layer$data, function(p) p$x, 0),
+    unname(FRUIT)
+  )
+})
+
+test_that("the xlab the values were nearly mistaken for is still the title", {
+  # The fix must not read past the argument to reach the data: the author's
+  # `xlab` is what names the axis, and losing it would trade one silent
+  # failure for another.
+  axes <- arg_layers(function() dotchart(FRUIT, xlab = "Value"))[[1]]$axes
+
+  testthat::expect_equal(axes$x$label, "Value")
+})
+
+test_that("any x-prefixed argument leaves the values alone", {
+  # `xlab` is the common one, but the partial match fires for whatever the
+  # caller writes -- so this names a second one rather than resting on the
+  # first. `xlim` reaches the drawing, not the data.
+  layer <- arg_layers(function() dotchart(FRUIT, xlim = c(0, 100)))[[1]]
+
+  testthat::expect_equal(
+    vapply(layer$data, function(p) p$x, 0),
+    unname(FRUIT)
+  )
+})
+
+test_that("two x-prefixed arguments leave the values alone", {
+  # The failure was not uniform: two candidates make the partial match
+  # ambiguous and `$` returns NULL, which fell through to the positional
+  # branch and read correctly by accident. A chart's correctness should not
+  # depend on how many arguments the author happened to write.
+  layer <- arg_layers(function() {
+    dotchart(FRUIT, xlab = "Value", xlim = c(0, 100))
+  })[[1]]
+
+  testthat::expect_equal(
+    vapply(layer$data, function(p) p$x, 0),
+    unname(FRUIT)
+  )
+})
+
+test_that("a dot chart with no x-prefixed argument is unchanged", {
+  # The control. Everything above has to be a statement about `xlab`, not
+  # about dot charts, so the plain call is asserted alongside it.
+  layer <- arg_layers(function() dotchart(FRUIT))[[1]]
+
+  testthat::expect_equal(
+    vapply(layer$data, function(p) p$x, 0),
+    unname(FRUIT)
+  )
+})
+
+test_that("a named x argument still wins over a positional one", {
+  # `resolve_xy_args()` prefers an exact `x`, which is the arrangement the
+  # partial match was standing in for. Spelling it out keeps the fix from
+  # being read as "always take the first argument".
+  layer <- arg_layers(function() dotchart(x = FRUIT, xlab = "Value"))[[1]]
+
+  testthat::expect_equal(
+    vapply(layer$data, function(p) p$x, 0),
+    unname(FRUIT)
+  )
+})
+
+test_that("a grouped dot chart given an xlab is still declined", {
+  # The decline reads the same argument. Under the partial match it saw
+  # "Value", which is neither a matrix nor a data frame, so a grouped chart
+  # with an `xlab` was accepted and then read as an empty flat layer --
+  # the two halves of the bug meeting.
+  adapter <- maidr:::BaseRAdapter$new()
+  grouped <- matrix(
+    c(1, 2, 3, 4, 5, 6),
+    nrow = 3,
+    dimnames = list(c("a", "b", "c"), c("g1", "g2"))
+  )
+
+  testthat::expect_equal(
+    adapter$detect_layer_type(list(
+      function_name = "dotchart",
+      args = list(grouped, xlab = "Value")
+    )),
+    "unknown"
+  )
+  testthat::expect_equal(
+    adapter$detect_layer_type(list(
+      function_name = "dotchart",
+      args = list(FRUIT, xlab = "Value")
+    )),
+    "dot"
+  )
+})
+
+test_that("resolve_xy_args does not partial-match", {
+  # The helper the sites now go through, asserted directly: the property
+  # every one of them depends on, in one line, so a change to the helper
+  # names itself here rather than as four unrelated chart failures.
+  args <- list(c(a = 1, b = 2), xlab = "Value")
+
+  testthat::expect_identical(args$x, "Value")
+  testthat::expect_identical(maidr:::resolve_xy_args(args)$x, c(a = 1, b = 2))
+})


### PR DESCRIPTION
Closes #245.

## The bug

`$` on a list partial-matches. Every Base R processor that resolved its data
with `args$x` was asking for an element named `x`, and R hands back `xlab`
when there is no exact one:

```r
args <- list(c(a = 1, b = 2), xlab = "Value")
args$x      #> "Value"
args[["x"]] #> NULL
```

`match_recorded_args()` deliberately leaves the dispatch argument exactly as
the user wrote it, so a positional first argument stays unnamed and the
partial match is what a lookup finds.

Measured through the orchestrator:

```
dotchart(v)             type=dot  n=3  axes={"x":{...}}
    p1: {"x":3,"y":"alpha"}
dotchart(v, xlab=)      type=dot  n=0  axes={"x":{"label":"Value",...}}
```

`is.numeric("Value")` is `FALSE`, so `extract_data()` returned `list()`. The
chart renders, the axis is named, the layer is typed `dot` — and it holds no
points. Nothing looks broken from the outside; a reader just gets an empty
chart.

`is_grouped_dotchart()` read the same argument, so the two halves met: a
grouped `dotchart()` **with** an `xlab` stopped being declined (`"Value"` is
neither a matrix nor a data frame) and was accepted, then read as that same
empty flat layer.

## The fix

`resolve_xy_args()` already existed for exactly this — exact `args[["x"]]`,
then the first *unnamed* argument, which is how `plot()`/`lines()`/`points()`
already resolve theirs. Three data lookups now go through it:

| File | Call it reads | Verified |
|---|---|---|
| `base_r_dotchart_layer_processor.R` | `dotchart(x, ...)` | measured, end to end |
| `base_r_adapter.R` (`is_grouped_dotchart`) | `dotchart(x, ...)` | measured, end to end |
| `base_r_candlestick_layer_processor.R` ×3 | `chartSeries(x, ...)` | **not** measured — see below |

The candlestick sites are the same idiom and take the same one-line fix, but
quantmod is not installed in this environment so they could not be driven
end to end. They are also the weaker case: `chartSeries()` has no
`x`-prefixed argument of its own for `$` to reach, so the partial match
needs the caller to pass an extra one. Stating that plainly rather than
implying the same evidence stands behind all five.

`resolve_xy_args()` is also strictly better than the old fallback in one
more way: the old code fell back to `args[[1]]` whatever it was named, so
`chartSeries(name = "X", obj)` read `"X"` as the series.

Not changed, and why: `args$a`/`args$b`/`args$h`/`args$v` in the line
processor read `abline()`, whose remaining arguments are graphical parameters
with no `a`/`b`/`h`/`v` prefix among the ones a reference line would
plausibly carry; `args$labels`, `args$main`, `args$height`, `args$names.arg`
and `args$legend.text` are not prefixes of any other argument of the calls
that record them.

## Precedent

This hazard was already found once here. `base_r_plot_orchestrator.R` moved
its title lookups to `args[[name]]` with the note that `args$sub` would
partial-match `subset` in `plot(y ~ x, subset = ...)`. The data lookups had
not been given the same treatment.

## Tests

`tests/testthat/test-base-r-recorded-arg-matching.R`, 8 tests. They drive
the arguments that trip the partial match rather than the helper, so a site
that reverts to `args$x` fails here.

One of them is worth calling out: **two** `x`-prefixed arguments made the
partial match ambiguous, `$` returned `NULL`, and the old code fell through
to the positional branch and read correctly *by accident*. So the bug was
not uniform, and a chart's correctness depended on how many arguments its
author happened to write. That case is asserted alongside the single-`xlab`
one.

Mutation sweep — each reverted alone against a restored baseline:

| Mutation | Result |
|---|---|
| dotchart back to `args$x` | 3 failures |
| `is_grouped_dotchart` back to `args$x` | 1 failure |
| both restored | 11/11 pass |

Full `testthat` suite: **6461 pass, 0 fail, 0 error, 100 skip**.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_