### PR TITLE
docs(vignette): tell deck authors how to keep off-slide charts out of the tab order

### DIFF
--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -166,7 +166,7 @@ Plots can be heard through:
 - Volume changes
 - Different tones for different series
 
-## Quarto revealjs Slides
+## Quarto Reveal.js Slides
 
 A `revealjs` deck needs nothing special from this package: call
 `maidr_on()` once in a setup chunk, as in any other Quarto or R Markdown
@@ -179,7 +179,7 @@ slide, so **Space** advances the deck again. None of that needs configuring.
 What does need attention is a reveal.js behaviour that has nothing to do with
 MAIDR. reveal.js keeps the slides on either side of the current one rendered so
 that transitions stay smooth, and marking them `hidden` does not take them out
-of the tab order --- reveal's own inline style overrides the attribute. On a
+of the tab order — reveal's own inline style overrides the attribute. On a
 deck with a chart on every slide, a single **Tab** can therefore land on an
 off-screen slide's chart rather than the one in front of the reader. This is
 [hakimel/reveal.js#1587](https://github.com/hakimel/reveal.js/issues/1587),
@@ -187,7 +187,7 @@ open since 2016.
 
 The fix is now on reveal.js `master`, which marks every slide but the current
 one `inert`. It has not reached a published release yet, and Quarto carries its
-own copy of reveal.js --- Quarto 1.10 ships 5.1.0 --- so it will arrive in a
+own copy of reveal.js — Quarto 1.10 ships 5.1.0 — so it will arrive in a
 Quarto release some time after reveal.js cuts one. Nothing will need to change
 in your deck when it does.
 
@@ -216,7 +216,6 @@ With the extension enabled, each slide gives one **Tab** to its own chart and
 **Shift+Tab** back out. The extension also adds a skip link ahead of the
 slides, so Shift+Tab lands there rather than on the slide element itself;
 either way **Space** still moves to the next slide.
-
 
 ## Supported Plot Types
 

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -166,6 +166,58 @@ Plots can be heard through:
 - Volume changes
 - Different tones for different series
 
+## Quarto revealjs Slides
+
+A `revealjs` deck needs nothing special from this package: call
+`maidr_on()` once in a setup chunk, as in any other Quarto or R Markdown
+document, and every plot the deck draws becomes an accessible MAIDR chart.
+
+A chart on a `revealjs` slide is keyboard reachable on its own: **Tab** moves
+into it, the arrow keys explore it, and **Shift+Tab** hands focus back to the
+slide, so **Space** advances the deck again. None of that needs configuring.
+
+What does need attention is a reveal.js behaviour that has nothing to do with
+MAIDR. reveal.js keeps the slides on either side of the current one rendered so
+that transitions stay smooth, and marking them `hidden` does not take them out
+of the tab order --- reveal's own inline style overrides the attribute. On a
+deck with a chart on every slide, a single **Tab** can therefore land on an
+off-screen slide's chart rather than the one in front of the reader. This is
+[hakimel/reveal.js#1587](https://github.com/hakimel/reveal.js/issues/1587),
+open since 2016.
+
+The fix is now on reveal.js `master`, which marks every slide but the current
+one `inert`. It has not reached a published release yet, and Quarto carries its
+own copy of reveal.js --- Quarto 1.10 ships 5.1.0 --- so it will arrive in a
+Quarto release some time after reveal.js cuts one. Nothing will need to change
+in your deck when it does.
+
+Until then,
+[quarto-revealjs-a11y](https://github.com/mcanouil/quarto-revealjs-a11y) does
+the same thing for a Quarto deck. Add it once per project:
+
+``` bash
+quarto add mcanouil/quarto-revealjs-a11y
+```
+
+and enable it in the deck's front matter:
+
+``` yaml
+format:
+  revealjs:
+    revealjs-plugins:
+      - a11y
+```
+
+Use **0.2.3 or newer**. Earlier versions took off-slide elements out of the tab
+order by setting `tabindex="-1"` on them and could not find them again to put
+them back, which left the chart on the *current* slide unreachable as well.
+
+With the extension enabled, each slide gives one **Tab** to its own chart and
+**Shift+Tab** back out. The extension also adds a skip link ahead of the
+slides, so Shift+Tab lands there rather than on the slide element itself;
+either way **Space** still moves to the next slide.
+
+
 ## Supported Plot Types
 
 MAIDR supports a comprehensive range of visualizations:

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -176,7 +176,7 @@ A chart on a `revealjs` slide is keyboard reachable on its own: **Tab** moves
 into it, the arrow keys explore it, and **Shift+Tab** hands focus back to the
 slide, so **Space** advances the deck again. None of that needs configuring.
 
-What does need attention is a reveal.js behaviour that has nothing to do with
+What does need attention is a reveal.js behavior that has nothing to do with
 MAIDR. reveal.js keeps the slides on either side of the current one rendered so
 that transitions stay smooth, and marking them `hidden` does not take them out
 of the tab order — reveal's own inline style overrides the attribute. On a

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -166,7 +166,7 @@ Plots can be heard through:
 - Volume changes
 - Different tones for different series
 
-## Quarto Reveal.js Slides
+## Quarto reveal.js Slides
 
 A `revealjs` deck needs nothing special from this package: call
 `maidr_on()` once in a setup chunk, as in any other Quarto or R Markdown


### PR DESCRIPTION
## Description

Adds a `## Quarto revealjs Slides` section to `vignettes/getting-started.Rmd`, after the sonification part and before the plot-type list.

A chart on a slide is already keyboard reachable on its own — Tab moves into it, the arrows explore it, Shift+Tab hands focus back to the slide, and Space advances the deck. That half is what #208 and #213 fixed, and it needs no configuration; the section says so, along with the fact that `maidr_on()` in a setup chunk is all a deck needs from this package.

What does need attention is a reveal.js behaviour that has nothing to do with MAIDR. reveal.js keeps the slides on either side of the current one rendered so transitions stay smooth, and marking them `hidden` does not take them out of the tab order, because reveal's own inline style overrides the attribute. On a deck with a chart on every slide, one Tab therefore lands on an off-screen slide's chart rather than the one in front of the reader.

Upstream this is hakimel/reveal.js#1587, open since 2016. The fix has since landed on reveal.js `master`, which marks every slide but the current one `inert`. It is not in a published release yet, and Quarto carries its own copy — Quarto 1.10 ships reveal.js 5.1.0 — so it will reach decks in some Quarto release after reveal.js cuts one, and nothing in the deck will need to change when it does.

## Changes Made

`vignettes/getting-started.Rmd`, 52 lines added, no other file touched:

- that a deck needs nothing special from the package beyond `maidr_on()`
- what the keyboard already does, and that it needs no configuration
- why one Tab can land on an off-screen slide's chart, with the upstream issue
- that reveal.js `master` fixes it, and what has to happen before that reaches Quarto
- until then, `quarto add mcanouil/quarto-revealjs-a11y` plus the YAML to enable it
- that 0.2.3 or newer is required: earlier versions parked off-slide elements at `tabindex="-1"` and could not find them again to restore them, which left the chart on the *current* slide unreachable too

No R code, no roxygen block and no generated file is touched, so nothing under `man/` changes.

## Verification

Checked in Chromium against a ten-slide Quarto `revealjs` deck with a ggplot2 chart on every slide, not reasoned about. With quarto-revealjs-a11y 0.2.3 installed, ten of the eleven slides carry `inert` and each slide gives one path in and out:

```
slide  2: chart after 2 Tab(s) -> iframe @slide-2*  | Shift+Tab -> skip-link | Space 2->3
slide  5: chart after 2 Tab(s) -> iframe @slide-5*  | Shift+Tab -> skip-link | Space 5->6
slide 10: chart after 2 Tab(s) -> iframe @slide-10* | Shift+Tab -> skip-link | Space 10->10 (last slide)
```

The 0.2.2 warning is from a measured regression, not caution: with 0.2.2 the chart on the current slide stayed at `tabindex="-1"` with the saved value still parked on it, and 42 consecutive Tab presses never reached it. Its restore query was `[tabindex]:not([tabindex="-1"])`, which cannot match anything it had itself set to `-1`. 0.2.3 replaced that mechanism with `inert` on the slide.

`rmarkdown::render()` on the whole vignette succeeds with the section in place.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eadkcqpkod61zhhbfy8Wj8)_