### PR TITLE
docs(articles): add a word cloud example to the gallery

### DIFF
--- a/vignettes/articles/examples.qmd
+++ b/vignettes/articles/examples.qmd
@@ -227,6 +227,78 @@ pie(shares,
 
 ---
 
+## Word Cloud
+
+A word cloud is the extreme case of a chart that carries real data while
+being readable only by eye: each term's weight is drawn as **glyph size**
+and written down nowhere on the page. Structurally it is a categorical
+label and a magnitude, so maidr reads it as a term and its number.
+
+> **Experimental.** `word_cloud` is one of the experimental layer types.
+> It has not been through a user study, and it may change without a
+> deprecation period. See the experimental table in the README.
+
+> **Note:** Word clouds are a Base R feature. ggplot2 has no word cloud
+> geom, and the packages that add one draw through their own devices
+> rather than through a layer maidr can read.
+
+> **Requires the {wordcloud} package.** Install with
+> `install.packages("wordcloud")`.
+
+#### Base R
+
+The counts you pass survive into the reading, so the weight axis honestly
+says **Occurrences**. (The Python binding cannot: `wordcloud.WordCloud`
+divides every frequency by the largest and keeps only the ratio, so
+py-maidr announces a *relative* frequency. Same chart, two different
+honest readings.)
+
+```{r}
+mentions <- c(
+  accessibility = 412, sonification = 300, braille = 250,
+  screenreader = 190, keyboard = 155, contrast = 120
+)
+
+maidr::wordcloud(
+  words = names(mentions),
+  freq = mentions,
+  min.freq = 1,
+  random.order = FALSE,
+  colors = c("#3498db", "#2ecc71", "#9b59b6", "#e67e22")
+)
+```
+
+> **Attach order matters.** `library(wordcloud)` after `library(maidr)`
+> puts `package:wordcloud` ahead of `package:maidr` on the search path, so
+> a bare `wordcloud()` call reaches the wordcloud package directly and
+> maidr never records it — the chart draws, but `show()` and
+> `save_html()` then report that no Base R plot was found. Measured on a
+> three-term cloud:
+>
+> | How it is called | Recorded? |
+> |---|---|
+> | `library(maidr)` then `library(wordcloud)`, bare `wordcloud()` | **no** |
+> | `library(wordcloud)` then `library(maidr)`, bare `wordcloud()` | yes |
+> | `maidr::wordcloud()` | yes |
+>
+> Either attach `wordcloud` **before** `maidr`, or call
+> `maidr::wordcloud()` explicitly as above, which works in either order.
+
+> **No highlighting.** `wordcloud()` draws each term with a bare `text()`
+> call at a rotation chosen by `rot.per`, and nothing names those — the
+> exported SVG carries no `id` attributes at all. So a word cloud is read
+> without a visual highlight, rather than pairing the terms with whatever
+> else happened to resolve.
+
+Two of `wordcloud()`'s arguments decide **which** terms are drawn, and the
+reading replicates both so it never announces a term the chart left out:
+`min.freq` (default 3) drops anything rarer, and `max.words` keeps only
+the heaviest. `wordcloud()` also lowers `min.freq` to 0 when it exceeds
+every frequency, which is what stops a cloud of rare terms coming out
+empty; that rule is copied rather than approximated.
+
+---
+
 ## Histogram
 
 A histogram shows the frequency distribution of a continuous variable by

--- a/vignettes/articles/examples.qmd
+++ b/vignettes/articles/examples.qmd
@@ -264,7 +264,10 @@ maidr::wordcloud(
   freq = mentions,
   min.freq = 1,
   random.order = FALSE,
-  colors = c("#3498db", "#2ecc71", "#9b59b6", "#e67e22")
+  colors = c(
+    "#3498db", "#2ecc71", "#9b59b6",
+    "#e67e22", "#e74c3c", "#16a085"
+  )
 )
 ```
 


### PR DESCRIPTION
## What this adds

A worked word cloud example in the article gallery (`vignettes/articles/examples.qmd`).

## Why

`word_cloud` merged in #288 with only a README table row naming it, so a reader could learn the type exists but not how to produce one.

Unlike the Python side, this is not a word-cloud-specific gap — **none** of the roadmap-added Base R types (vioplot, stripchart, spineplot, cdplot, biplot, stars, lag.plot) has a gallery section. This adds the one that was just asked for; the rest remain a known gap worth a separate pass if you want it.

## The part that matters more than the example

The same **attach-order trap** the quantmod section documents applies here, and it is the most likely way a user's cloud goes silently unread. Measured on a three-term cloud rather than assumed:

| How it is called | Recorded? |
|---|---|
| `library(maidr)` then `library(wordcloud)`, bare `wordcloud()` | **no** |
| `library(wordcloud)` then `library(maidr)`, bare `wordcloud()` | yes |
| `maidr::wordcloud()` | yes |

`library(wordcloud)` after `library(maidr)` puts `package:wordcloud` ahead on the search path, so a bare call reaches upstream directly — the chart draws, and `save_html()` then reports that no Base R plot was found. This is the visible consequence of the same mechanism behind the export stub in #288.

## Why the chunk is live rather than `eval: false`

The example calls `maidr::wordcloud()` explicitly, which works in either order **and** keeps the chunk safe to evaluate: attaching `wordcloud` mid-document would mask `maidr::wordcloud` for every later chunk, which is why the quantmod chunk is this file's one `eval: false`.

Suggests are available at render time — the `tidyquant` / `patchwork` chunk is evaluated with no guard and pkgdown passes — so `wordcloud` will be there too.

## Also stated

- The counts survive into the reading, so the axis honestly says **Occurrences**, unlike py-maidr's normalised ratio.
- The layer emits **no selectors**: `wordcloud()` draws each term with a bare `text()` at a rotation and nothing names those.
- `min.freq` / `max.words` are replicated so a term the chart left out is never announced, including `wordcloud()`'s own rule that `min.freq` drops to 0 when it exceeds every frequency.

## Verification

The chunk was run before being written down:

```
type      : word_cloud
axes      : Term / Occurrences
n points  : 6
terms     : accessibility, sonification, braille, screenreader, keyboard, contrast
counts    : 412, 300, 250, 190, 155, 120
selectors : none (by design)
```

The raw counts reaching the payload intact is what makes the "Occurrences" claim in the prose true rather than aspirational.

Vignette-only change; no R code, `NAMESPACE`, or `man/` touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_