### PR TITLE
docs: mark the roadmap's new layer types as experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,84 @@ graphics with a one-time advisory.
 | Multi-panel layouts | `patchwork` package | `par(mfrow)`, `par(mfcol)` |
 | Multi-layered plots | Multiple `geom_*` layers | Sequential plot calls |
 
+### Experimental Plot Types
+
+> [!WARNING]
+> **These are prototypes. Treat them as prototypes.** They are under active
+> development, they are unstable, and **none of them has been through a user
+> study**. Field names, announcement wording and navigation may change without
+> a deprecation period, including in a patch release. If you are building
+> something that has to keep working, build it on the plot types above.
+
+Everything in the two tables above predates the plot coverage roadmap
+([#137](https://github.com/xability/r-maidr/issues/137)) and has been exercised
+by real readers over real charts. Everything below was added by that roadmap
+and the base R sweeps that followed it
+([#251](https://github.com/xability/r-maidr/issues/251),
+[#262](https://github.com/xability/r-maidr/issues/262)), most inside a few
+weeks.
+
+Each was measured against the chart it reads — that is what the issues and the
+tests record. But measuring that a reading is *faithful to the drawing* is a
+different claim from establishing that it is *useful to a reader*. Nobody has
+asked a blind or low-vision reader whether hearing `stars()` as a radar, or
+navigating a `termplot()` panel by panel, is the right way to read one. Until
+that happens these are proposals about how a chart could be read, not answers.
+
+Feedback is exactly what would move one of these into the tables above.
+
+#### ggplot2
+
+| Layer type | Drawn by |
+|-----------|----------|
+| `area` | `geom_area()`, `geom_ribbon(aes(ymin = 0, ...))` |
+| `stacked_area` | stacked `geom_area()` |
+| `stacked_normalized_area` | `geom_area(position = "fill")` |
+| `stacked_normalized_bar` | `geom_bar(position = "fill")` |
+| `contour` | `geom_contour()`, `geom_density_2d()` |
+| `error_bar` | `geom_errorbar()`, `geom_errorbarh()`, `geom_linerange()`, `geom_pointrange()`, `geom_crossbar()`, `geom_ribbon()` as a band |
+| `gantt` | `geom_segment()`, `geom_curve()` |
+| `hexbin` | `geom_hex()`, `stat_bin_2d()` |
+| `polygon` | `geom_polygon()` |
+| `rug` | `geom_rug()` |
+
+#### Base R
+
+| Layer type | Drawn by |
+|-----------|----------|
+| `biplot` | `biplot()` |
+| `box_stats` | `bxp()` |
+| `conditional_density` | `cdplot()` |
+| `correlogram` | `acf()`, `pacf()`, `ccf()` |
+| `cumulative_periodogram` | `cpgram()` |
+| `dot` | `dotchart()` (ungrouped) |
+| `filled_contour` | `filled.contour()` |
+| `interaction` | `interaction.plot()` |
+| `lag` | `lag.plot()` |
+| `lollipop` | `plot(type = "h")` |
+| `mosaic` | `mosaicplot()` (two-way tables) |
+| `qq` | `qqnorm()` |
+| `qqline` | `qqline()` |
+| `radar` | `stars()` |
+| `residual` | `assocplot()` (two-way tables) |
+| `spectral_density` | `spectrum()` |
+| `spine` | `spineplot()` |
+| `stacked_normalized_bar` | `barplot()` of proportions |
+| `strip` | `stripchart()` |
+| `subseries` | `monthplot()` |
+| `termplot` | `termplot()` |
+
+The split is the diff of each factory's `get_supported_types()` against
+`8de0e98`, the last commit on `main` before
+[#137](https://github.com/xability/r-maidr/issues/137) was filed.
+`tests/testthat/test-plot-type-stability.R` fails if a supported type appears
+in neither the stable tables nor the experimental ones, so a new layer type has
+to be placed deliberately rather than inherit either promise by being
+forgotten.
+
+The JavaScript core and the Python binding make the same distinction over their
+own type lists, with the same boundary and for the same reason.
+
 See `vignette("plot-types")` for detailed examples of each plot type.
 
 ## Accessibility features

--- a/tests/testthat/test-plot-type-stability.R
+++ b/tests/testthat/test-plot-type-stability.R
@@ -1,0 +1,113 @@
+# README's stability split has to cover every supported layer type
+#
+# "Supported plot types" divides what the two adapters read into tables that
+# predate the coverage roadmap and an "Experimental Plot Types" section that
+# does not. The split is a promise: the first set has been exercised by real
+# readers, the second is prototypes that may change in a patch release.
+#
+# A type in neither set inherits whichever promise the reader assumes, which
+# is the failure this guards. Thirty-one types were added across the two
+# factories in a few weeks; at that rate a new one reaching a factory and not
+# the README is the expected outcome, not an unlikely one.
+#
+# The stable side is checked as a *baseline*, not scraped: those tables name
+# charts ("Bar charts", "Density/Smooth") rather than layer types, so there is
+# no type string in them to read. The baseline is the diff source the README
+# names -- each factory's `get_supported_types()` at `8de0e98`, the last
+# commit before #137 was filed -- written out here so the check does not need
+# a git history to run against.
+
+#' Layer types each factory claimed before the coverage roadmap
+STABLE <- list(
+  ggplot2 = c(
+    "bar", "box", "candlestick", "dodged_bar", "heat", "hist", "line", "pie",
+    "point", "smooth", "stacked_bar", "step", "unknown", "violin"
+  ),
+  base_r = c(
+    "bar", "box", "candlestick", "contour", "dodged_bar", "heat", "hist",
+    "line", "pie", "point", "smooth", "stacked_bar", "step", "unknown"
+  )
+)
+
+#' The layer types named in one `####` sub-table of the experimental section
+experimental_in_readme <- function(heading) {
+  readme <- paste(
+    readLines(testthat::test_path("..", "..", "README.md"), warn = FALSE),
+    collapse = "\n"
+  )
+
+  marker <- paste0("\n#### ", heading, "\n")
+  testthat::expect_true(
+    grepl(marker, readme, fixed = TRUE),
+    label = paste0("README has a '#### ", heading, "' table")
+  )
+
+  after <- strsplit(readme, marker, fixed = TRUE)[[1]][[2]]
+  body <- strsplit(after, "\n#", fixed = TRUE)[[1]][[1]]
+
+  # A row is `| \`type\` | drawn by |`; the first cell is the layer type.
+  rows <- regmatches(body, gregexpr("\n\\| `[a-z_0-9]+` \\|", body))[[1]]
+  unique(gsub("^\n\\| `|` \\|$", "", rows))
+}
+
+
+test_that("every ggplot2 layer type is classified as stable or experimental", {
+  supported <- Ggplot2ProcessorFactory$new()$get_supported_types()
+  classified <- c(STABLE$ggplot2, experimental_in_readme("ggplot2"))
+
+  testthat::expect_setequal(classified, supported)
+})
+
+
+test_that("every base R layer type is classified as stable or experimental", {
+  supported <- BaseRProcessorFactory$new()$get_supported_types()
+  classified <- c(STABLE$base_r, experimental_in_readme("Base R"))
+
+  testthat::expect_setequal(classified, supported)
+})
+
+
+test_that("no layer type is called both stable and experimental", {
+  # Each list reads as complete on its own, so an overlap makes both wrong.
+  testthat::expect_length(
+    intersect(STABLE$ggplot2, experimental_in_readme("ggplot2")), 0
+  )
+  testthat::expect_length(
+    intersect(STABLE$base_r, experimental_in_readme("Base R")), 0
+  )
+})
+
+
+test_that("the boundary is where the README says it is", {
+  # `violin` is a ggplot2 type from before the roadmap and `area` the first
+  # added after, so this pair is where an off-by-one in the boundary shows.
+  testthat::expect_true("violin" %in% STABLE$ggplot2)
+  testthat::expect_true("area" %in% experimental_in_readme("ggplot2"))
+
+  # Base R's own last-before and first-after.
+  testthat::expect_true("candlestick" %in% STABLE$base_r)
+  testthat::expect_true("radar" %in% experimental_in_readme("Base R"))
+})
+
+
+test_that("the README says what the experimental set does not promise", {
+  # The tables alone would read as a changelog. What makes the section usable
+  # is the claim attached to it, so the claim is pinned too -- softening the
+  # wording without revisiting the split fails here. Whitespace is normalised
+  # because these phrases wrap across lines and a reflow should not be what
+  # breaks this test.
+  lines <- readLines(testthat::test_path("..", "..", "README.md"), warn = FALSE)
+  # The warning is a GitHub alert, so its lines carry a "> " prefix that would
+  # otherwise land in the middle of a phrase once the lines are joined.
+  prose <- gsub("\\s+", " ", paste(sub("^> ?", "", lines), collapse = " "))
+
+  testthat::expect_true(grepl(
+    "These are prototypes. Treat them as prototypes.", prose, fixed = TRUE
+  ))
+  testthat::expect_true(grepl(
+    "has been through a user study", prose, fixed = TRUE
+  ))
+  testthat::expect_true(grepl(
+    "without a deprecation period", prose, fixed = TRUE
+  ))
+})

--- a/tests/testthat/test-plot-type-stability.R
+++ b/tests/testthat/test-plot-type-stability.R
@@ -29,12 +29,32 @@ STABLE <- list(
   )
 )
 
+#' The README's lines, or `character(0)` where it is not reachable
+readme_lines <- function() {
+  path <- testthat::test_path("..", "..", "README.md")
+  if (!file.exists(path)) {
+    return(character(0))
+  }
+  readLines(path, warn = FALSE)
+}
+
+# `R CMD check` copies the tests into `<pkg>.Rcheck/tests/` and runs them
+# there, so `../..` is the check directory rather than the package root and
+# the README is not beside it -- the same shape as
+# `skip_without_sources()` in test-roxygen-orphans.R, and for the same
+# reason. This says so instead of failing. It runs on `devtools::test()` and
+# `testthat::test_local()`, which is the loop a type is added in.
+skip_without_readme <- function() {
+  testthat::skip_if(
+    length(readme_lines()) == 0L,
+    "README.md is not beside the tests under R CMD check"
+  )
+}
+
 #' The layer types named in one `####` sub-table of the experimental section
 experimental_in_readme <- function(heading) {
-  readme <- paste(
-    readLines(testthat::test_path("..", "..", "README.md"), warn = FALSE),
-    collapse = "\n"
-  )
+  skip_without_readme()
+  readme <- paste(readme_lines(), collapse = "\n")
 
   marker <- paste0("\n#### ", heading, "\n")
   testthat::expect_true(
@@ -96,10 +116,13 @@ test_that("the README says what the experimental set does not promise", {
   # wording without revisiting the split fails here. Whitespace is normalised
   # because these phrases wrap across lines and a reflow should not be what
   # breaks this test.
-  lines <- readLines(testthat::test_path("..", "..", "README.md"), warn = FALSE)
+  skip_without_readme()
   # The warning is a GitHub alert, so its lines carry a "> " prefix that would
   # otherwise land in the middle of a phrase once the lines are joined.
-  prose <- gsub("\\s+", " ", paste(sub("^> ?", "", lines), collapse = " "))
+  prose <- gsub(
+    "\\s+", " ",
+    paste(sub("^> ?", "", readme_lines()), collapse = " ")
+  )
 
   testthat::expect_true(grepl(
     "These are prototypes. Treat them as prototypes.", prose, fixed = TRUE


### PR DESCRIPTION
## What

Both factories claimed **14** layer types each when the coverage roadmap (#137) was filed. `Ggplot2ProcessorFactory` claims **24** now and `BaseRProcessorFactory` claims **35**. The 31 that arrived with #137 and the base R sweeps that followed (#251, #262) are not on the same footing as the ones that predate them — they landed over a few weeks, and **none has been through a user study**.

Worse, the README's "Supported plot types" tables never mentioned them at all, so a reader had **neither the list nor the caveat**. This adds an **Experimental Plot Types** section with both.

## The boundary is measured, not editorial

It is the diff of each factory's `get_supported_types()` against `8de0e98`, the last commit on `main` before #137 was filed. The stable side ends at `violin` / `candlestick`, which matches where the pre-roadmap work actually stopped.

Every experimental row names what draws it, read out of the adapters rather than recalled — `stars()` → `radar`, `assocplot()` → `residual`, `plot(type = "h")` → `lollipop`, `dotchart()` (ungrouped) → `dot`, and so on.

## What the experimental set is told not to promise

Under a `> [!WARNING]` alert, and in the same words as the core and the Python binding: under active development, unstable, no deprecation period, no support commitment, and **measured against the drawing rather than validated with a reader**. Measuring that a reading is *faithful to the chart* is a different claim from establishing that it is *useful*, and only the first has been done for these.

The section also says what would move a type out of it, which is feedback.

## The drift guard

`tests/testthat/test-plot-type-stability.R` fails if a supported type lands in **neither** set or in **both**.

One design note: the stable side is a **written-out baseline**, not a scrape. Those README tables name charts — "Bar charts", "Density/Smooth" — rather than layer types, so there is no type string in them to read. The baseline is the diff source the README names, written into the test so the check does not need a git history to run against, and the test comment says exactly that.

## Two things caught while writing it

- The prose assertions failed at first because the warning is a GitHub alert, so its lines carry a `> ` prefix that lands mid-phrase once the lines are joined. The test now strips the prefix before normalising whitespace, so a reflow is not what breaks it.
- Running the test with `library(maidr)` could not see `Ggplot2ProcessorFactory` — the R6 classes are internal. `testthat::test_local()` is the invocation that works, which is also what the package's own suite uses.

## Verified

```
Rscript -e 'testthat::test_local(filter = "plot-type-stability")'
  [ FAIL 0 | WARN 0 | SKIP 0 | PASS 17 ]

Rscript -e 'testthat::test_local(filter = "plot-type-stability|base-r-biplot|unrecorded")'
  [ FAIL 0 | WARN 0 | SKIP 0 | PASS 164 ]
```

## Companions

The same split, same boundary, same reasoning, in the core and the Python binding: xability/maidr#1208 and xability/py-maidr#687.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_