### PR TITLE
docs(base-r): record why three recorded calls are still unread

### DIFF
--- a/R/base_r_function_classification.R
+++ b/R/base_r_function_classification.R
@@ -70,6 +70,28 @@ NULL
     # promise of a reading. Adding a reading later means adding a processor
     # and a `detect_layer_type()` branch; it does not mean touching this
     # list, because each of these is already recorded.
+    # Five of these eight have since gained readings, without this list
+    # changing -- `spineplot` as a `mosaic` (#258), `cdplot` as a normalized
+    # stacked area (#259), `qqnorm`/`qqplot` as `point`, and
+    # `filled.contour` as a `contour`. What is left is three, and the sweep
+    # #251 records has now measured each, so they are separated here rather
+    # than left to be re-derived:
+    #
+    #   persp          Declined. A 3D surface has no 2D reading that is not
+    #                  a different chart.
+    #   fourfoldplot   Declined. Quarter-circles whose radii encode a 2xk
+    #                  odds ratio: the numbers drawn are the ratio, not the
+    #                  table, so a `mosaic` would announce something the
+    #                  plot does not draw. #268 measures a second obstacle
+    #                  on top of that -- the counts reach the drawing only
+    #                  when the caller asks for no standardisation.
+    #   sunflowerplot  Not declined -- **blocked**. The petals count the
+    #                  observations at each position, which had no field
+    #                  until xability/maidr#1161 added a `sunflower` trace.
+    #                  It is on `main` there and after the 4.4.0 that
+    #                  `MAIDR_VERSION` pins, so a layer emitted today would
+    #                  name a trace the bundle this package loads cannot
+    #                  render. Nothing to decide; it waits on a release.
     "persp",
     "sunflowerplot",
     "fourfoldplot",

--- a/tests/testthat/test-base-r-unrecorded-calls.R
+++ b/tests/testthat/test-base-r-unrecorded-calls.R
@@ -89,7 +89,15 @@ save_base_figure <- function(plot_fun) {
 }
 
 # The three of the eight that are still recorded-but-unread, with the smallest
-# call that draws each.
+# call that draws each. They are not alike, and #251's sweep separates them:
+# `persp` and `fourfoldplot` are **declined** -- a 3D surface has no 2D
+# reading that is not a different chart, and a fourfold plot's radii encode
+# an odds ratio rather than the table it came from -- while
+# `sunflowerplot` is **blocked**, on a maidr release carrying the
+# `sunflower` trace xability/maidr#1161 added after the 4.4.0
+# `MAIDR_VERSION` pins. The distinction matters here because a reading
+# arriving for the third would move it to `read_calls` below, and the other
+# two should stay put.
 unrecorded_calls <- list(
   persp = function() {
     z <- outer(


### PR DESCRIPTION
Closes #251.

## What is left of #251

#251 measured `.base_r_function_classes$HIGH` and found eleven entry points recorded but read as nothing. Eight of them sat under one comment — *"recorded so the chart falls back to a picture, not so it is read"*. Five have since gained readings without that list changing:

| call | reads as | merged in |
|---|---|---|
| `spineplot` | `mosaic` | #258 |
| `cdplot` | `stacked_normalized_area` | #259 |
| `qqnorm` / `qqplot` | `point` | #253 |
| `filled.contour` | `contour` | #255 |

which is the point the comment already makes: being recorded and being read are separate steps.

## What was never written down

Why the other three are still unread — and they are **not alike**, which is the whole reason this is worth a commit rather than an issue comment:

- **`persp` — declined.** A 3D surface has no 2D reading that is not a different chart.
- **`fourfoldplot` — declined.** Quarter-circles whose radii encode a 2×k odds ratio. The numbers drawn are the ratio, not the table they came from, so a `mosaic` would announce something the plot does not draw. #268 measures a second obstacle on top of that: the counts reach the drawing only when the caller asks for no standardisation.
- **`sunflowerplot` — blocked, not declined.** The petals count the observations at each position, which had no field until xability/maidr#1161 added a `sunflower` trace. That is on `main` upstream and *after* the 4.4.0 `MAIDR_VERSION` pins, so a layer emitted today would name a trace the bundle this package loads cannot render. Nothing to decide; it waits on a release, which is a maintainer's call per xability/maidr#814.

The distinction is what the next sweep needs. Two of these should stay where they are however often the sweep is re-run; the third moves the moment a release carries the trace.

## Where it is recorded

Beside the list in `R/base_r_function_classification.R`, and beside the `unrecorded_calls` fixture in `tests/testthat/test-base-r-unrecorded-calls.R` that exercises all three — because a reading arriving for `sunflowerplot` moves it to that file's `read_calls` list, and the other two should not follow it.

## Verification

`testthat::test_local(filter = "base-r-unrecorded-calls")` — 97 assertions, all passing. Comments only; no behaviour changes.

## Also on #251, for the record

`sunflowerplot` was the last of the four "plausible home" readings. `stripchart`, `spineplot`, `cdplot` and `pairs` (#273) are all merged, and `assocplot` gained a reading in #267 despite #251's body listing it as having none — so the issue's own decline list is one entry out of date, and this commit is the current one.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_