### PR TITLE
docs: document every public R6 method and fail regeneration on any roxygen2 warning

### DIFF
--- a/.github/workflows/docs-drift.yaml
+++ b/.github/workflows/docs-drift.yaml
@@ -61,13 +61,18 @@ jobs:
           needs: check
           cache-version: 1
 
-      # No `load_code` argument: the default loader is what generated what is
-      # committed, and roxygen2's loaders do not all see the same thing. R6
-      # class methods are documented from the object roxygen2 loads, so
-      # sourcing the files instead of loading the package would produce a
-      # different `man/` and this job would fail on a tree that is correct.
-      - name: Regenerate
-        run: Rscript -e 'roxygen2::roxygenise()'
+      # Through the same script a contributor runs, which checks the pin it
+      # was installed against and fails on any roxygen2 warning: a warning
+      # is a block roxygen attached somewhere other than where its author
+      # meant, and the page it then writes is valid Rd that nothing else
+      # can see through (#296). It calls `roxygenise()` with no `load_code`
+      # argument: the default loader is what generated what is committed,
+      # and roxygen2's loaders do not all see the same thing. R6 class
+      # methods are documented from the object roxygen2 loads, so sourcing
+      # the files instead of loading the package would produce a different
+      # `man/` and this job would fail on a tree that is correct.
+      - name: Regenerate, failing on any roxygen2 warning
+        run: Rscript tools/document.R
 
       # `git diff --exit-code` prints what moved and fails on any of it, so
       # the log names the files rather than only reporting that something

--- a/NEWS.md
+++ b/NEWS.md
@@ -376,9 +376,12 @@
   no longer NOTEs "Lost braces" in four of them. Ten method descriptions on
   `SystemAdapter` and `Ggplot2ViolinLayerProcessor` that had been glued onto
   the previous method's section have their own, and `find_graphics_plot_grob`
-  has its own title rather than its file's. The test suite now rejects the
-  three roxygen layouts that produce such pages, and `tools/document.R`
-  regenerates `man/` with the pinned roxygen2 release.
+  has its own title rather than its file's. Every public R6 method is
+  documented, so `roxygenise()` runs without a warning (there were 391);
+  `tools/document.R` regenerates `man/` with the pinned roxygen2 release
+  and fails on any warning, as does the `docs-drift` CI job, and the test
+  suite rejects the roxygen layouts that produce a page describing the
+  wrong object.
 * The README lists every roadmap-added layer type under "Experimental Plot
   Types", the examples gallery has a worked example for each Base R and
   ggplot2 chart, and `use_cdn` is documented as it behaves: `show()` and

--- a/R/base_r_assocplot_layer_processor.R
+++ b/R/base_r_assocplot_layer_processor.R
@@ -70,6 +70,9 @@ BaseRAssocplotLayerProcessor <- R6::R6Class(
         domMapping = list(order = "row")
       )
     },
+    #' @description Whether the plot data must be reordered before drawing; a Base R layer is read
+    #'   from the recorded call and never is
+    #' @return FALSE
     needs_reordering = function() {
       FALSE
     },

--- a/R/base_r_barplot_layer_processor.R
+++ b/R/base_r_barplot_layer_processor.R
@@ -7,6 +7,17 @@ BaseRBarplotLayerProcessor <- R6::R6Class(
   "BaseRBarplotLayerProcessor",
   inherit = LayerProcessor,
   public = list(
+    #' @description Process the layer: read its data, selectors, axis titles and main title from
+    #'   the recorded call
+    #' @param plot Unused; present for the processor interface
+    #' @param layout Unused; present for the processor interface
+    #' @param built Unused; present for the processor interface
+    #' @param gt Gtable of the replayed drawing, searched for selectors (optional)
+    #' @param grob_id Unused; present for the processor interface
+    #' @param panel_id Unused; present for the processor interface
+    #' @param panel_ctx Unused; present for the processor interface
+    #' @param layer_info Layer information with the recorded call
+    #' @return List describing the layer for the MAIDR payload
     process = function(plot,
                        layout,
                        built = NULL,
@@ -43,9 +54,15 @@ BaseRBarplotLayerProcessor <- R6::R6Class(
     is_horizontal = function(layer_info) {
       self$is_horizontal_call(layer_info)
     },
+    #' @description Whether the plot data must be reordered before drawing; a Base R layer is read
+    #'   from the recorded call and never is
+    #' @return FALSE
     needs_reordering = function() {
       FALSE # Base R bar plots don't need reordering like ggplot2
     },
+    #' @description One point per bar, read from the recorded `height`
+    #' @param layer_info Layer information with the recorded call
+    #' @return List of points
     extract_data = function(layer_info) {
       if (is.null(layer_info)) {
         return(list())
@@ -103,22 +120,25 @@ BaseRBarplotLayerProcessor <- R6::R6Class(
 
       data_points
     },
-    # Extract the axis titles for this layer
-    #
-    # `barplot()` writes no title of its own, so an author who wrote none
-    # leaves both axes nameless. A bar chart always plots categories against
-    # their measured heights, whether or not the heights arrived named, so
-    # that is what the defaults say. `horiz = TRUE` puts the heights on the
-    # visual x axis -- the same swap extract_data() applies to the points.
-    #
-    # @param layer_info Layer information
-    # @return Canonical axes list
+    #' @description Extract the axis titles for this layer
+    #'
+    #' `barplot()` writes no title of its own, so an author who wrote none
+    #' leaves both axes nameless. A bar chart always plots categories against
+    #' their measured heights, whether or not the heights arrived named, so
+    #' that is what the defaults say. `horiz = TRUE` puts the heights on the
+    #' visual x axis -- the same swap extract_data() applies to the points.
+    #'
+    #' @param layer_info Layer information
+    #' @return Canonical axes list
     extract_axis_titles = function(layer_info) {
       base_r_categorical_axes(
         layer_info$plot_call$args,
         horizontal = self$is_horizontal(layer_info)
       )
     },
+    #' @description The main title of the recorded call, or an empty string
+    #' @param layer_info Layer information with the recorded call
+    #' @return Character string
     extract_main_title = function(layer_info) {
       if (is.null(layer_info)) {
         return("")
@@ -130,6 +150,10 @@ BaseRBarplotLayerProcessor <- R6::R6Class(
       main_title <- recorded_main_title(args)
       main_title
     },
+    #' @description Generate the CSS selectors that address this layer's drawn elements
+    #' @param layer_info Layer information with the recorded call
+    #' @param gt Gtable of the replayed drawing (optional)
+    #' @return List of selectors
     generate_selectors = function(layer_info, gt = NULL) {
       # For Base R plots converted with ggplotify, we generate selectors
       # using the same recursive approach as ggplot2

--- a/R/base_r_boxplot_layer_processor.R
+++ b/R/base_r_boxplot_layer_processor.R
@@ -8,6 +8,14 @@ BaseRBoxplotLayerProcessor <- R6::R6Class(
   "BaseRBoxplotLayerProcessor",
   inherit = LayerProcessor,
   public = list(
+    #' @description Process the layer: read its data, selectors, axis titles and main title from
+    #'   the recorded call
+    #' @param plot Unused; present for the processor interface
+    #' @param layout Unused; present for the processor interface
+    #' @param built Unused; present for the processor interface
+    #' @param gt Gtable of the replayed drawing, searched for selectors (optional)
+    #' @param layer_info Layer information with the recorded call
+    #' @return List describing the layer for the MAIDR payload
     process = function(plot, layout, built = NULL, gt = NULL, layer_info = NULL) {
       data <- self$extract_data(layer_info)
       selectors <- self$generate_selectors(layer_info, gt, data)
@@ -29,27 +37,30 @@ BaseRBoxplotLayerProcessor <- R6::R6Class(
         domMapping = list(iqrDirection = iqr_direction)
       )
     },
-    # The five-number summaries the drawn boxes came from
-    #
-    # A `boxplot()` call carries the *observations*, so the summaries have to
-    # be recomputed from them -- which `boxplot(plot = FALSE)` does, using
-    # the same code path the drawing did, rather than a reimplementation of
-    # it here. `graphics::boxplot` is named directly so the replay does not
-    # go back through maidr's own wrapper and record a second call.
-    #
-    # Overridable because `bxp()` is handed the summaries already computed
-    # and draws exactly the same marks from them: everything below this
-    # method -- the outlier grouping, the polygon and segment indices, the
-    # shift each box with no outliers puts on the ones after it -- is the
-    # same reading either way, and only where the summaries come from
-    # differs (#262).
-    #
-    # @param args Recorded argument list
-    # @return The `boxplot.stats`-shaped list, or NULL when it cannot be had
+    #' @description The five-number summaries the drawn boxes came from
+    #'
+    #' A `boxplot()` call carries the *observations*, so the summaries have to
+    #' be recomputed from them -- which `boxplot(plot = FALSE)` does, using
+    #' the same code path the drawing did, rather than a reimplementation of
+    #' it here. `graphics::boxplot` is named directly so the replay does not
+    #' go back through maidr's own wrapper and record a second call.
+    #'
+    #' Overridable because `bxp()` is handed the summaries already computed
+    #' and draws exactly the same marks from them: everything below this
+    #' method -- the outlier grouping, the polygon and segment indices, the
+    #' shift each box with no outliers puts on the ones after it -- is the
+    #' same reading either way, and only where the summaries come from
+    #' differs (#262).
+    #'
+    #' @param args Recorded argument list
+    #' @return The `boxplot.stats`-shaped list, or NULL when it cannot be had
     read_stats = function(args) {
       args$plot <- FALSE
       tryCatch(do.call(graphics::boxplot, args), error = function(e) NULL)
     },
+    #' @description One five-number summary per group, recomputed from the recorded observations
+    #' @param layer_info Layer information with the recorded call
+    #' @return List of box summaries
     extract_data = function(layer_info) {
       if (is.null(layer_info)) {
         return(list())
@@ -107,6 +118,11 @@ BaseRBoxplotLayerProcessor <- R6::R6Class(
 
       results
     },
+    #' @description Selectors for each box's polygon, whiskers, median and outliers
+    #' @param layer_info Layer information with the recorded call
+    #' @param gt Gtable of the replayed drawing (optional)
+    #' @param extracted_data The data already extracted for this layer (optional)
+    #' @return List of selectors
     generate_selectors = function(layer_info, gt = NULL, extracted_data = NULL) {
       # Simplified selector mapping: use the IQ polygon selector for all parts
       data_len <- 0
@@ -317,18 +333,18 @@ BaseRBoxplotLayerProcessor <- R6::R6Class(
 
       selectors
     },
-    # Extract the axis titles for this layer
-    #
-    # `boxplot()` records no title unless the author wrote one, but the
-    # formula method derives both from the formula itself and draws them, so
-    # a `y ~ g` call already names its axes: the response on the value axis
-    # and the grouping terms on the category axis. Everything else falls back
-    # to what a box plot always shows -- groups against their distributions.
-    # `horizontal = TRUE` swaps which visual axis is which, exactly as
-    # boxplot.formula()'s own defaults do.
-    #
-    # @param layer_info Layer information
-    # @return Canonical axes list
+    #' @description Extract the axis titles for this layer
+    #'
+    #' `boxplot()` records no title unless the author wrote one, but the
+    #' formula method derives both from the formula itself and draws them, so
+    #' a `y ~ g` call already names its axes: the response on the value axis
+    #' and the grouping terms on the category axis. Everything else falls back
+    #' to what a box plot always shows -- groups against their distributions.
+    #' `horizontal = TRUE` swaps which visual axis is which, exactly as
+    #' boxplot.formula()'s own defaults do.
+    #'
+    #' @param layer_info Layer information
+    #' @return Canonical axes list
     extract_axis_titles = function(layer_info) {
       args <- layer_info$plot_call$args
       horizontal <- self$determine_orientation(layer_info) == "horz"
@@ -352,17 +368,18 @@ BaseRBoxplotLayerProcessor <- R6::R6Class(
       )
     },
 
-    # Read the axis titles boxplot.formula() derives from its formula
-    #
-    # `boxplot.formula()` builds them out of the model frame's column names:
-    # the response column names the value axis and the remaining columns,
-    # joined with " : ", name the category axis. Building the same model
-    # frame reproduces the drawn titles for expressions (`log(mpg) ~ cyl`)
-    # and for `.` alike, where deparsing the formula's terms would not.
-    #
-    # @param args Recorded argument list
-    # @return List with `response` and `groups`, or NULL when this call is
-    #   not the formula method or the model frame cannot be rebuilt
+    #' @description Read the axis titles boxplot.formula() derives from its formula
+    #'
+    #' `boxplot.formula()` builds them out of the model frame's column names:
+    #' the response column names the value axis and the remaining columns,
+    #' joined with " : ", name the category axis. Building the same model
+    #' frame reproduces the drawn titles for expressions (`log(mpg) ~ cyl`)
+    #' and for `.` alike, where deparsing the formula's terms would not.
+    #'
+    #' @param args Recorded argument list
+    #' @return List with `response` and `groups`, or NULL when this call is
+    #'   not the formula method or the model frame cannot be rebuilt
+    #' @param frame The model frame kept by the recording (optional)
     extract_formula_labels = function(args, frame = NULL) {
       # boxplot()'s formula method names its first formal `formula`, and
       # match_recorded_args() leaves the dispatch argument as the author
@@ -408,6 +425,9 @@ BaseRBoxplotLayerProcessor <- R6::R6Class(
 
       labels
     },
+    #' @description The main title of the recorded call, or an empty string
+    #' @param layer_info Layer information with the recorded call
+    #' @return Character string
     extract_main_title = function(layer_info) {
       if (is.null(layer_info)) {
         return("")
@@ -415,6 +435,9 @@ BaseRBoxplotLayerProcessor <- R6::R6Class(
       args <- layer_info$plot_call$args
       recorded_main_title(args)
     },
+    #' @description Which way the boxes were drawn, from the recorded `horizontal` flag
+    #' @param layer_info Layer information with the recorded call
+    #' @return "horz" or "vert"
     determine_orientation = function(layer_info) {
       if (is.null(layer_info)) {
         return("vert")

--- a/R/base_r_bxp_layer_processor.R
+++ b/R/base_r_bxp_layer_processor.R
@@ -39,25 +39,25 @@ BaseRBxpLayerProcessor <- R6::R6Class(
   "BaseRBxpLayerProcessor",
   inherit = BaseRBoxplotLayerProcessor,
   public = list(
-    # The summaries `bxp()` was handed
-    #
-    # `bxp()`'s first formal is `z`, and it draws nothing without a numeric
-    # `z$stats` with five rows -- so a recorded call that reached this
-    # package has one. It is still checked rather than assumed: a shape that
-    # does not answer leaves the layer empty and the figure falls back to the
-    # picture it already was, where reaching past it would raise out of
-    # `process()` with nothing to catch it.
-    #
-    # The positional half looks for the first *unnamed* argument rather than
-    # for slot 1. `match_recorded_args()` keeps the author's order and leaves
-    # only the dispatch argument unnamed, wherever it was written, so
-    # `bxp(horizontal = TRUE, z)` records `z` in slot 2 -- a call R itself
-    # accepts and draws. Reading slot 1 there hands `TRUE` to the check below
-    # and leaves the layer empty. `resolve_xy_args()` resolves a positional
-    # argument the same way, for the same reason. Raised in review of #265.
-    #
-    # @param args Recorded argument list
-    # @return The `boxplot.stats`-shaped list, or NULL when it is not one
+    #' @description The summaries `bxp()` was handed
+    #'
+    #' `bxp()`'s first formal is `z`, and it draws nothing without a numeric
+    #' `z$stats` with five rows -- so a recorded call that reached this
+    #' package has one. It is still checked rather than assumed: a shape that
+    #' does not answer leaves the layer empty and the figure falls back to the
+    #' picture it already was, where reaching past it would raise out of
+    #' `process()` with nothing to catch it.
+    #'
+    #' The positional half looks for the first *unnamed* argument rather than
+    #' for slot 1. `match_recorded_args()` keeps the author's order and leaves
+    #' only the dispatch argument unnamed, wherever it was written, so
+    #' `bxp(horizontal = TRUE, z)` records `z` in slot 2 -- a call R itself
+    #' accepts and draws. Reading slot 1 there hands `TRUE` to the check below
+    #' and leaves the layer empty. `resolve_xy_args()` resolves a positional
+    #' argument the same way, for the same reason. Raised in review of #265.
+    #'
+    #' @param args Recorded argument list
+    #' @return The `boxplot.stats`-shaped list, or NULL when it is not one
     read_stats = function(args) {
       z <- args[["z"]]
       if (is.null(z)) {

--- a/R/base_r_candlestick_layer_processor.R
+++ b/R/base_r_candlestick_layer_processor.R
@@ -66,6 +66,7 @@ BaseRCandlestickLayerProcessor <- R6::R6Class(
 
     #' @description Detect whether the chartSeries call requests addVo()
     #' @param layer_info Layer information with the recorded call
+    #' @return Logical
     has_add_vo = function(layer_info) {
       if (is.null(layer_info)) {
         return(FALSE)
@@ -144,6 +145,7 @@ BaseRCandlestickLayerProcessor <- R6::R6Class(
     #' @param layer_info Layer information with the recorded call
     #' @param gt Gtable of the replayed drawing (optional)
     #' @param n_bars Number of volume bars
+    #' @return List of selectors, one per volume bar
     generate_volume_selectors = function(layer_info, gt, n_bars) {
       if (is.null(gt) || is.null(n_bars) || n_bars <= 0L) {
         return(list())
@@ -460,6 +462,7 @@ BaseRCandlestickLayerProcessor <- R6::R6Class(
 
     #' @description Format a vector of x-axis index values to character
     #' @param idx Integer x-axis positions
+    #' @return Character vector
     format_x_values = function(idx) {
       if (inherits(idx, c("Date", "POSIXct", "POSIXlt"))) {
         format(idx)
@@ -470,6 +473,7 @@ BaseRCandlestickLayerProcessor <- R6::R6Class(
 
     #' @description Recursively collect all grob names in a grob tree
     #' @param g A grob
+    #' @return Character vector of grob names
     collect_grob_names = function(g) {
       names <- character(0)
       if (is.null(g)) {
@@ -498,6 +502,7 @@ BaseRCandlestickLayerProcessor <- R6::R6Class(
 
     #' @description Sort grob ids by trailing integer suffix
     #' @param ids Grob ids
+    #' @return The ids in numeric order of their suffix
     sort_ids = function(ids) {
       if (length(ids) == 0L) {
         return(ids)
@@ -511,6 +516,7 @@ BaseRCandlestickLayerProcessor <- R6::R6Class(
     #' @description Find the grob node whose name matches `id`
     #' @param g A grob
     #' @param id The grob name to find
+    #' @return The grob, or NULL when no name matches
     find_grob_by_name = function(g, id) {
       if (is.null(g)) {
         return(NULL)
@@ -547,6 +553,7 @@ BaseRCandlestickLayerProcessor <- R6::R6Class(
 
     #' @description Count the number of primitive coordinates a grob carries
     #' @param g A grob
+    #' @return Integer
     grob_coord_count = function(g) {
       if (is.null(g)) {
         return(0L)

--- a/R/base_r_candlestick_layer_processor.R
+++ b/R/base_r_candlestick_layer_processor.R
@@ -20,6 +20,14 @@ BaseRCandlestickLayerProcessor <- R6::R6Class(
   "BaseRCandlestickLayerProcessor",
   inherit = LayerProcessor,
   public = list(
+    #' @description Process the layer: the candlestick layer, plus a volume bar layer when
+    #'   `addVo()` was requested
+    #' @param plot Unused; present for the processor interface
+    #' @param layout Unused; present for the processor interface
+    #' @param built Unused; present for the processor interface
+    #' @param gt Gtable of the replayed drawing, searched for selectors (optional)
+    #' @param layer_info Layer information with the recorded call
+    #' @return A candlestick layer, or a multi-layer list with the volume bars
     process = function(plot, layout, built = NULL, gt = NULL,
                        layer_info = NULL) {
       data <- self$extract_data(layer_info)
@@ -57,6 +65,7 @@ BaseRCandlestickLayerProcessor <- R6::R6Class(
     },
 
     #' @description Detect whether the chartSeries call requests addVo()
+    #' @param layer_info Layer information with the recorded call
     has_add_vo = function(layer_info) {
       if (is.null(layer_info)) {
         return(FALSE)
@@ -78,6 +87,9 @@ BaseRCandlestickLayerProcessor <- R6::R6Class(
     },
 
     #' @description Build a "bar" layer carrying volume data
+    #' @param layer_info Layer information with the recorded call
+    #' @param gt Gtable of the replayed drawing (optional)
+    #' @param candle_data The candlestick data already extracted
     build_volume_layer = function(layer_info, gt, candle_data) {
       if (is.null(layer_info)) {
         return(NULL)
@@ -129,6 +141,9 @@ BaseRCandlestickLayerProcessor <- R6::R6Class(
     #' (typically N = 2). Returns a per-bar selector list so each volume
     #' bar can be individually highlighted on navigation; matches the
     #' bar layer contract used by the Base R barplot processor.
+    #' @param layer_info Layer information with the recorded call
+    #' @param gt Gtable of the replayed drawing (optional)
+    #' @param n_bars Number of volume bars
     generate_volume_selectors = function(layer_info, gt, n_bars) {
       if (is.null(gt) || is.null(n_bars) || n_bars <= 0L) {
         return(list())
@@ -389,6 +404,9 @@ BaseRCandlestickLayerProcessor <- R6::R6Class(
     # Axes / title
     # ------------------------------------------------------------------
 
+    #' @description The axis titles, defaulting to Date and Price
+    #' @param layer_info Layer information with the recorded call
+    #' @return Canonical axes list
     extract_axis_titles = function(layer_info) {
       if (is.null(layer_info)) {
         return(build_axes(x = "Date", y = "Price"))
@@ -407,6 +425,9 @@ BaseRCandlestickLayerProcessor <- R6::R6Class(
       build_axes(x = x_title, y = y_title)
     },
 
+    #' @description The main title of the recorded call, or an empty string
+    #' @param layer_info Layer information with the recorded call
+    #' @return Character string
     extract_main_title = function(layer_info) {
       if (is.null(layer_info)) {
         return("")
@@ -438,6 +459,7 @@ BaseRCandlestickLayerProcessor <- R6::R6Class(
     # ------------------------------------------------------------------
 
     #' @description Format a vector of x-axis index values to character
+    #' @param idx Integer x-axis positions
     format_x_values = function(idx) {
       if (inherits(idx, c("Date", "POSIXct", "POSIXlt"))) {
         format(idx)
@@ -447,6 +469,7 @@ BaseRCandlestickLayerProcessor <- R6::R6Class(
     },
 
     #' @description Recursively collect all grob names in a grob tree
+    #' @param g A grob
     collect_grob_names = function(g) {
       names <- character(0)
       if (is.null(g)) {
@@ -474,6 +497,7 @@ BaseRCandlestickLayerProcessor <- R6::R6Class(
     },
 
     #' @description Sort grob ids by trailing integer suffix
+    #' @param ids Grob ids
     sort_ids = function(ids) {
       if (length(ids) == 0L) {
         return(ids)
@@ -485,6 +509,8 @@ BaseRCandlestickLayerProcessor <- R6::R6Class(
     },
 
     #' @description Find the grob node whose name matches `id`
+    #' @param g A grob
+    #' @param id The grob name to find
     find_grob_by_name = function(g, id) {
       if (is.null(g)) {
         return(NULL)
@@ -520,6 +546,7 @@ BaseRCandlestickLayerProcessor <- R6::R6Class(
     },
 
     #' @description Count the number of primitive coordinates a grob carries
+    #' @param g A grob
     grob_coord_count = function(g) {
       if (is.null(g)) {
         return(0L)
@@ -538,6 +565,8 @@ BaseRCandlestickLayerProcessor <- R6::R6Class(
     },
 
     #' @description Pick the rect-id whose grob has the most coordinates
+    #' @param gt Gtable of the replayed drawing (optional)
+    #' @param ids Grob ids
     pick_largest_child_group = function(gt, ids) {
       if (length(ids) == 0L) {
         return(NULL)

--- a/R/base_r_dodged_bar_layer_processor.R
+++ b/R/base_r_dodged_bar_layer_processor.R
@@ -7,6 +7,14 @@ BaseRDodgedBarLayerProcessor <- R6::R6Class(
   "BaseRDodgedBarLayerProcessor",
   inherit = LayerProcessor,
   public = list(
+    #' @description Process the layer: read its data, selectors, axis titles and main title from
+    #'   the recorded call
+    #' @param plot Unused; present for the processor interface
+    #' @param layout Unused; present for the processor interface
+    #' @param built Unused; present for the processor interface
+    #' @param gt Gtable of the replayed drawing, searched for selectors (optional)
+    #' @param layer_info Layer information with the recorded call
+    #' @return List describing the layer for the MAIDR payload
     process = function(plot, layout, built = NULL, gt = NULL, layer_info = NULL) {
       data <- self$extract_data(layer_info)
       selectors <- self$generate_selectors(layer_info, gt)
@@ -31,6 +39,9 @@ BaseRDodgedBarLayerProcessor <- R6::R6Class(
         domMapping = list(groupDirection = "forward")
       )
     },
+    #' @description One series per row of the recorded height matrix
+    #' @param layer_info Layer information with the recorded call
+    #' @return List of series
     extract_data = function(layer_info) {
       plot_call <- layer_info$plot_call
       args <- plot_call$args
@@ -85,6 +96,10 @@ BaseRDodgedBarLayerProcessor <- R6::R6Class(
 
       data_by_fill
     },
+    #' @description The selector for the bars, scoped to this layer's plot group
+    #' @param layer_info Layer information with the recorded call
+    #' @param gt Gtable of the replayed drawing (optional)
+    #' @return List of selectors
     generate_selectors = function(layer_info, gt = NULL) {
       # For multipanel plots, use group_index (panel number)
       # For single panel, use the regular index
@@ -106,6 +121,10 @@ BaseRDodgedBarLayerProcessor <- R6::R6Class(
       main_selector <- paste0("rect[id^='graphics-plot-", plot_call_index, "-rect-1']")
       list(main_selector)
     },
+    #' @description Find the rect grobs drawn by the recorded call at `call_index`
+    #' @param grob The grob tree to search
+    #' @param call_index Index of the recorded plot group, which numbers the panel's grobs
+    #' @return Character vector of grob names
     find_rect_grobs = function(grob, call_index) {
       names <- character(0)
 
@@ -134,6 +153,10 @@ BaseRDodgedBarLayerProcessor <- R6::R6Class(
 
       names
     },
+    #' @description Build this layer's selector from the grob tree
+    #' @param grob The grob tree to search
+    #' @param call_index Index of the recorded plot group, which numbers the panel's grobs
+    #' @return A selector string, or an empty string when no grob matches
     generate_selectors_from_grob = function(grob, call_index) {
       rect_names <- self$find_rect_grobs(grob, call_index)
 
@@ -152,18 +175,21 @@ BaseRDodgedBarLayerProcessor <- R6::R6Class(
       escaped_parent <- gsub("\\.", "\\\\.", paste0(main_container, ".1"))
       paste0("#", escaped_parent, " rect")
     },
-    # Extract the axis titles for this layer
-    #
-    # Same shape as the stacked processor: `barplot(beside = TRUE)` writes no
-    # title, its points carry the column category on x and the bar height on
-    # y, and the group each bar belongs to travels with the point as z rather
-    # than as a named axis.
-    #
-    # @param layer_info Layer information
-    # @return Canonical axes list
+    #' @description Extract the axis titles for this layer
+    #'
+    #' Same shape as the stacked processor: `barplot(beside = TRUE)` writes no
+    #' title, its points carry the column category on x and the bar height on
+    #' y, and the group each bar belongs to travels with the point as z rather
+    #' than as a named axis.
+    #'
+    #' @param layer_info Layer information
+    #' @return Canonical axes list
     extract_axis_titles = function(layer_info) {
       base_r_categorical_axes(layer_info$plot_call$args)
     },
+    #' @description The main title of the recorded call, or an empty string
+    #' @param layer_info Layer information with the recorded call
+    #' @return Character string
     extract_main_title = function(layer_info) {
       if (is.null(layer_info)) {
         return("")

--- a/R/base_r_heatmap_layer_processor.R
+++ b/R/base_r_heatmap_layer_processor.R
@@ -7,6 +7,17 @@ BaseRHeatmapLayerProcessor <- R6::R6Class(
   "BaseRHeatmapLayerProcessor",
   inherit = LayerProcessor,
   public = list(
+    #' @description Process the layer: read its data, selectors, axis titles and main title from
+    #'   the recorded call
+    #' @param plot Unused; present for the processor interface
+    #' @param layout Unused; present for the processor interface
+    #' @param built Unused; present for the processor interface
+    #' @param gt Gtable of the replayed drawing, searched for selectors (optional)
+    #' @param grob_id Unused; present for the processor interface
+    #' @param panel_id Unused; present for the processor interface
+    #' @param panel_ctx Unused; present for the processor interface
+    #' @param layer_info Layer information with the recorded call
+    #' @return List describing the layer for the MAIDR payload
     process = function(plot,
                        layout,
                        built = NULL,
@@ -29,6 +40,9 @@ BaseRHeatmapLayerProcessor <- R6::R6Class(
         domMapping = list(order = "row") # Explicit row-major DOM mapping
       )
     },
+    #' @description One row per cell of the recorded matrix, in drawn order
+    #' @param layer_info Layer information with the recorded call
+    #' @return List of rows
     extract_data = function(layer_info) {
       if (is.null(layer_info)) {
         return(list())
@@ -186,6 +200,11 @@ BaseRHeatmapLayerProcessor <- R6::R6Class(
       }
       result
     },
+    #' @description Selectors for the image tiles, one per cell
+    #' @param layer_info Layer information with the recorded call
+    #' @param gt Gtable of the replayed drawing (optional)
+    #' @param extracted_data The data already extracted for this layer (optional)
+    #' @return List of selectors
     generate_selectors = function(layer_info, gt = NULL, extracted_data = NULL) {
       if (is.null(gt)) {
         return(list())
@@ -236,6 +255,10 @@ BaseRHeatmapLayerProcessor <- R6::R6Class(
 
       list(selector)
     },
+    #' @description Find the image-rect grobs drawn by the plot group at `group_index`
+    #' @param grob The grob tree to search
+    #' @param group_index Index of the recorded plot group, which numbers the panel's grobs
+    #' @return Character vector of grob names
     find_image_rect_grobs = function(grob, group_index) {
       names <- character(0)
 
@@ -275,6 +298,10 @@ BaseRHeatmapLayerProcessor <- R6::R6Class(
 
       names
     },
+    #' @description Build this layer's selector from the grob tree
+    #' @param grob The grob tree to search
+    #' @param group_index Index of the recorded plot group, which numbers the panel's grobs
+    #' @return A selector string, or an empty string when no grob matches
     generate_selectors_from_grob = function(grob, group_index = NULL) {
       rect_names <- self$find_image_rect_grobs(grob, group_index)
 
@@ -290,16 +317,16 @@ BaseRHeatmapLayerProcessor <- R6::R6Class(
 
       selector
     },
-    # Extract the axis titles for this layer
-    #
-    # `heatmap()` lays the matrix out one way round only -- its columns run
-    # along x and its rows up y -- so those two words are facts about the
-    # call. `image()` is not the same picture: it draws a coordinate grid,
-    # and `image(x, y, z)` puts the caller's own coordinates on those axes,
-    # so naming them after a matrix would be a guess. It gets no default.
-    #
-    # @param layer_info Layer information
-    # @return Canonical axes list
+    #' @description Extract the axis titles for this layer
+    #'
+    #' `heatmap()` lays the matrix out one way round only -- its columns run
+    #' along x and its rows up y -- so those two words are facts about the
+    #' call. `image()` is not the same picture: it draws a coordinate grid,
+    #' and `image(x, y, z)` puts the caller's own coordinates on those axes,
+    #' so naming them after a matrix would be a guess. It gets no default.
+    #'
+    #' @param layer_info Layer information
+    #' @return Canonical axes list
     extract_axis_titles = function(layer_info) {
       args <- layer_info$plot_call$args
       is_heatmap <- identical(layer_info$function_name, "heatmap")
@@ -312,6 +339,9 @@ BaseRHeatmapLayerProcessor <- R6::R6Class(
         z = "value"
       )
     },
+    #' @description The main title of the recorded call, or an empty string
+    #' @param layer_info Layer information with the recorded call
+    #' @return Character string
     extract_main_title = function(layer_info) {
       if (is.null(layer_info)) {
         return("")

--- a/R/base_r_histogram_layer_processor.R
+++ b/R/base_r_histogram_layer_processor.R
@@ -8,6 +8,14 @@ BaseRHistogramLayerProcessor <- R6::R6Class(
   "BaseRHistogramLayerProcessor",
   inherit = LayerProcessor,
   public = list(
+    #' @description Process the layer: read its data, selectors, axis titles and main title from
+    #'   the recorded call
+    #' @param plot Unused; present for the processor interface
+    #' @param layout Unused; present for the processor interface
+    #' @param built Unused; present for the processor interface
+    #' @param gt Gtable of the replayed drawing, searched for selectors (optional)
+    #' @param layer_info Layer information with the recorded call
+    #' @return List describing the layer for the MAIDR payload
     process = function(plot, layout, built = NULL, gt = NULL, layer_info = NULL) {
       data <- self$extract_data(layer_info)
       selectors <- self$generate_selectors(layer_info, gt)
@@ -22,6 +30,9 @@ BaseRHistogramLayerProcessor <- R6::R6Class(
         axes = axes
       )
     },
+    #' @description One point per bin, from the histogram recomputed from the recorded call
+    #' @param layer_info Layer information with the recorded call
+    #' @return List of points
     extract_data = function(layer_info) {
       if (is.null(layer_info)) {
         return(list())
@@ -56,10 +67,10 @@ BaseRHistogramLayerProcessor <- R6::R6Class(
       histogram_data
     },
 
-    # Recompute the plotted histogram from the recorded call
-    #
-    # @param args Recorded argument list
-    # @return A "histogram" object, or NULL when the call recorded no data
+    #' @description Recompute the plotted histogram from the recorded call
+    #'
+    #' @param args Recorded argument list
+    #' @return A "histogram" object, or NULL when the call recorded no data
     recompute_histogram = function(args) {
       hist_data <- args[["x"]]
       if (is.null(hist_data) && length(args) > 0) {
@@ -91,15 +102,15 @@ BaseRHistogramLayerProcessor <- R6::R6Class(
       suppressWarnings(do.call(graphics::hist, c(list(hist_data), hist_params)))
     },
 
-    # Is this a frequency histogram rather than a density one?
-    #
-    # The plotted y-axis shows counts only for frequency histograms; with
-    # freq = FALSE or probability = TRUE it shows densities. hist()'s own
-    # default is freq = TRUE only for equidistant breaks.
-    #
-    # @param args Recorded argument list
-    # @param hist_obj The recomputed histogram, or NULL when there is none
-    # @return Logical
+    #' @description Is this a frequency histogram rather than a density one?
+    #'
+    #' The plotted y-axis shows counts only for frequency histograms; with
+    #' freq = FALSE or probability = TRUE it shows densities. hist()'s own
+    #' default is freq = TRUE only for equidistant breaks.
+    #'
+    #' @param args Recorded argument list
+    #' @param hist_obj The recomputed histogram, or NULL when there is none
+    #' @return Logical
     is_frequency = function(args, hist_obj = NULL) {
       if (!is.null(args[["freq"]])) {
         return(recorded_flag(args, "freq"))
@@ -111,6 +122,10 @@ BaseRHistogramLayerProcessor <- R6::R6Class(
       # a histogram with no recorded data draws nothing either way.
       is.null(hist_obj) || isTRUE(hist_obj$equidist)
     },
+    #' @description The selector for the bins, scoped to this layer's plot group
+    #' @param layer_info Layer information with the recorded call
+    #' @param gt Gtable of the replayed drawing (optional)
+    #' @return List of selectors
     generate_selectors = function(layer_info, gt = NULL) {
       # Use group_index for grob lookup (not layer index)
       # Multiple layers in same group share same grob with group-based naming
@@ -136,6 +151,10 @@ BaseRHistogramLayerProcessor <- R6::R6Class(
       )
       list(main_selector)
     },
+    #' @description Find the rect grobs drawn by the recorded call at `call_index`
+    #' @param grob The grob tree to search
+    #' @param call_index Index of the recorded plot group, which numbers the panel's grobs
+    #' @return Character vector of grob names
     find_rect_grobs = function(grob, call_index) {
       names <- character(0)
 
@@ -171,25 +190,29 @@ BaseRHistogramLayerProcessor <- R6::R6Class(
 
       names
     },
+    #' @description Build this layer's selector from the grob tree
+    #' @param grob The grob tree to search
+    #' @param call_index Index of the recorded plot group, which numbers the panel's grobs
+    #' @return A selector string, or an empty string when no grob matches
     generate_selectors_from_grob = function(grob, call_index = NULL) {
       # Use robust selector generation with plot_index for multipanel support
       selector <- generate_robust_selector(grob, "rect", "rect", plot_index = call_index)
 
       return(selector)
     },
-    # Extract the axis titles for this layer
-    #
-    # `hist()` derives both titles inside the call and so records neither:
-    # the x title is `deparse(substitute(x))`, which is gone by the time the
-    # evaluated arguments reach us, and the y title is "Frequency" or
-    # "Density" depending on what the bars measure. The y default therefore
-    # repeats hist()'s own choice -- resolved by the same rule that decides
-    # which values extract_data() emits, so the noun always names the number
-    # being announced -- while x says only what the axis certainly holds:
-    # the bins.
-    #
-    # @param layer_info Layer information
-    # @return Canonical axes list
+    #' @description Extract the axis titles for this layer
+    #'
+    #' `hist()` derives both titles inside the call and so records neither:
+    #' the x title is `deparse(substitute(x))`, which is gone by the time the
+    #' evaluated arguments reach us, and the y title is "Frequency" or
+    #' "Density" depending on what the bars measure. The y default therefore
+    #' repeats hist()'s own choice -- resolved by the same rule that decides
+    #' which values extract_data() emits, so the noun always names the number
+    #' being announced -- while x says only what the axis certainly holds:
+    #' the bins.
+    #'
+    #' @param layer_info Layer information
+    #' @return Canonical axes list
     extract_axis_titles = function(layer_info) {
       args <- layer_info$plot_call$args
 
@@ -199,10 +222,10 @@ BaseRHistogramLayerProcessor <- R6::R6Class(
       )
     },
 
-    # The title hist() itself would print above the counted axis
-    #
-    # @param args Recorded argument list
-    # @return "Frequency" or "Density"
+    #' @description The title hist() itself would print above the counted axis
+    #'
+    #' @param args Recorded argument list
+    #' @return "Frequency" or "Density"
     frequency_label = function(args) {
       # The histogram is only recomputed when neither freq nor probability
       # was recorded, since only then does the answer depend on the breaks.
@@ -211,6 +234,9 @@ BaseRHistogramLayerProcessor <- R6::R6Class(
 
       if (self$is_frequency(args, hist_obj)) "Frequency" else "Density"
     },
+    #' @description The main title of the recorded call, or an empty string
+    #' @param layer_info Layer information with the recorded call
+    #' @return Character string
     extract_main_title = function(layer_info) {
       if (is.null(layer_info)) {
         return("")

--- a/R/base_r_interaction_layer_processor.R
+++ b/R/base_r_interaction_layer_processor.R
@@ -33,6 +33,9 @@ BaseRInteractionLayerProcessor <- R6::R6Class(
   "BaseRInteractionLayerProcessor",
   inherit = BaseRLineLayerProcessor,
   public = list(
+    #' @description One series per trace level, read from the grid of cell means
+    #' @param layer_info Layer information with the recorded call
+    #' @return List of series
     extract_data = function(layer_info) {
       cells <- private$cell_grid(layer_info)
       if (is.null(cells)) {

--- a/R/base_r_line_layer_processor.R
+++ b/R/base_r_line_layer_processor.R
@@ -383,6 +383,7 @@ BaseRLineLayerProcessor <- R6::R6Class(
     #' what `abline()` draws its clipped line across.
     #' @param limits An explicit `xlim`/`ylim`, or NULL
     #' @param data The plotted values on that axis
+    #' @return Numeric vector of two, or NULL when nothing finite was plotted
     axis_extent = function(limits, data) {
       if (is.numeric(limits) && length(limits) == 2L && all(is.finite(limits))) {
         return(grDevices::extendrange(limits, f = 0.04))
@@ -517,6 +518,7 @@ BaseRLineLayerProcessor <- R6::R6Class(
     #' subclasses whose geometry lands under a different grob name (see
     #' BaseRStepLayerProcessor).
     #' @param layer_info Layer information with the recorded call
+    #' @return "abline" or "lines"
     selector_grob_type = function(layer_info) {
       function_name <- if (!is.null(layer_info)) layer_info$function_name else "lines"
       if (function_name == "abline") "abline" else "lines"

--- a/R/base_r_line_layer_processor.R
+++ b/R/base_r_line_layer_processor.R
@@ -8,6 +8,17 @@ BaseRLineLayerProcessor <- R6::R6Class(
   "BaseRLineLayerProcessor",
   inherit = LayerProcessor,
   public = list(
+    #' @description Process the layer: read its data, selectors, axis titles and main title from
+    #'   the recorded call
+    #' @param plot Unused; present for the processor interface
+    #' @param layout Unused; present for the processor interface
+    #' @param built Unused; present for the processor interface
+    #' @param gt Gtable of the replayed drawing, searched for selectors (optional)
+    #' @param grob_id Unused; present for the processor interface
+    #' @param panel_id Unused; present for the processor interface
+    #' @param panel_ctx Unused; present for the processor interface
+    #' @param layer_info Layer information with the recorded call
+    #' @return List describing the layer for the MAIDR payload
     process = function(plot,
                        layout,
                        built = NULL,
@@ -29,9 +40,16 @@ BaseRLineLayerProcessor <- R6::R6Class(
         axes = axes
       )
     },
+    #' @description Whether the plot data must be reordered before drawing; a Base R layer is read
+    #'   from the recorded call and never is
+    #' @return FALSE
     needs_reordering = function() {
       FALSE
     },
+    #' @description One series per line: a vector, each column of a matrix, a time series, or the
+    #'   endpoints of `abline()`
+    #' @param layer_info Layer information with the recorded call
+    #' @return List of series
     extract_data = function(layer_info) {
       if (is.null(layer_info)) {
         return(list())
@@ -144,6 +162,11 @@ BaseRLineLayerProcessor <- R6::R6Class(
 
       NULL
     },
+    #' @description The points of one line, pairing each x with its y
+    #' @param x x positions
+    #' @param y y values
+    #' @param x_labels Category labels to announce in place of the x positions (optional)
+    #' @return List holding one series
     extract_single_line_data = function(x, y, x_labels = NULL) {
       data_points <- list()
 
@@ -163,6 +186,11 @@ BaseRLineLayerProcessor <- R6::R6Class(
 
       list(data_points)
     },
+    #' @description One series per column of `y_matrix`, named after the columns
+    #' @param x x positions
+    #' @param y_matrix One column of y values per series
+    #' @param x_labels Category labels to announce in place of the x positions (optional)
+    #' @return List of series
     extract_multiline_data = function(x, y_matrix, x_labels = NULL) {
       series_names <- colnames(y_matrix)
       if (is.null(series_names)) {
@@ -198,6 +226,10 @@ BaseRLineLayerProcessor <- R6::R6Class(
 
       series_list
     },
+    #' @description The axis titles, taken from the HIGH-level call for an overlay such as
+    #'   `abline()`
+    #' @param layer_info Layer information with the recorded call
+    #' @return Canonical axes list
     extract_axis_titles = function(layer_info) {
       if (is.null(layer_info)) {
         return(build_axes())
@@ -237,6 +269,9 @@ BaseRLineLayerProcessor <- R6::R6Class(
         y = recorded_axis_label(args, "ylab", curve_labels$y)
       )
     },
+    #' @description The endpoints of an `abline()` call across the axis the HIGH-level call set up
+    #' @param layer_info Layer information with the recorded call
+    #' @return List holding one two-point series, or empty
     extract_abline_data = function(layer_info) {
       plot_call <- layer_info$plot_call
       args <- plot_call$args
@@ -321,6 +356,9 @@ BaseRLineLayerProcessor <- R6::R6Class(
 
       list(data_points)
     },
+    #' @description The x extent of the group's HIGH-level call, as the axis was drawn
+    #' @param group The recorded plot group holding the HIGH-level call
+    #' @return Numeric vector of two, or NULL
     get_x_range_from_group = function(group) {
       if (is.null(group) || is.null(group$high_call)) {
         return(NULL)
@@ -329,6 +367,9 @@ BaseRLineLayerProcessor <- R6::R6Class(
       high_args <- group$high_call$args
       self$axis_extent(high_args$xlim, resolve_xy_args(high_args)$x)
     },
+    #' @description The y extent of the group's HIGH-level call, as the axis was drawn
+    #' @param group The recorded plot group holding the HIGH-level call
+    #' @return Numeric vector of two, or NULL
     get_y_range_from_group = function(group) {
       if (is.null(group) || is.null(group$high_call)) {
         return(NULL)
@@ -337,9 +378,11 @@ BaseRLineLayerProcessor <- R6::R6Class(
       high_args <- group$high_call$args
       self$axis_extent(high_args$ylim, resolve_xy_args(high_args)$y)
     },
-    # The extent of an axis the way `plot.default()` sets it: an explicit
-    # `xlim`/`ylim`, or the finite data extended by 4 % each way, which is
-    # what `abline()` draws its clipped line across.
+    #' @description The extent of an axis the way `plot.default()` sets it: an explicit
+    #' `xlim`/`ylim`, or the finite data extended by 4 % each way, which is
+    #' what `abline()` draws its clipped line across.
+    #' @param limits An explicit `xlim`/`ylim`, or NULL
+    #' @param data The plotted values on that axis
     axis_extent = function(limits, data) {
       if (is.numeric(limits) && length(limits) == 2L && all(is.finite(limits))) {
         return(grDevices::extendrange(limits, f = 0.04))
@@ -353,6 +396,9 @@ BaseRLineLayerProcessor <- R6::R6Class(
       }
       grDevices::extendrange(range(data), f = 0.04)
     },
+    #' @description The main title, taken from the HIGH-level call for `abline()`
+    #' @param layer_info Layer information with the recorded call
+    #' @return Character string
     extract_main_title = function(layer_info) {
       if (is.null(layer_info)) {
         return("")
@@ -377,6 +423,10 @@ BaseRLineLayerProcessor <- R6::R6Class(
       main_title <- recorded_main_title(args)
       main_title
     },
+    #' @description One selector per polyline, in series order
+    #' @param layer_info Layer information with the recorded call
+    #' @param gt Gtable of the replayed drawing (optional)
+    #' @return List of selectors
     generate_selectors = function(layer_info, gt = NULL) {
       selectors <- list()
 
@@ -393,6 +443,11 @@ BaseRLineLayerProcessor <- R6::R6Class(
 
       selectors
     },
+    #' @description Find every grob of the given family drawn by the plot group at `group_index`
+    #' @param grob The grob tree to search
+    #' @param group_index Index of the recorded plot group, which numbers the panel's grobs
+    #' @param grob_type The grob family to match: "lines", "abline", "segments", "spike" or "step"
+    #' @return Character vector of grob names
     find_lines_grobs = function(grob, group_index, grob_type = "lines") {
       names <- character(0)
 
@@ -457,14 +512,20 @@ BaseRLineLayerProcessor <- R6::R6Class(
 
       names
     },
-    # Which family of grob names this layer's selectors are drawn from:
-    # "abline", "lines", "segments", "spike" or "step". Overridden by
-    # subclasses whose geometry lands under a different grob name (see
-    # BaseRStepLayerProcessor).
+    #' @description Which family of grob names this layer's selectors are drawn from:
+    #' "abline", "lines", "segments", "spike" or "step". Overridden by
+    #' subclasses whose geometry lands under a different grob name (see
+    #' BaseRStepLayerProcessor).
+    #' @param layer_info Layer information with the recorded call
     selector_grob_type = function(layer_info) {
       function_name <- if (!is.null(layer_info)) layer_info$function_name else "lines"
       if (function_name == "abline") "abline" else "lines"
     },
+    #' @description One selector per matching polyline, sorted by the grob number
+    #' @param grob The grob tree to search
+    #' @param group_index Index of the recorded plot group, which numbers the panel's grobs
+    #' @param layer_info Layer information with the recorded call
+    #' @return List of selectors
     generate_selectors_from_grob = function(grob, group_index, layer_info) {
       grob_type <- self$selector_grob_type(layer_info)
 

--- a/R/base_r_mosaic_layer_processor.R
+++ b/R/base_r_mosaic_layer_processor.R
@@ -46,6 +46,9 @@ BaseRMosaicLayerProcessor <- R6::R6Class(
         axes = self$extract_axis_titles(layer_info)
       )
     },
+    #' @description Whether the plot data must be reordered before drawing; a Base R layer is read
+    #'   from the recorded call and never is
+    #' @return FALSE
     needs_reordering = function() {
       FALSE
     },

--- a/R/base_r_patch_architecture.R
+++ b/R/base_r_patch_architecture.R
@@ -8,14 +8,22 @@
 BaseRPatcher <- R6::R6Class(
   "BaseRPatcher",
   public = list(
+    #' @description Abstract: whether this patcher applies to the call
+    #' @param function_name Name of the plotting function
+    #' @param args Recorded argument list
+    #' @return Logical
     can_patch = function(function_name, args) {
       stop("Abstract method - must be implemented by subclass")
     },
+    #' @description Abstract: the argument list with this patcher's change applied
+    #' @param function_name Name of the plotting function
+    #' @param args Recorded argument list
+    #' @return Argument list
     apply_patch = function(function_name, args) {
       stop("Abstract method - must be implemented by subclass")
     },
 
-    # Get the patcher name for debugging
+    #' @description Get the patcher name for debugging
     get_name = function() {
       stop("Abstract method - must be implemented by subclass")
     }

--- a/R/base_r_plot_orchestrator.R
+++ b/R/base_r_plot_orchestrator.R
@@ -107,6 +107,8 @@ BaseRPlotOrchestrator <- R6::R6Class(
     }
   ),
   public = list(
+    #' @description Create an orchestrator for the calls recorded on a device
+    #' @param device_id Graphics device ID
     initialize = function(device_id = grDevices::dev.cur()) {
       private$.device_id <- device_id
       registry <- get_global_registry()
@@ -122,6 +124,8 @@ BaseRPlotOrchestrator <- R6::R6Class(
       self$create_layer_processors()
       self$process_layers()
     },
+    #' @description Turn each recorded plot group into layer entries: one for its HIGH-level call
+    #'   and one per LOW-level overlay
     detect_layers = function() {
       plot_groups <- private$.plot_groups
       private$.layers <- list()
@@ -178,6 +182,11 @@ BaseRPlotOrchestrator <- R6::R6Class(
         }
       }
     },
+    #' @description Describe one recorded call as a layer entry with its detected type
+    #' @param plot_call The recorded call
+    #' @param layer_index Index of the layer
+    #' @param group The recorded plot group holding the HIGH-level call
+    #' @return Layer information list
     analyze_single_layer = function(plot_call, layer_index, group = NULL) {
       function_name <- plot_call$function_name
       args <- plot_call$args
@@ -197,6 +206,7 @@ BaseRPlotOrchestrator <- R6::R6Class(
 
       layer_info
     },
+    #' @description Create a processor for every layer of a known type
     create_layer_processors = function() {
       # Pre-allocate list to avoid sparse list issues
       # In R, list[[i]] <- NULL deletes instead of setting NULL
@@ -213,6 +223,9 @@ BaseRPlotOrchestrator <- R6::R6Class(
         # Unknown types keep their pre-allocated NULL value
       }
     },
+    #' @description Create the processor for one layer
+    #' @param layer_info Layer information with the recorded call
+    #' @return A layer processor, or NULL for an unknown type
     create_layer_processor = function(layer_info) {
       # Use unified layer processor creation logic
       self$create_unified_layer_processor(layer_info)
@@ -232,6 +245,7 @@ BaseRPlotOrchestrator <- R6::R6Class(
 
       processor
     },
+    #' @description Run every layer processor and combine the results
     process_layers = function() {
       private$.layout <- self$extract_layout()
 
@@ -353,6 +367,9 @@ BaseRPlotOrchestrator <- R6::R6Class(
       config
     },
 
+    #' @description Read the figure-level title, subtitle and axis labels from the recorded
+    #'   HIGH-level calls
+    #' @return List
     extract_layout = function() {
       # Extract layout from the recorded HIGH-level plot calls
       # We scan all plot groups for main, sub, xlab, ylab arguments
@@ -415,6 +432,8 @@ BaseRPlotOrchestrator <- R6::R6Class(
 
       layout
     },
+    #' @description Combine the per-layer results into the subplot grid
+    #' @param layer_results List of per-layer results, one per processor
     combine_layer_results = function(layer_results) {
       grid_result <- private$declared_grid(layer_results)
       if (!is.null(grid_result)) {
@@ -688,6 +707,8 @@ BaseRPlotOrchestrator <- R6::R6Class(
         private$.combined_selectors <- combined_selectors
       }
     },
+    #' @description Assemble the MAIDR data object for the figure
+    #' @return List with an id and the subplots
     generate_maidr_data = function() {
       # Base R plots use the same unified structure as ggplot2
       # title, subtitle, caption are figure-level (root of the Maidr object)
@@ -710,21 +731,33 @@ BaseRPlotOrchestrator <- R6::R6Class(
 
       maidr_obj
     },
+    #' @description The figure-level layout read by `extract_layout()`
+    #' @return List
     get_layout = function() {
       private$.layout
     },
+    #' @description The combined per-layer data
+    #' @return List
     get_combined_data = function() {
       private$.combined_data
     },
+    #' @description The processors created for the layers
+    #' @return List
     get_layer_processors = function() {
       private$.layer_processors
     },
+    #' @description The detected layer entries
+    #' @return List
     get_layers = function() {
       private$.layers
     },
+    #' @description The recorded plot calls
+    #' @return List
     get_plot_calls = function() {
       private$.plot_calls
     },
+    #' @description The gtable of the replayed drawing, built once and cached
+    #' @return A gtable, or NULL when nothing was recorded
     get_gtable = function() {
       if (length(private$.plot_groups) == 0) {
         return(NULL)
@@ -901,6 +934,9 @@ BaseRPlotOrchestrator <- R6::R6Class(
         NULL
       }
     },
+    #' @description The grob a layer's processor searches for its selectors
+    #' @param layer_index Index of the layer
+    #' @return A grob, or NULL
     get_grob_for_layer = function(layer_index) {
       if (layer_index < 1 || layer_index > length(private$.layers)) {
         return(NULL)

--- a/R/base_r_point_layer_processor.R
+++ b/R/base_r_point_layer_processor.R
@@ -7,6 +7,17 @@ BaseRPointLayerProcessor <- R6::R6Class(
   "BaseRPointLayerProcessor",
   inherit = LayerProcessor,
   public = list(
+    #' @description Process the layer: read its data, selectors, axis titles and main title from
+    #'   the recorded call
+    #' @param plot Unused; present for the processor interface
+    #' @param layout Unused; present for the processor interface
+    #' @param built Unused; present for the processor interface
+    #' @param gt Gtable of the replayed drawing, searched for selectors (optional)
+    #' @param grob_id Unused; present for the processor interface
+    #' @param panel_id Unused; present for the processor interface
+    #' @param panel_ctx Unused; present for the processor interface
+    #' @param layer_info Layer information with the recorded call
+    #' @return List describing the layer for the MAIDR payload
     process = function(plot,
                        layout,
                        built = NULL,
@@ -28,9 +39,16 @@ BaseRPointLayerProcessor <- R6::R6Class(
         axes = axes
       )
     },
+    #' @description Whether the plot data must be reordered before drawing; a Base R layer is read
+    #'   from the recorded call and never is
+    #' @return FALSE
     needs_reordering = function() {
       FALSE
     },
+    #' @description One point per observation, from the recorded x and y or from the formula's
+    #'   model frame
+    #' @param layer_info Layer information with the recorded call
+    #' @return List of points
     extract_data = function(layer_info) {
       if (is.null(layer_info)) {
         return(list())
@@ -88,16 +106,16 @@ BaseRPointLayerProcessor <- R6::R6Class(
 
       data_points
     },
-    # The x and y a recorded call plots, resolved as plot() resolves them.
-    #
-    # `plot(y ~ x, data = d)` carries a formula rather than two vectors, and
-    # its coordinates are the two columns of the model frame the recording
-    # kept (#254). Read from `resolve_xy_args()` alone, the formula is a
-    # language object and the layer came out with no points at all -- an
-    # interactive chart with nothing in it.
-    #
-    # @param plot_call The recorded call
-    # @return A list with `x` and `y`, either of which may be NULL
+    #' @description The x and y a recorded call plots, resolved as plot() resolves them.
+    #'
+    #' `plot(y ~ x, data = d)` carries a formula rather than two vectors, and
+    #' its coordinates are the two columns of the model frame the recording
+    #' kept (#254). Read from `resolve_xy_args()` alone, the formula is a
+    #' language object and the layer came out with no points at all -- an
+    #' interactive chart with nothing in it.
+    #'
+    #' @param plot_call The recorded call
+    #' @return A list with `x` and `y`, either of which may be NULL
     resolve_coordinates = function(plot_call) {
       frame <- self$formula_variables(plot_call)
       if (!is.null(frame)) {
@@ -105,14 +123,14 @@ BaseRPointLayerProcessor <- R6::R6Class(
       }
       resolve_xy_args(plot_call$args)
     },
-    # The two numeric variables of a recorded formula call, or NULL.
-    #
-    # Only a numeric pair is a scatter: `plot(y ~ f)` on a factor draws a
-    # box plot through `plot.factor()`, and a frame with more than one
-    # predictor draws something else again. Both are left as they were.
-    #
-    # @param plot_call The recorded call
-    # @return A list with `x`, `y`, `x_name`, `y_name`, or NULL
+    #' @description The two numeric variables of a recorded formula call, or NULL.
+    #'
+    #' Only a numeric pair is a scatter: `plot(y ~ f)` on a factor draws a
+    #' box plot through `plot.factor()`, and a frame with more than one
+    #' predictor draws something else again. Both are left as they were.
+    #'
+    #' @param plot_call The recorded call
+    #' @return A list with `x`, `y`, `x_name`, `y_name`, or NULL
     formula_variables = function(plot_call) {
       args <- plot_call$args
       handed <- resolve_xy_args(args)$x
@@ -140,16 +158,16 @@ BaseRPointLayerProcessor <- R6::R6Class(
         y_name = names(frame)[response]
       )
     },
-    # Extract axis information from Base R plot call
-    #
-    # Returns per-axis objects with an optional label and optional grid
-    # navigation fields (min, max, tickStep). Grid fields are derived from
-    # xlim/ylim args or data range, and tick intervals via pretty(). Every
-    # field is included only when extraction succeeds, and an axis that ends
-    # up with none of them is left out of the payload entirely.
-    #
-    # @param layer_info Layer information with recorded plot call
-    # @return Canonical axes list
+    #' @description Extract axis information from Base R plot call
+    #'
+    #' Returns per-axis objects with an optional label and optional grid
+    #' navigation fields (min, max, tickStep). Grid fields are derived from
+    #' xlim/ylim args or data range, and tick intervals via pretty(). Every
+    #' field is included only when extraction succeeds, and an axis that ends
+    #' up with none of them is left out of the payload entirely.
+    #'
+    #' @param layer_info Layer information with recorded plot call
+    #' @return Canonical axes list
     extract_axis_titles = function(layer_info) {
       if (is.null(layer_info)) {
         return(build_axes())
@@ -226,14 +244,14 @@ BaseRPointLayerProcessor <- R6::R6Class(
       build_axes(x = x_axis, y = y_axis)
     },
 
-    # Extract grid navigation info for a Base R axis
-    #
-    # Computes min, max from xlim/ylim or data range, and tickStep from
-    # pretty() tick positions. Returns NULL if extraction fails.
-    #
-    # @param data Numeric vector of data values
-    # @param lim Optional axis limits (xlim or ylim)
-    # @return List with min, max, tickStep or NULL
+    #' @description Extract grid navigation info for a Base R axis
+    #'
+    #' Computes min, max from xlim/ylim or data range, and tickStep from
+    #' pretty() tick positions. Returns NULL if extraction fails.
+    #'
+    #' @param data Numeric vector of data values
+    #' @param lim Optional axis limits (xlim or ylim)
+    #' @return List with min, max, tickStep or NULL
     extract_base_r_axis_grid_info = function(data, lim = NULL) {
       tryCatch(
         {
@@ -280,6 +298,9 @@ BaseRPointLayerProcessor <- R6::R6Class(
         }
       )
     },
+    #' @description The main title of the recorded call, or an empty string
+    #' @param layer_info Layer information with the recorded call
+    #' @return Character string
     extract_main_title = function(layer_info) {
       if (is.null(layer_info)) {
         return("")
@@ -291,6 +312,10 @@ BaseRPointLayerProcessor <- R6::R6Class(
       main_title <- recorded_main_title(args)
       main_title
     },
+    #' @description The selector for the points, scoped to this layer's plot group
+    #' @param layer_info Layer information with the recorded call
+    #' @param gt Gtable of the replayed drawing (optional)
+    #' @return List of selectors
     generate_selectors = function(layer_info, gt = NULL) {
       if (is.null(gt)) {
         return(list())

--- a/R/base_r_smooth_layer_processor.R
+++ b/R/base_r_smooth_layer_processor.R
@@ -10,6 +10,17 @@ BaseRSmoothLayerProcessor <- R6::R6Class(
   "BaseRSmoothLayerProcessor",
   inherit = LayerProcessor,
   public = list(
+    #' @description Process the layer: read its data, selectors, axis titles and main title from
+    #'   the recorded call
+    #' @param plot Unused; present for the processor interface
+    #' @param layout Unused; present for the processor interface
+    #' @param built Unused; present for the processor interface
+    #' @param gt Gtable of the replayed drawing, searched for selectors (optional)
+    #' @param grob_id Unused; present for the processor interface
+    #' @param panel_id Unused; present for the processor interface
+    #' @param panel_ctx Unused; present for the processor interface
+    #' @param layer_info Layer information with the recorded call
+    #' @return List describing the layer for the MAIDR payload
     process = function(plot,
                        layout,
                        built = NULL,
@@ -31,6 +42,9 @@ BaseRSmoothLayerProcessor <- R6::R6Class(
         axes = axes
       )
     },
+    #' @description One point per fitted value of the smooth, density or curve
+    #' @param layer_info Layer information with the recorded call
+    #' @return List of points
     extract_data = function(layer_info) {
       if (is.null(layer_info)) {
         return(list())
@@ -81,6 +95,10 @@ BaseRSmoothLayerProcessor <- R6::R6Class(
 
       list()
     },
+    #' @description The selector for the curve's polyline
+    #' @param layer_info Layer information with the recorded call
+    #' @param gt Gtable of the replayed drawing (optional)
+    #' @return List of selectors
     generate_selectors = function(layer_info, gt = NULL) {
       if (is.null(gt)) {
         return(list())
@@ -98,11 +116,19 @@ BaseRSmoothLayerProcessor <- R6::R6Class(
 
       selectors
     },
+    #' @description Find the lines container grob for this layer
+    #' @param grob The grob tree to search
+    #' @param call_index Index of the recorded plot group, which numbers the panel's grobs
+    #' @return Grob name, or NULL
     find_polyline_grobs = function(grob, call_index = NULL) {
       # Use robust utility function to find lines container
       # This doesn't rely on call_index matching the actual grob names
       find_graphics_plot_grob(grob, "lines")
     },
+    #' @description Build this layer's selector from the grob tree
+    #' @param grob The grob tree to search
+    #' @param call_index Index of the recorded plot group, which numbers the panel's grobs
+    #' @return A selector string, or an empty string when no grob matches
     generate_selectors_from_grob = function(grob, call_index = NULL) {
       # Scope to this plot group's grobs so multipanel layouts don't
       # match another panel's lines
@@ -123,15 +149,15 @@ BaseRSmoothLayerProcessor <- R6::R6Class(
 
       list(selector)
     },
-    # Extract the axis titles for this layer
-    #
-    # The x axis holds whatever variable was smoothed, which the recorded
-    # arguments no longer name, so it carries no default. The y axis does
-    # when the curve came from `density()`: that estimate is a density, and
-    # plot.density() prints exactly that word.
-    #
-    # @param layer_info Layer information
-    # @return Canonical axes list
+    #' @description Extract the axis titles for this layer
+    #'
+    #' The x axis holds whatever variable was smoothed, which the recorded
+    #' arguments no longer name, so it carries no default. The y axis does
+    #' when the curve came from `density()`: that estimate is a density, and
+    #' plot.density() prints exactly that word.
+    #'
+    #' @param layer_info Layer information
+    #' @return Canonical axes list
     extract_axis_titles = function(layer_info) {
       if (is.null(layer_info)) {
         return(build_axes())
@@ -158,6 +184,9 @@ BaseRSmoothLayerProcessor <- R6::R6Class(
         y = recorded_axis_label(args, "ylab", y_default)
       )
     },
+    #' @description The main title of the recorded call, or an empty string
+    #' @param layer_info Layer information with the recorded call
+    #' @return Character string
     extract_main_title = function(layer_info) {
       if (is.null(layer_info)) {
         return("")

--- a/R/base_r_stacked_bar_layer_processor.R
+++ b/R/base_r_stacked_bar_layer_processor.R
@@ -9,6 +9,17 @@ BaseRStackedBarLayerProcessor <- R6::R6Class(
   "BaseRStackedBarLayerProcessor",
   inherit = LayerProcessor,
   public = list(
+    #' @description Process the layer: read its data, selectors, axis titles and main title from
+    #'   the recorded call
+    #' @param plot Unused; present for the processor interface
+    #' @param layout Unused; present for the processor interface
+    #' @param built Unused; present for the processor interface
+    #' @param gt Gtable of the replayed drawing, searched for selectors (optional)
+    #' @param grob_id Unused; present for the processor interface
+    #' @param panel_id Unused; present for the processor interface
+    #' @param panel_ctx Unused; present for the processor interface
+    #' @param layer_info Layer information with the recorded call
+    #' @return List describing the layer for the MAIDR payload
     process = function(plot,
                        layout,
                        built = NULL,
@@ -50,9 +61,15 @@ BaseRStackedBarLayerProcessor <- R6::R6Class(
         domMapping = list(groupDirection = "forward")
       )
     },
+    #' @description Whether the plot data must be reordered before drawing; a Base R layer is read
+    #'   from the recorded call and never is
+    #' @return FALSE
     needs_reordering = function() {
       FALSE
     },
+    #' @description One series per row of the recorded height matrix
+    #' @param layer_info Layer information with the recorded call
+    #' @return List of series
     extract_data = function(layer_info) {
       if (is.null(layer_info)) {
         return(list())
@@ -104,19 +121,22 @@ BaseRStackedBarLayerProcessor <- R6::R6Class(
 
       data
     },
-    # Extract the axis titles for this layer
-    #
-    # A stacked `barplot()` records no title unless the author wrote one, and
-    # its points always carry the column category on x and the segment height
-    # on y, so the defaults name those two. The stack's own dimension is
-    # already announced per point as z; nothing in the call names the
-    # variable those groups came from, so no z title is claimed.
-    #
-    # @param layer_info Layer information
-    # @return Canonical axes list
+    #' @description Extract the axis titles for this layer
+    #'
+    #' A stacked `barplot()` records no title unless the author wrote one, and
+    #' its points always carry the column category on x and the segment height
+    #' on y, so the defaults name those two. The stack's own dimension is
+    #' already announced per point as z; nothing in the call names the
+    #' variable those groups came from, so no z title is claimed.
+    #'
+    #' @param layer_info Layer information
+    #' @return Canonical axes list
     extract_axis_titles = function(layer_info) {
       base_r_categorical_axes(layer_info$plot_call$args)
     },
+    #' @description The main title of the recorded call, or an empty string
+    #' @param layer_info Layer information with the recorded call
+    #' @return Character string
     extract_main_title = function(layer_info) {
       if (is.null(layer_info)) {
         return("")
@@ -124,6 +144,11 @@ BaseRStackedBarLayerProcessor <- R6::R6Class(
       args <- layer_info$plot_call$args
       recorded_main_title(args)
     },
+    #' @description The selector for the segments, scoped to this layer's plot group
+    #' @param layer_info Layer information with the recorded call
+    #' @param gt Gtable of the replayed drawing (optional)
+    #' @param extracted_data The data already extracted for this layer (optional)
+    #' @return List of selectors
     generate_selectors = function(layer_info, gt = NULL, extracted_data = NULL) {
       if (is.null(layer_info) || is.null(gt)) {
         return(list())
@@ -168,6 +193,10 @@ BaseRStackedBarLayerProcessor <- R6::R6Class(
 
       list(selectors)
     },
+    #' @description Find every rect group drawn by the plot group at `call_index`
+    #' @param grob The grob tree to search
+    #' @param call_index Index of the recorded plot group, which numbers the panel's grobs
+    #' @return Character vector of grob names
     find_rect_groups = function(grob, call_index) {
       names <- character(0)
 

--- a/R/base_r_unknown_layer_processor.R
+++ b/R/base_r_unknown_layer_processor.R
@@ -7,6 +7,16 @@ BaseRUnknownLayerProcessor <- R6::R6Class(
   "BaseRUnknownLayerProcessor",
   inherit = LayerProcessor,
   public = list(
+    #' @description Describe a layer nothing is known about
+    #' @param plot Unused; present for the processor interface
+    #' @param layout Unused; present for the processor interface
+    #' @param built Unused; present for the processor interface
+    #' @param gt Gtable of the replayed drawing, searched for selectors (optional)
+    #' @param grob_id Unused; present for the processor interface
+    #' @param panel_id Unused; present for the processor interface
+    #' @param panel_ctx Unused; present for the processor interface
+    #' @param layer_info Layer information with the recorded call
+    #' @return List with no data and no selectors
     process = function(plot,
                        layout,
                        built = NULL,
@@ -29,13 +39,22 @@ BaseRUnknownLayerProcessor <- R6::R6Class(
         axes = build_axes()
       )
     },
+    #' @description Whether the plot data must be reordered before drawing; a Base R layer is read
+    #'   from the recorded call and never is
+    #' @return FALSE
     needs_reordering = function() {
       FALSE
     },
+    #' @description Nothing: an unknown layer has no data to announce
+    #' @param layer_info Layer information with the recorded call
+    #' @return Empty list
     extract_data = function(layer_info) {
       # For unknown plot types, return minimal data
       list()
     },
+    #' @description Nothing: an unknown layer has no elements to address
+    #' @param layer_info Layer information with the recorded call
+    #' @return Empty list
     generate_selectors = function(layer_info) {
       # For unknown plot types, return minimal selectors
       list()

--- a/R/ggplot2_bar_layer_processor.R
+++ b/R/ggplot2_bar_layer_processor.R
@@ -310,6 +310,7 @@ Ggplot2BarLayerProcessor <- R6::R6Class(
     #' `as.character()`. Mirrors `Ggplot2CandlestickProcessor$format_x_value()`
     #' so candle and bar layers from the same Date column align string-wise.
     #' @param x The value to format
+    #' @return Character vector
     format_x_value = function(x) {
       if (inherits(x, c("Date", "POSIXct", "POSIXlt"))) {
         return(format(x))

--- a/R/ggplot2_bar_layer_processor.R
+++ b/R/ggplot2_bar_layer_processor.R
@@ -7,6 +7,15 @@ Ggplot2BarLayerProcessor <- R6::R6Class(
   "Ggplot2BarLayerProcessor",
   inherit = LayerProcessor,
   public = list(
+    #' @description Process the layer: read its bars, selectors and orientation from the built plot
+    #' @param plot The ggplot2 object
+    #' @param layout Layout information
+    #' @param built Built plot data (optional)
+    #' @param gt Gtable object (optional)
+    #' @param grob_id Grob ID for faceted plots (optional)
+    #' @param panel_id Panel ID for faceted plots (optional)
+    #' @param panel_ctx Panel context for panel-scoped selector generation (optional)
+    #' @return List describing the layer for the MAIDR payload
     process = function(plot,
                        layout,
                        built = NULL,
@@ -96,9 +105,16 @@ Ggplot2BarLayerProcessor <- R6::R6Class(
       }
       plot
     },
+    #' @description Whether the plot data must be reordered before drawing, so the emitted order
+    #'   matches the drawn rects
+    #' @return TRUE
     needs_reordering = function() {
       TRUE
     },
+    #' @description Reorder the plot data by category so the emitted rows match the drawn rects
+    #' @param data The data frame ggplot2 will draw from
+    #' @param plot The ggplot2 object
+    #' @return The reordered data frame
     reorder_layer_data = function(data, plot) {
       # Sorted by the *category*, which is the y mapping on a flipped layer.
       # Sorting by x there ordered the rows by the measure, so the emitted
@@ -120,6 +136,11 @@ Ggplot2BarLayerProcessor <- R6::R6Class(
         data
       }
     },
+    #' @description One point per bar, read from the built plot
+    #' @param plot The ggplot2 object
+    #' @param built Built plot data (optional)
+    #' @param panel_id Panel ID for faceted plots (optional)
+    #' @return List of points
     extract_data = function(plot, built = NULL, panel_id = NULL) {
       if (is.null(built)) {
         built <- ggplot2::ggplot_build(plot)
@@ -288,6 +309,7 @@ Ggplot2BarLayerProcessor <- R6::R6Class(
     #' default scale-tick labels ("Jan 02"). All other types use
     #' `as.character()`. Mirrors `Ggplot2CandlestickProcessor$format_x_value()`
     #' so candle and bar layers from the same Date column align string-wise.
+    #' @param x The value to format
     format_x_value = function(x) {
       if (inherits(x, c("Date", "POSIXct", "POSIXlt"))) {
         return(format(x))
@@ -390,6 +412,12 @@ Ggplot2BarLayerProcessor <- R6::R6Class(
       x_values
     },
 
+    #' @description Selectors for the layer's rects
+    #' @param plot The ggplot2 object
+    #' @param gt Gtable object (optional)
+    #' @param grob_id Grob ID for faceted plots (optional)
+    #' @param panel_ctx Panel context for panel-scoped selector generation (optional)
+    #' @return List of selectors
     generate_selectors = function(plot, gt = NULL, grob_id = NULL, panel_ctx = NULL) {
       # Prefer panel-scoped selection when panel_ctx is provided
       if (!is.null(panel_ctx) && !is.null(gt)) {

--- a/R/ggplot2_candlestick_layer_processor.R
+++ b/R/ggplot2_candlestick_layer_processor.R
@@ -275,6 +275,8 @@ Ggplot2CandlestickProcessor <- R6::R6Class(
     # ------------------------------------------------------------------
 
     #' @description Resolve a mapping quosure to a column name in `data`
+    #' @param mapping_expr A mapping quosure
+    #' @param data The data frame to resolve the column in
     resolve_col = function(mapping_expr, data) {
       if (is.null(mapping_expr)) return(NULL)
       nm <- tryCatch(rlang::as_label(mapping_expr), error = function(e) NULL)
@@ -283,6 +285,7 @@ Ggplot2CandlestickProcessor <- R6::R6Class(
     },
 
     #' @description Format an x-axis value as character
+    #' @param x The value to format
     format_x_value = function(x) {
       if (inherits(x, c("Date", "POSIXct", "POSIXlt"))) {
         return(format(x))
@@ -291,6 +294,7 @@ Ggplot2CandlestickProcessor <- R6::R6Class(
     },
 
     #' @description Get the effective mapping (layer mapping merged on top)
+    #' @param plot The ggplot2 object
     get_effective_mapping = function(plot) {
       layer_index <- self$get_layer_index()
       layer_mapping <- plot$layers[[layer_index]]$mapping
@@ -302,6 +306,7 @@ Ggplot2CandlestickProcessor <- R6::R6Class(
     },
 
     #' @description Get original data for the layer (falls back to plot$data)
+    #' @param plot The ggplot2 object
     get_original_data = function(plot) {
       layer_index <- self$get_layer_index()
       layer <- plot$layers[[layer_index]]
@@ -316,6 +321,7 @@ Ggplot2CandlestickProcessor <- R6::R6Class(
     },
 
     #' @description Count candles from the original data
+    #' @param plot The ggplot2 object
     count_candles = function(plot) {
       d <- self$get_original_data(plot)
       if (is.data.frame(d)) nrow(d) else 0L
@@ -331,6 +337,8 @@ Ggplot2CandlestickProcessor <- R6::R6Class(
     },
 
     #' @description Find the first descendant whose name matches `pattern`
+    #' @param grob The grob tree to search
+    #' @param pattern Regular expression the grob name must match
     find_first_child_name = function(grob, pattern) {
       if (!inherits(grob, "gTree") || is.null(grob$children)) {
         return(NULL)

--- a/R/ggplot2_candlestick_layer_processor.R
+++ b/R/ggplot2_candlestick_layer_processor.R
@@ -277,6 +277,7 @@ Ggplot2CandlestickProcessor <- R6::R6Class(
     #' @description Resolve a mapping quosure to a column name in `data`
     #' @param mapping_expr A mapping quosure
     #' @param data The data frame to resolve the column in
+    #' @return The column name, or NULL when the mapping names no column of `data`
     resolve_col = function(mapping_expr, data) {
       if (is.null(mapping_expr)) return(NULL)
       nm <- tryCatch(rlang::as_label(mapping_expr), error = function(e) NULL)
@@ -286,6 +287,7 @@ Ggplot2CandlestickProcessor <- R6::R6Class(
 
     #' @description Format an x-axis value as character
     #' @param x The value to format
+    #' @return Character vector
     format_x_value = function(x) {
       if (inherits(x, c("Date", "POSIXct", "POSIXlt"))) {
         return(format(x))
@@ -322,6 +324,7 @@ Ggplot2CandlestickProcessor <- R6::R6Class(
 
     #' @description Count candles from the original data
     #' @param plot The ggplot2 object
+    #' @return Integer, 0 when there is no data
     count_candles = function(plot) {
       d <- self$get_original_data(plot)
       if (is.data.frame(d)) nrow(d) else 0L
@@ -339,6 +342,7 @@ Ggplot2CandlestickProcessor <- R6::R6Class(
     #' @description Find the first descendant whose name matches `pattern`
     #' @param grob The grob tree to search
     #' @param pattern Regular expression the grob name must match
+    #' @return The matching grob name, or NULL
     find_first_child_name = function(grob, pattern) {
       if (!inherits(grob, "gTree") || is.null(grob$children)) {
         return(NULL)

--- a/R/ggplot2_dodged_bar_layer_processor.R
+++ b/R/ggplot2_dodged_bar_layer_processor.R
@@ -7,6 +7,16 @@ Ggplot2DodgedBarLayerProcessor <- R6::R6Class(
   "Ggplot2DodgedBarLayerProcessor",
   inherit = LayerProcessor,
   public = list(
+    #' @description Process the layer: read its series, selectors and DOM mapping from the built
+    #'   plot
+    #' @param plot The ggplot2 object
+    #' @param layout Layout information
+    #' @param built Built plot data (optional)
+    #' @param gt Gtable object (optional)
+    #' @param grob_id Grob ID for faceted plots (optional)
+    #' @param panel_id Panel ID for faceted plots (optional)
+    #' @param panel_ctx Panel context for panel-scoped selector generation (optional)
+    #' @return List describing the layer for the MAIDR payload
     process = function(plot,
                        layout,
                        built = NULL,
@@ -58,6 +68,9 @@ Ggplot2DodgedBarLayerProcessor <- R6::R6Class(
       }
       result
     },
+    #' @description Whether the plot data must be reordered before drawing, so the emitted order
+    #'   matches the drawn rects
+    #' @return TRUE
     needs_reordering = function() {
       TRUE
     },
@@ -114,6 +127,11 @@ Ggplot2DodgedBarLayerProcessor <- R6::R6Class(
         fill = evaluate(quo_for("fill"))
       )
     },
+    #' @description Reorder the plot data by x and fill so each column's rects are drawn in the
+    #'   order the frontend walks them
+    #' @param data The data frame ggplot2 will draw from
+    #' @param plot The ggplot2 object
+    #' @return The reordered data frame
     reorder_layer_data = function(data, plot) {
       aes_values <- self$resolve_aes_values(plot, data)
       x_values <- aes_values$x
@@ -144,6 +162,12 @@ Ggplot2DodgedBarLayerProcessor <- R6::R6Class(
 
       data[order(x_ordered, fill_ordered), , drop = FALSE]
     },
+    #' @description One series per fill level, as a rectangular grid with a `0` for every missing
+    #'   bar
+    #' @param plot The ggplot2 object
+    #' @param built Built plot data (optional)
+    #' @param panel_ctx Panel context for panel-scoped selector generation (optional)
+    #' @return List of series
     extract_data = function(plot, built = NULL, panel_ctx = NULL) {
       if (!inherits(plot, "ggplot")) {
         stop("Input must be a ggplot object.")
@@ -431,6 +455,12 @@ Ggplot2DodgedBarLayerProcessor <- R6::R6Class(
     #
     # Pinned by test-segmented-bar-selector-contract.R (stat = "identity")
     # and by test-dodged-bar-count-grid.R (stat = "count").
+    #' @description One flat selector matching every rect in the layer, which is the contract the
+    #'   frontend expects (see the note above)
+    #' @param plot The ggplot2 object
+    #' @param gt Gtable object (optional)
+    #' @param panel_ctx Panel context for panel-scoped selector generation (optional)
+    #' @return List holding one selector
     generate_selectors = function(plot, gt = NULL, panel_ctx = NULL) {
       if (is.null(gt)) {
         gt <- ggplot2::ggplotGrob(plot)

--- a/R/ggplot2_heatmap_layer_processor.R
+++ b/R/ggplot2_heatmap_layer_processor.R
@@ -7,6 +7,15 @@ Ggplot2HeatmapLayerProcessor <- R6::R6Class(
   "Ggplot2HeatmapLayerProcessor",
   inherit = LayerProcessor,
   public = list(
+    #' @description Process the layer: read its tiles, selectors and axis names from the built plot
+    #' @param plot The ggplot2 object
+    #' @param layout Layout information
+    #' @param built Built plot data (optional)
+    #' @param gt Gtable object (optional)
+    #' @param grob_id Grob ID for faceted plots (optional)
+    #' @param panel_id Panel ID for faceted plots (optional)
+    #' @param panel_ctx Panel context for panel-scoped selector generation (optional)
+    #' @return List describing the layer for the MAIDR payload
     process = function(plot,
                        layout,
                        built = NULL,
@@ -41,9 +50,16 @@ Ggplot2HeatmapLayerProcessor <- R6::R6Class(
         axes = axes
       )
     },
+    #' @description Whether the plot data must be reordered before drawing, so the emitted order
+    #'   matches the drawn tiles
+    #' @return TRUE
     needs_reordering = function() {
       TRUE
     },
+    #' @description Reorder the plot data row-wise so the emitted cells match the drawn tiles
+    #' @param data The data frame ggplot2 will draw from
+    #' @param plot The ggplot2 object
+    #' @return The reordered data frame
     reorder_layer_data = function(data, plot) {
       # Generic data reordering for heatmaps
       # Reorder data to match visual order (row-wise)
@@ -222,6 +238,11 @@ Ggplot2HeatmapLayerProcessor <- R6::R6Class(
         paste0(self$format_bin_edge(lower), " to ", self$format_bin_edge(upper))
       }, character(1))
     },
+    #' @description One row per tile plus the fill label, read from the built plot
+    #' @param plot The ggplot2 object
+    #' @param built Built plot data (optional)
+    #' @param panel_id Panel ID for faceted plots (optional)
+    #' @return List
     extract_data = function(plot, built = NULL, panel_id = NULL) {
       if (is.null(built)) {
         built <- ggplot2::ggplot_build(plot)
@@ -368,6 +389,11 @@ Ggplot2HeatmapLayerProcessor <- R6::R6Class(
         fill_label = fill_col
       ))
     },
+    #' @description Selectors for the tiles, scoped to the panel
+    #' @param plot The ggplot2 object
+    #' @param gt Gtable object (optional)
+    #' @param panel_ctx Panel context for panel-scoped selector generation (optional)
+    #' @return List of selectors
     generate_selectors = function(plot, gt = NULL, panel_ctx = NULL) {
       selectors <- list()
 

--- a/R/ggplot2_histogram_layer_processor.R
+++ b/R/ggplot2_histogram_layer_processor.R
@@ -7,6 +7,15 @@ Ggplot2HistogramLayerProcessor <- R6::R6Class(
   "Ggplot2HistogramLayerProcessor",
   inherit = LayerProcessor,
   public = list(
+    #' @description Process the layer: read its bins, selectors and orientation from the built plot
+    #' @param plot The ggplot2 object
+    #' @param layout Layout information
+    #' @param built Built plot data (optional)
+    #' @param gt Gtable object (optional)
+    #' @param grob_id Grob ID for faceted plots (optional)
+    #' @param panel_id Panel ID for faceted plots (optional)
+    #' @param panel_ctx Panel context for panel-scoped selector generation (optional)
+    #' @return List describing the layer for the MAIDR payload
     process = function(plot,
                        layout,
                        built = NULL,
@@ -60,6 +69,11 @@ Ggplot2HistogramLayerProcessor <- R6::R6Class(
       layer_data <- built$data[[layer_index]]
       if (isTRUE(layer_data$flipped_aes[1])) "horz" else "vert"
     },
+    #' @description One point per bin, read from this layer's own built data
+    #' @param plot The ggplot2 object
+    #' @param built Built plot data (optional)
+    #' @param panel_id Panel ID for faceted plots (optional)
+    #' @return List of points
     extract_data = function(plot, built = NULL, panel_id = NULL) {
       if (is.null(built)) {
         built <- ggplot2::ggplot_build(plot)
@@ -90,6 +104,11 @@ Ggplot2HistogramLayerProcessor <- R6::R6Class(
         )
       })
     },
+    #' @description Selectors for the bins, scoped to the panel
+    #' @param plot The ggplot2 object
+    #' @param gt Gtable object (optional)
+    #' @param panel_ctx Panel context for panel-scoped selector generation (optional)
+    #' @return List of selectors
     generate_selectors = function(plot, gt = NULL, panel_ctx = NULL) {
       if (is.null(gt)) {
         return(list())

--- a/R/ggplot2_line_layer_processor.R
+++ b/R/ggplot2_line_layer_processor.R
@@ -567,6 +567,7 @@ Ggplot2LineLayerProcessor <- R6::R6Class(
     #' `Ggplot2BarLayerProcessor$format_x_value()` so bar and line layers
     #' from the same Date column align string-wise.
     #' @param x The value to format
+    #' @return Character vector
     format_x_value = function(x) {
       if (inherits(x, c("Date", "POSIXct", "POSIXlt"))) {
         return(format(x))

--- a/R/ggplot2_line_layer_processor.R
+++ b/R/ggplot2_line_layer_processor.R
@@ -566,6 +566,7 @@ Ggplot2LineLayerProcessor <- R6::R6Class(
     #' `ggplot_build()`. All other types use `as.character()`. Mirrors
     #' `Ggplot2BarLayerProcessor$format_x_value()` so bar and line layers
     #' from the same Date column align string-wise.
+    #' @param x The value to format
     format_x_value = function(x) {
       if (inherits(x, c("Date", "POSIXct", "POSIXlt"))) {
         return(format(x))

--- a/R/ggplot2_plot_orchestrator.R
+++ b/R/ggplot2_plot_orchestrator.R
@@ -55,6 +55,8 @@ Ggplot2PlotOrchestrator <- R6::R6Class(
     .format_config = NULL
   ),
   public = list(
+    #' @description Create an orchestrator for a ggplot2 object
+    #' @param plot The ggplot2 object
     initialize = function(plot) {
       private$.plot <- plot
 
@@ -85,6 +87,7 @@ Ggplot2PlotOrchestrator <- R6::R6Class(
         self$process_layers()
       }
     },
+    #' @description Turn each layer of the plot into a layer entry with its detected type
     detect_layers = function() {
       layers <- private$.plot$layers
       private$.layers <- list()
@@ -137,6 +140,10 @@ Ggplot2PlotOrchestrator <- R6::R6Class(
 
       invisible(NULL)
     },
+    #' @description Describe one ggplot2 layer as a layer entry with its detected type
+    #' @param layer A ggplot2 layer object
+    #' @param layer_index Index of the layer
+    #' @return Layer information list
     analyze_single_layer = function(layer, layer_index) {
       # Safely extract layer components with error handling
       geom <- tryCatch(layer$geom, error = function(e) NULL)
@@ -164,6 +171,10 @@ Ggplot2PlotOrchestrator <- R6::R6Class(
 
       layer_info
     },
+    #' @description The layer type the adapter detects for one layer of the plot
+    #' @param plot The ggplot2 object
+    #' @param layer_index Index of the layer
+    #' @return Character string
     determine_layer_type = function(plot, layer_index) {
       layer <- plot$layers[[layer_index]]
       if (is.null(layer)) {
@@ -173,6 +184,7 @@ Ggplot2PlotOrchestrator <- R6::R6Class(
       # Delegate layer type detection to the adapter
       private$.adapter$detect_layer_type(layer, plot)
     },
+    #' @description Create a processor for every layer of a known type
     create_layer_processors = function() {
       private$.layer_processors <- list()
 
@@ -185,6 +197,9 @@ Ggplot2PlotOrchestrator <- R6::R6Class(
         }
       }
     },
+    #' @description Create the processor for one layer
+    #' @param layer_info Layer information
+    #' @return A layer processor, or NULL for an unknown type
     create_layer_processor = function(layer_info) {
       # Use unified layer processor creation logic
       self$create_unified_layer_processor(layer_info)
@@ -204,6 +219,7 @@ Ggplot2PlotOrchestrator <- R6::R6Class(
 
       processor
     },
+    #' @description Run every layer processor and combine the results
     process_layers = function() {
       plot_for_render <- private$.plot
       for (i in seq_along(private$.layer_processors)) {
@@ -275,6 +291,10 @@ Ggplot2PlotOrchestrator <- R6::R6Class(
 
       self$combine_layer_results(layer_results)
     },
+    #' @description Read the figure-level title, subtitle, caption and axis labels from the built
+    #'   plot
+    #' @param built Built plot data (optional)
+    #' @return List
     extract_layout = function(built = NULL) {
       if (is.null(built)) {
         built <- ggplot2::ggplot_build(private$.plot)
@@ -320,6 +340,8 @@ Ggplot2PlotOrchestrator <- R6::R6Class(
 
       layout
     },
+    #' @description Combine the per-layer results into the subplot grid
+    #' @param layer_results List of per-layer results, one per processor
     combine_layer_results = function(layer_results) {
       combined_data <- list()
 
@@ -438,6 +460,8 @@ Ggplot2PlotOrchestrator <- R6::R6Class(
 
       private$.combined_selectors <- combined_selectors
     },
+    #' @description Assemble the MAIDR data object for the figure
+    #' @return List with an id and the subplots
     generate_maidr_data = function() {
       # All plot types use the same unified structure
       # The combined_data already has the correct format for each plot type
@@ -461,18 +485,28 @@ Ggplot2PlotOrchestrator <- R6::R6Class(
 
       maidr_obj
     },
+    #' @description The gtable the plot was drawn to
+    #' @return A gtable, or NULL before the layers are processed
     get_gtable = function() {
       private$.gtable
     },
+    #' @description The figure-level layout read by `extract_layout()`
+    #' @return List
     get_layout = function() {
       private$.layout
     },
+    #' @description The combined per-layer data
+    #' @return List
     get_combined_data = function() {
       private$.combined_data
     },
+    #' @description The processors created for the layers
+    #' @return List
     get_layer_processors = function() {
       private$.layer_processors
     },
+    #' @description The detected layer entries
+    #' @return List
     get_layers = function() {
       private$.layers
     },

--- a/R/ggplot2_smooth_layer_processor.R
+++ b/R/ggplot2_smooth_layer_processor.R
@@ -7,6 +7,15 @@ Ggplot2SmoothLayerProcessor <- R6::R6Class(
   "Ggplot2SmoothLayerProcessor",
   inherit = LayerProcessor,
   public = list(
+    #' @description Process the layer: read its curves, selectors and axes from the built plot
+    #' @param plot The ggplot2 object
+    #' @param layout Layout information
+    #' @param built Built plot data (optional)
+    #' @param gt Gtable object (optional)
+    #' @param grob_id Grob ID for faceted plots (optional)
+    #' @param panel_id Panel ID for faceted plots (optional)
+    #' @param panel_ctx Panel context for panel-scoped selector generation (optional)
+    #' @return List describing the layer for the MAIDR payload
     process = function(plot,
                        layout,
                        built = NULL,
@@ -332,6 +341,14 @@ Ggplot2SmoothLayerProcessor <- R6::R6Class(
     # the empty panel highlighted panel 1's fitted line. Emit nothing
     # instead: the caller can tell an empty selector list apart from a
     # wrong one, a user cannot.
+    #' @description The selector for the polyline this layer drew, or none when it cannot be found
+    #'   (see the note above)
+    #' @param plot The ggplot2 object
+    #' @param gt Gtable object (optional)
+    #' @param panel_ctx Panel context for panel-scoped selector generation (optional)
+    #' @param built Built plot data (optional)
+    #' @param panel_id Panel ID for faceted plots (optional)
+    #' @return List of selectors
     generate_selectors = function(plot, gt = NULL, panel_ctx = NULL,
                                   built = NULL, panel_id = NULL) {
       if (is.null(gt)) {

--- a/R/ggplot2_stacked_bar_layer_processor.R
+++ b/R/ggplot2_stacked_bar_layer_processor.R
@@ -7,6 +7,16 @@ Ggplot2StackedBarProcessor <- R6::R6Class(
   "Ggplot2StackedBarProcessor",
   inherit = LayerProcessor,
   public = list(
+    #' @description Process the layer: read its series, selectors and the fill legend title from
+    #'   the built plot
+    #' @param plot The ggplot2 object
+    #' @param layout Layout information
+    #' @param built Built plot data (optional)
+    #' @param gt Gtable object (optional)
+    #' @param grob_id Grob ID for faceted plots (optional)
+    #' @param panel_id Panel ID for faceted plots (optional)
+    #' @param panel_ctx Panel context for panel-scoped selector generation (optional)
+    #' @return List describing the layer for the MAIDR payload
     process = function(plot,
                        layout,
                        built = NULL,
@@ -45,9 +55,17 @@ Ggplot2StackedBarProcessor <- R6::R6Class(
         axes = axes
       )
     },
+    #' @description Whether the plot data must be reordered before drawing, so the emitted order
+    #'   matches the drawn rects
+    #' @return TRUE
     needs_reordering = function() {
       TRUE
     },
+    #' @description Reorder the plot data by category and fill so the emitted rows match the drawn
+    #'   rects
+    #' @param data The data frame ggplot2 will draw from
+    #' @param plot The ggplot2 object
+    #' @return The reordered data frame
     reorder_layer_data = function(data, plot) {
       columns <- self$extract_plot_columns(plot)
       fill_col <- columns$fill_col
@@ -62,6 +80,9 @@ Ggplot2StackedBarProcessor <- R6::R6Class(
       data <- data[order(data[[category_col]], data[[fill_col]]), , drop = FALSE]
       data
     },
+    #' @description The column names the plot maps to x, y and fill
+    #' @param plot The ggplot2 object
+    #' @return List with `category_col`, `value_col` and `fill_col`
     extract_plot_columns = function(plot) {
       plot_mapping <- plot$mapping
 
@@ -82,6 +103,12 @@ Ggplot2StackedBarProcessor <- R6::R6Class(
         category_col = extract_col_name(plot_mapping$x)
       )
     },
+    #' @description One series per fill level, restricted to the panel's rows under faceting
+    #' @param plot The ggplot2 object
+    #' @param built Built plot data (optional)
+    #' @param panel_id Panel ID for faceted plots (optional)
+    #' @param panel_ctx Panel context for panel-scoped selector generation (optional)
+    #' @return List of series
     extract_data = function(plot, built = NULL, panel_id = NULL, panel_ctx = NULL) {
       original_data <- plot$data
 
@@ -458,6 +485,12 @@ Ggplot2StackedBarProcessor <- R6::R6Class(
     # regrouping above reunites data[0] = v with the v rects.
     #
     # Pinned by tests/testthat/test-segmented-bar-selector-contract.R.
+    #' @description One flat selector matching every rect in the layer, which is the contract the
+    #'   frontend expects (see the note above)
+    #' @param plot The ggplot2 object
+    #' @param gt Gtable object (optional)
+    #' @param panel_ctx Panel context for panel-scoped selector generation (optional)
+    #' @return List holding one selector
     generate_selectors = function(plot, gt = NULL, panel_ctx = NULL) {
       if (is.null(gt)) {
         return(list())

--- a/R/ggplot2_unknown_layer_processor.R
+++ b/R/ggplot2_unknown_layer_processor.R
@@ -7,6 +7,15 @@ Ggplot2UnknownLayerProcessor <- R6::R6Class(
   "Ggplot2UnknownLayerProcessor",
   inherit = LayerProcessor,
   public = list(
+    #' @description Describe a layer nothing is known about
+    #' @param plot The ggplot2 object
+    #' @param layout Layout information
+    #' @param built Built plot data (optional)
+    #' @param gt Gtable object (optional)
+    #' @param grob_id Grob ID for faceted plots (optional)
+    #' @param panel_id Panel ID for faceted plots (optional)
+    #' @param panel_ctx Panel context for panel-scoped selector generation (optional)
+    #' @return List with no data and no selectors
     process = function(plot,
                        layout,
                        built = NULL,
@@ -21,9 +30,19 @@ Ggplot2UnknownLayerProcessor <- R6::R6Class(
         axes = self$extract_layer_axes(plot, layout)
       )
     },
+    #' @description Nothing: an unknown layer has no data to announce
+    #' @param plot The ggplot2 object
+    #' @param built Built plot data (optional)
+    #' @return Empty list
     extract_data = function(plot, built = NULL) {
       list()
     },
+    #' @description Nothing: an unknown layer has no elements to address
+    #' @param plot The ggplot2 object
+    #' @param gt Gtable object (optional)
+    #' @param grob_id Grob ID for faceted plots (optional)
+    #' @param panel_ctx Panel context for panel-scoped selector generation (optional)
+    #' @return Empty list
     generate_selectors = function(plot, gt = NULL, grob_id = NULL, panel_ctx = NULL) {
       list()
     }

--- a/R/ggplot2_violin_layer_processor.R
+++ b/R/ggplot2_violin_layer_processor.R
@@ -701,6 +701,7 @@ Ggplot2ViolinLayerProcessor <- R6::R6Class(
     # ------------------------------------------------------------------
 
     #' @description Determine orientation from built data
+    #' @param built Built plot data (optional)
     determine_orientation = function(built) {
       layer_index <- self$get_layer_index()
       layer_data <- built$data[[layer_index]]

--- a/man/BaseRAssocplotLayerProcessor.Rd
+++ b/man/BaseRAssocplotLayerProcessor.Rd
@@ -125,10 +125,15 @@ areas are shares of a total when they are a departure from an expectation.
 \if{html}{\out{<a id="method-BaseRAssocplotLayerProcessor-needs_reordering"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRAssocplotLayerProcessor-needs_reordering}{}}}
 \subsection{\code{BaseRAssocplotLayerProcessor$needs_reordering()}}{
+  Whether the plot data must be reordered before drawing; a Base R layer is read
+from the recorded call and never is
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRAssocplotLayerProcessor$needs_reordering()}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    FALSE
   }
 }
 

--- a/man/BaseRBarplotLayerProcessor.Rd
+++ b/man/BaseRBarplotLayerProcessor.Rd
@@ -53,6 +53,8 @@ Processes Base R bar plot layers based on recorded plot calls
 \if{html}{\out{<a id="method-BaseRBarplotLayerProcessor-process"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRBarplotLayerProcessor-process}{}}}
 \subsection{\code{BaseRBarplotLayerProcessor$process()}}{
+  Process the layer: read its data, selectors, axis titles and main title from
+the recorded call
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRBarplotLayerProcessor$process(
@@ -70,14 +72,19 @@ Processes Base R bar plot layers based on recorded plot calls
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{plot}}{The ggplot2 object}
-      \item{\code{layout}}{Layout information}
-      \item{\code{built}}{Built plot data (optional)}
-      \item{\code{gt}}{Gtable object (optional)}
-      \item{\code{grob_id}}{Grob ID for faceted plots (optional)}
-      \item{\code{panel_ctx}}{Panel context for panel-scoped selector generation (optional)}
+      \item{\code{plot}}{Unused; present for the processor interface}
+      \item{\code{layout}}{Unused; present for the processor interface}
+      \item{\code{built}}{Unused; present for the processor interface}
+      \item{\code{gt}}{Gtable of the replayed drawing, searched for selectors (optional)}
+      \item{\code{grob_id}}{Unused; present for the processor interface}
+      \item{\code{panel_id}}{Unused; present for the processor interface}
+      \item{\code{panel_ctx}}{Unused; present for the processor interface}
+      \item{\code{layer_info}}{Layer information with the recorded call}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List describing the layer for the MAIDR payload
   }
 }
 
@@ -107,10 +114,15 @@ Processes Base R bar plot layers based on recorded plot calls
 \if{html}{\out{<a id="method-BaseRBarplotLayerProcessor-needs_reordering"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRBarplotLayerProcessor-needs_reordering}{}}}
 \subsection{\code{BaseRBarplotLayerProcessor$needs_reordering()}}{
+  Whether the plot data must be reordered before drawing; a Base R layer is read
+from the recorded call and never is
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRBarplotLayerProcessor$needs_reordering()}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    FALSE
   }
 }
 
@@ -118,10 +130,21 @@ Processes Base R bar plot layers based on recorded plot calls
 \if{html}{\out{<a id="method-BaseRBarplotLayerProcessor-extract_data"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRBarplotLayerProcessor-extract_data}{}}}
 \subsection{\code{BaseRBarplotLayerProcessor$extract_data()}}{
+  One point per bar, read from the recorded \code{height}
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRBarplotLayerProcessor$extract_data(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of points
   }
 }
 
@@ -129,10 +152,27 @@ Processes Base R bar plot layers based on recorded plot calls
 \if{html}{\out{<a id="method-BaseRBarplotLayerProcessor-extract_axis_titles"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRBarplotLayerProcessor-extract_axis_titles}{}}}
 \subsection{\code{BaseRBarplotLayerProcessor$extract_axis_titles()}}{
+  Extract the axis titles for this layer
+
+\code{barplot()} writes no title of its own, so an author who wrote none
+leaves both axes nameless. A bar chart always plots categories against
+their measured heights, whether or not the heights arrived named, so
+that is what the defaults say. \code{horiz = TRUE} puts the heights on the
+visual x axis -- the same swap extract_data() applies to the points.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRBarplotLayerProcessor$extract_axis_titles(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Canonical axes list
   }
 }
 
@@ -140,10 +180,21 @@ Processes Base R bar plot layers based on recorded plot calls
 \if{html}{\out{<a id="method-BaseRBarplotLayerProcessor-extract_main_title"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRBarplotLayerProcessor-extract_main_title}{}}}
 \subsection{\code{BaseRBarplotLayerProcessor$extract_main_title()}}{
+  The main title of the recorded call, or an empty string
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRBarplotLayerProcessor$extract_main_title(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Character string
   }
 }
 
@@ -151,6 +202,7 @@ Processes Base R bar plot layers based on recorded plot calls
 \if{html}{\out{<a id="method-BaseRBarplotLayerProcessor-generate_selectors"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRBarplotLayerProcessor-generate_selectors}{}}}
 \subsection{\code{BaseRBarplotLayerProcessor$generate_selectors()}}{
+  Generate the CSS selectors that address this layer's drawn elements
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRBarplotLayerProcessor$generate_selectors(layer_info, gt = NULL)}
@@ -159,9 +211,13 @@ Processes Base R bar plot layers based on recorded plot calls
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{gt}}{Gtable object (optional)}
+      \item{\code{layer_info}}{Layer information with the recorded call}
+      \item{\code{gt}}{Gtable of the replayed drawing (optional)}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of selectors
   }
 }
 

--- a/man/BaseRBoxplotLayerProcessor.Rd
+++ b/man/BaseRBoxplotLayerProcessor.Rd
@@ -54,6 +54,8 @@ and generating selectors for boxplot components.
 \if{html}{\out{<a id="method-BaseRBoxplotLayerProcessor-process"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRBoxplotLayerProcessor-process}{}}}
 \subsection{\code{BaseRBoxplotLayerProcessor$process()}}{
+  Process the layer: read its data, selectors, axis titles and main title from
+the recorded call
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRBoxplotLayerProcessor$process(
@@ -68,12 +70,16 @@ and generating selectors for boxplot components.
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{plot}}{The ggplot2 object}
-      \item{\code{layout}}{Layout information}
-      \item{\code{built}}{Built plot data (optional)}
-      \item{\code{gt}}{Gtable object (optional)}
+      \item{\code{plot}}{Unused; present for the processor interface}
+      \item{\code{layout}}{Unused; present for the processor interface}
+      \item{\code{built}}{Unused; present for the processor interface}
+      \item{\code{gt}}{Gtable of the replayed drawing, searched for selectors (optional)}
+      \item{\code{layer_info}}{Layer information with the recorded call}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List describing the layer for the MAIDR payload
   }
 }
 
@@ -81,10 +87,34 @@ and generating selectors for boxplot components.
 \if{html}{\out{<a id="method-BaseRBoxplotLayerProcessor-read_stats"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRBoxplotLayerProcessor-read_stats}{}}}
 \subsection{\code{BaseRBoxplotLayerProcessor$read_stats()}}{
+  The five-number summaries the drawn boxes came from
+
+A \code{boxplot()} call carries the \emph{observations}, so the summaries have to
+be recomputed from them -- which \code{boxplot(plot = FALSE)} does, using
+the same code path the drawing did, rather than a reimplementation of
+it here. \code{graphics::boxplot} is named directly so the replay does not
+go back through maidr's own wrapper and record a second call.
+
+Overridable because \code{bxp()} is handed the summaries already computed
+and draws exactly the same marks from them: everything below this
+method -- the outlier grouping, the polygon and segment indices, the
+shift each box with no outliers puts on the ones after it -- is the
+same reading either way, and only where the summaries come from
+differs (#262).
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRBoxplotLayerProcessor$read_stats(args)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{args}}{Recorded argument list}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    The \code{boxplot.stats}-shaped list, or NULL when it cannot be had
   }
 }
 
@@ -92,10 +122,21 @@ and generating selectors for boxplot components.
 \if{html}{\out{<a id="method-BaseRBoxplotLayerProcessor-extract_data"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRBoxplotLayerProcessor-extract_data}{}}}
 \subsection{\code{BaseRBoxplotLayerProcessor$extract_data()}}{
+  One five-number summary per group, recomputed from the recorded observations
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRBoxplotLayerProcessor$extract_data(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of box summaries
   }
 }
 
@@ -103,6 +144,7 @@ and generating selectors for boxplot components.
 \if{html}{\out{<a id="method-BaseRBoxplotLayerProcessor-generate_selectors"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRBoxplotLayerProcessor-generate_selectors}{}}}
 \subsection{\code{BaseRBoxplotLayerProcessor$generate_selectors()}}{
+  Selectors for each box's polygon, whiskers, median and outliers
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRBoxplotLayerProcessor$generate_selectors(
@@ -115,9 +157,14 @@ and generating selectors for boxplot components.
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{gt}}{Gtable object (optional)}
+      \item{\code{layer_info}}{Layer information with the recorded call}
+      \item{\code{gt}}{Gtable of the replayed drawing (optional)}
+      \item{\code{extracted_data}}{The data already extracted for this layer (optional)}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of selectors
   }
 }
 
@@ -125,10 +172,29 @@ and generating selectors for boxplot components.
 \if{html}{\out{<a id="method-BaseRBoxplotLayerProcessor-extract_axis_titles"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRBoxplotLayerProcessor-extract_axis_titles}{}}}
 \subsection{\code{BaseRBoxplotLayerProcessor$extract_axis_titles()}}{
+  Extract the axis titles for this layer
+
+\code{boxplot()} records no title unless the author wrote one, but the
+formula method derives both from the formula itself and draws them, so
+a \code{y ~ g} call already names its axes: the response on the value axis
+and the grouping terms on the category axis. Everything else falls back
+to what a box plot always shows -- groups against their distributions.
+\code{horizontal = TRUE} swaps which visual axis is which, exactly as
+boxplot.formula()'s own defaults do.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRBoxplotLayerProcessor$extract_axis_titles(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Canonical axes list
   }
 }
 
@@ -136,10 +202,29 @@ and generating selectors for boxplot components.
 \if{html}{\out{<a id="method-BaseRBoxplotLayerProcessor-extract_formula_labels"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRBoxplotLayerProcessor-extract_formula_labels}{}}}
 \subsection{\code{BaseRBoxplotLayerProcessor$extract_formula_labels()}}{
+  Read the axis titles boxplot.formula() derives from its formula
+
+\code{boxplot.formula()} builds them out of the model frame's column names:
+the response column names the value axis and the remaining columns,
+joined with " : ", name the category axis. Building the same model
+frame reproduces the drawn titles for expressions (\code{log(mpg) ~ cyl})
+and for \code{.} alike, where deparsing the formula's terms would not.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRBoxplotLayerProcessor$extract_formula_labels(args, frame = NULL)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{args}}{Recorded argument list}
+      \item{\code{frame}}{The model frame kept by the recording (optional)}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List with \code{response} and \code{groups}, or NULL when this call is
+not the formula method or the model frame cannot be rebuilt
   }
 }
 
@@ -147,10 +232,21 @@ and generating selectors for boxplot components.
 \if{html}{\out{<a id="method-BaseRBoxplotLayerProcessor-extract_main_title"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRBoxplotLayerProcessor-extract_main_title}{}}}
 \subsection{\code{BaseRBoxplotLayerProcessor$extract_main_title()}}{
+  The main title of the recorded call, or an empty string
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRBoxplotLayerProcessor$extract_main_title(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Character string
   }
 }
 
@@ -158,10 +254,21 @@ and generating selectors for boxplot components.
 \if{html}{\out{<a id="method-BaseRBoxplotLayerProcessor-determine_orientation"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRBoxplotLayerProcessor-determine_orientation}{}}}
 \subsection{\code{BaseRBoxplotLayerProcessor$determine_orientation()}}{
+  Which way the boxes were drawn, from the recorded \code{horizontal} flag
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRBoxplotLayerProcessor$determine_orientation(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    "horz" or "vert"
   }
 }
 

--- a/man/BaseRBxpLayerProcessor.Rd
+++ b/man/BaseRBxpLayerProcessor.Rd
@@ -84,10 +84,36 @@ for \code{boxplot()}.
 \if{html}{\out{<a id="method-BaseRBxpLayerProcessor-read_stats"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRBxpLayerProcessor-read_stats}{}}}
 \subsection{\code{BaseRBxpLayerProcessor$read_stats()}}{
+  The summaries \code{bxp()} was handed
+
+\code{bxp()}'s first formal is \code{z}, and it draws nothing without a numeric
+\code{z$stats} with five rows -- so a recorded call that reached this
+package has one. It is still checked rather than assumed: a shape that
+does not answer leaves the layer empty and the figure falls back to the
+picture it already was, where reaching past it would raise out of
+\code{process()} with nothing to catch it.
+
+The positional half looks for the first \emph{unnamed} argument rather than
+for slot 1. \code{match_recorded_args()} keeps the author's order and leaves
+only the dispatch argument unnamed, wherever it was written, so
+\code{bxp(horizontal = TRUE, z)} records \code{z} in slot 2 -- a call R itself
+accepts and draws. Reading slot 1 there hands \code{TRUE} to the check below
+and leaves the layer empty. \code{resolve_xy_args()} resolves a positional
+argument the same way, for the same reason. Raised in review of #265.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRBxpLayerProcessor$read_stats(args)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{args}}{Recorded argument list}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    The \code{boxplot.stats}-shaped list, or NULL when it is not one
   }
 }
 

--- a/man/BaseRCandlestickLayerProcessor.Rd
+++ b/man/BaseRCandlestickLayerProcessor.Rd
@@ -118,6 +118,9 @@ wicks via \code{segments()} calls (one SVG \verb{<polyline>} per wick under
     }
     \if{html}{\out{</div>}}
   }
+  \subsection{Returns}{
+    Logical
+  }
 }
 
 \if{html}{\out{<hr>}}
@@ -169,6 +172,9 @@ bar layer contract used by the Base R barplot processor.
       \item{\code{n_bars}}{Number of volume bars}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of selectors, one per volume bar
   }
 }
 
@@ -310,6 +316,9 @@ grobs cannot be located.
     }
     \if{html}{\out{</div>}}
   }
+  \subsection{Returns}{
+    Character vector
+  }
 }
 
 \if{html}{\out{<hr>}}
@@ -329,6 +338,9 @@ grobs cannot be located.
     }
     \if{html}{\out{</div>}}
   }
+  \subsection{Returns}{
+    Character vector of grob names
+  }
 }
 
 \if{html}{\out{<hr>}}
@@ -347,6 +359,9 @@ grobs cannot be located.
       \item{\code{ids}}{Grob ids}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    The ids in numeric order of their suffix
   }
 }
 
@@ -368,6 +383,9 @@ grobs cannot be located.
     }
     \if{html}{\out{</div>}}
   }
+  \subsection{Returns}{
+    The grob, or NULL when no name matches
+  }
 }
 
 \if{html}{\out{<hr>}}
@@ -386,6 +404,9 @@ grobs cannot be located.
       \item{\code{g}}{A grob}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Integer
   }
 }
 

--- a/man/BaseRCandlestickLayerProcessor.Rd
+++ b/man/BaseRCandlestickLayerProcessor.Rd
@@ -72,6 +72,8 @@ wicks via \code{segments()} calls (one SVG \verb{<polyline>} per wick under
 \if{html}{\out{<a id="method-BaseRCandlestickLayerProcessor-process"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRCandlestickLayerProcessor-process}{}}}
 \subsection{\code{BaseRCandlestickLayerProcessor$process()}}{
+  Process the layer: the candlestick layer, plus a volume bar layer when
+\code{addVo()} was requested
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRCandlestickLayerProcessor$process(
@@ -86,12 +88,16 @@ wicks via \code{segments()} calls (one SVG \verb{<polyline>} per wick under
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{plot}}{The ggplot2 object}
-      \item{\code{layout}}{Layout information}
-      \item{\code{built}}{Built plot data (optional)}
-      \item{\code{gt}}{Gtable object (optional)}
+      \item{\code{plot}}{Unused; present for the processor interface}
+      \item{\code{layout}}{Unused; present for the processor interface}
+      \item{\code{built}}{Unused; present for the processor interface}
+      \item{\code{gt}}{Gtable of the replayed drawing, searched for selectors (optional)}
+      \item{\code{layer_info}}{Layer information with the recorded call}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A candlestick layer, or a multi-layer list with the volume bars
   }
 }
 
@@ -105,6 +111,13 @@ wicks via \code{segments()} calls (one SVG \verb{<polyline>} per wick under
     \preformatted{BaseRCandlestickLayerProcessor$has_add_vo(layer_info)}
     \if{html}{\out{</div>}}
   }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
 \if{html}{\out{<hr>}}
@@ -115,6 +128,15 @@ wicks via \code{segments()} calls (one SVG \verb{<polyline>} per wick under
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRCandlestickLayerProcessor$build_volume_layer(layer_info, gt, candle_data)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+      \item{\code{gt}}{Gtable of the replayed drawing (optional)}
+      \item{\code{candle_data}}{The candlestick data already extracted}
+    }
     \if{html}{\out{</div>}}
   }
 }
@@ -137,6 +159,15 @@ bar layer contract used by the Base R barplot processor.
   gt,
   n_bars
 )}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+      \item{\code{gt}}{Gtable of the replayed drawing (optional)}
+      \item{\code{n_bars}}{Number of volume bars}
+    }
     \if{html}{\out{</div>}}
   }
 }
@@ -222,10 +253,21 @@ grobs cannot be located.
 \if{html}{\out{<a id="method-BaseRCandlestickLayerProcessor-extract_axis_titles"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRCandlestickLayerProcessor-extract_axis_titles}{}}}
 \subsection{\code{BaseRCandlestickLayerProcessor$extract_axis_titles()}}{
+  The axis titles, defaulting to Date and Price
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRCandlestickLayerProcessor$extract_axis_titles(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Canonical axes list
   }
 }
 
@@ -233,10 +275,21 @@ grobs cannot be located.
 \if{html}{\out{<a id="method-BaseRCandlestickLayerProcessor-extract_main_title"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRCandlestickLayerProcessor-extract_main_title}{}}}
 \subsection{\code{BaseRCandlestickLayerProcessor$extract_main_title()}}{
+  The main title of the recorded call, or an empty string
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRCandlestickLayerProcessor$extract_main_title(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Character string
   }
 }
 
@@ -248,6 +301,13 @@ grobs cannot be located.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRCandlestickLayerProcessor$format_x_values(idx)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{idx}}{Integer x-axis positions}
+    }
     \if{html}{\out{</div>}}
   }
 }
@@ -262,6 +322,13 @@ grobs cannot be located.
     \preformatted{BaseRCandlestickLayerProcessor$collect_grob_names(g)}
     \if{html}{\out{</div>}}
   }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{g}}{A grob}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
 \if{html}{\out{<hr>}}
@@ -272,6 +339,13 @@ grobs cannot be located.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRCandlestickLayerProcessor$sort_ids(ids)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{ids}}{Grob ids}
+    }
     \if{html}{\out{</div>}}
   }
 }
@@ -286,6 +360,14 @@ grobs cannot be located.
     \preformatted{BaseRCandlestickLayerProcessor$find_grob_by_name(g, id)}
     \if{html}{\out{</div>}}
   }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{g}}{A grob}
+      \item{\code{id}}{The grob name to find}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
 \if{html}{\out{<hr>}}
@@ -298,6 +380,13 @@ grobs cannot be located.
     \preformatted{BaseRCandlestickLayerProcessor$grob_coord_count(g)}
     \if{html}{\out{</div>}}
   }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{g}}{A grob}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
 \if{html}{\out{<hr>}}
@@ -308,6 +397,14 @@ grobs cannot be located.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRCandlestickLayerProcessor$pick_largest_child_group(gt, ids)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{gt}}{Gtable of the replayed drawing (optional)}
+      \item{\code{ids}}{Grob ids}
+    }
     \if{html}{\out{</div>}}
   }
 }

--- a/man/BaseRDodgedBarLayerProcessor.Rd
+++ b/man/BaseRDodgedBarLayerProcessor.Rd
@@ -52,6 +52,8 @@ Processes Base R dodged bar plot layers with proper ordering to match backend lo
 \if{html}{\out{<a id="method-BaseRDodgedBarLayerProcessor-process"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRDodgedBarLayerProcessor-process}{}}}
 \subsection{\code{BaseRDodgedBarLayerProcessor$process()}}{
+  Process the layer: read its data, selectors, axis titles and main title from
+the recorded call
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRDodgedBarLayerProcessor$process(
@@ -66,12 +68,16 @@ Processes Base R dodged bar plot layers with proper ordering to match backend lo
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{plot}}{The ggplot2 object}
-      \item{\code{layout}}{Layout information}
-      \item{\code{built}}{Built plot data (optional)}
-      \item{\code{gt}}{Gtable object (optional)}
+      \item{\code{plot}}{Unused; present for the processor interface}
+      \item{\code{layout}}{Unused; present for the processor interface}
+      \item{\code{built}}{Unused; present for the processor interface}
+      \item{\code{gt}}{Gtable of the replayed drawing, searched for selectors (optional)}
+      \item{\code{layer_info}}{Layer information with the recorded call}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List describing the layer for the MAIDR payload
   }
 }
 
@@ -79,10 +85,21 @@ Processes Base R dodged bar plot layers with proper ordering to match backend lo
 \if{html}{\out{<a id="method-BaseRDodgedBarLayerProcessor-extract_data"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRDodgedBarLayerProcessor-extract_data}{}}}
 \subsection{\code{BaseRDodgedBarLayerProcessor$extract_data()}}{
+  One series per row of the recorded height matrix
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRDodgedBarLayerProcessor$extract_data(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of series
   }
 }
 
@@ -90,6 +107,7 @@ Processes Base R dodged bar plot layers with proper ordering to match backend lo
 \if{html}{\out{<a id="method-BaseRDodgedBarLayerProcessor-generate_selectors"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRDodgedBarLayerProcessor-generate_selectors}{}}}
 \subsection{\code{BaseRDodgedBarLayerProcessor$generate_selectors()}}{
+  The selector for the bars, scoped to this layer's plot group
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRDodgedBarLayerProcessor$generate_selectors(layer_info, gt = NULL)}
@@ -98,9 +116,13 @@ Processes Base R dodged bar plot layers with proper ordering to match backend lo
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{gt}}{Gtable object (optional)}
+      \item{\code{layer_info}}{Layer information with the recorded call}
+      \item{\code{gt}}{Gtable of the replayed drawing (optional)}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of selectors
   }
 }
 
@@ -108,10 +130,22 @@ Processes Base R dodged bar plot layers with proper ordering to match backend lo
 \if{html}{\out{<a id="method-BaseRDodgedBarLayerProcessor-find_rect_grobs"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRDodgedBarLayerProcessor-find_rect_grobs}{}}}
 \subsection{\code{BaseRDodgedBarLayerProcessor$find_rect_grobs()}}{
+  Find the rect grobs drawn by the recorded call at \code{call_index}
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRDodgedBarLayerProcessor$find_rect_grobs(grob, call_index)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{grob}}{The grob tree to search}
+      \item{\code{call_index}}{Index of the recorded plot group, which numbers the panel's grobs}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Character vector of grob names
   }
 }
 
@@ -119,10 +153,22 @@ Processes Base R dodged bar plot layers with proper ordering to match backend lo
 \if{html}{\out{<a id="method-BaseRDodgedBarLayerProcessor-generate_selectors_from_grob"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRDodgedBarLayerProcessor-generate_selectors_from_grob}{}}}
 \subsection{\code{BaseRDodgedBarLayerProcessor$generate_selectors_from_grob()}}{
+  Build this layer's selector from the grob tree
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRDodgedBarLayerProcessor$generate_selectors_from_grob(grob, call_index)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{grob}}{The grob tree to search}
+      \item{\code{call_index}}{Index of the recorded plot group, which numbers the panel's grobs}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A selector string, or an empty string when no grob matches
   }
 }
 
@@ -130,10 +176,26 @@ Processes Base R dodged bar plot layers with proper ordering to match backend lo
 \if{html}{\out{<a id="method-BaseRDodgedBarLayerProcessor-extract_axis_titles"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRDodgedBarLayerProcessor-extract_axis_titles}{}}}
 \subsection{\code{BaseRDodgedBarLayerProcessor$extract_axis_titles()}}{
+  Extract the axis titles for this layer
+
+Same shape as the stacked processor: \code{barplot(beside = TRUE)} writes no
+title, its points carry the column category on x and the bar height on
+y, and the group each bar belongs to travels with the point as z rather
+than as a named axis.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRDodgedBarLayerProcessor$extract_axis_titles(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Canonical axes list
   }
 }
 
@@ -141,10 +203,21 @@ Processes Base R dodged bar plot layers with proper ordering to match backend lo
 \if{html}{\out{<a id="method-BaseRDodgedBarLayerProcessor-extract_main_title"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRDodgedBarLayerProcessor-extract_main_title}{}}}
 \subsection{\code{BaseRDodgedBarLayerProcessor$extract_main_title()}}{
+  The main title of the recorded call, or an empty string
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRDodgedBarLayerProcessor$extract_main_title(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Character string
   }
 }
 

--- a/man/BaseRHeatmapLayerProcessor.Rd
+++ b/man/BaseRHeatmapLayerProcessor.Rd
@@ -53,6 +53,8 @@ Processes Base R heatmap layers using the heatmap() function
 \if{html}{\out{<a id="method-BaseRHeatmapLayerProcessor-process"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRHeatmapLayerProcessor-process}{}}}
 \subsection{\code{BaseRHeatmapLayerProcessor$process()}}{
+  Process the layer: read its data, selectors, axis titles and main title from
+the recorded call
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRHeatmapLayerProcessor$process(
@@ -70,14 +72,19 @@ Processes Base R heatmap layers using the heatmap() function
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{plot}}{The ggplot2 object}
-      \item{\code{layout}}{Layout information}
-      \item{\code{built}}{Built plot data (optional)}
-      \item{\code{gt}}{Gtable object (optional)}
-      \item{\code{grob_id}}{Grob ID for faceted plots (optional)}
-      \item{\code{panel_ctx}}{Panel context for panel-scoped selector generation (optional)}
+      \item{\code{plot}}{Unused; present for the processor interface}
+      \item{\code{layout}}{Unused; present for the processor interface}
+      \item{\code{built}}{Unused; present for the processor interface}
+      \item{\code{gt}}{Gtable of the replayed drawing, searched for selectors (optional)}
+      \item{\code{grob_id}}{Unused; present for the processor interface}
+      \item{\code{panel_id}}{Unused; present for the processor interface}
+      \item{\code{panel_ctx}}{Unused; present for the processor interface}
+      \item{\code{layer_info}}{Layer information with the recorded call}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List describing the layer for the MAIDR payload
   }
 }
 
@@ -85,10 +92,21 @@ Processes Base R heatmap layers using the heatmap() function
 \if{html}{\out{<a id="method-BaseRHeatmapLayerProcessor-extract_data"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRHeatmapLayerProcessor-extract_data}{}}}
 \subsection{\code{BaseRHeatmapLayerProcessor$extract_data()}}{
+  One row per cell of the recorded matrix, in drawn order
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRHeatmapLayerProcessor$extract_data(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of rows
   }
 }
 
@@ -118,6 +136,7 @@ Processes Base R heatmap layers using the heatmap() function
 \if{html}{\out{<a id="method-BaseRHeatmapLayerProcessor-generate_selectors"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRHeatmapLayerProcessor-generate_selectors}{}}}
 \subsection{\code{BaseRHeatmapLayerProcessor$generate_selectors()}}{
+  Selectors for the image tiles, one per cell
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRHeatmapLayerProcessor$generate_selectors(
@@ -130,9 +149,14 @@ Processes Base R heatmap layers using the heatmap() function
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{gt}}{Gtable object (optional)}
+      \item{\code{layer_info}}{Layer information with the recorded call}
+      \item{\code{gt}}{Gtable of the replayed drawing (optional)}
+      \item{\code{extracted_data}}{The data already extracted for this layer (optional)}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of selectors
   }
 }
 
@@ -140,10 +164,22 @@ Processes Base R heatmap layers using the heatmap() function
 \if{html}{\out{<a id="method-BaseRHeatmapLayerProcessor-find_image_rect_grobs"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRHeatmapLayerProcessor-find_image_rect_grobs}{}}}
 \subsection{\code{BaseRHeatmapLayerProcessor$find_image_rect_grobs()}}{
+  Find the image-rect grobs drawn by the plot group at \code{group_index}
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRHeatmapLayerProcessor$find_image_rect_grobs(grob, group_index)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{grob}}{The grob tree to search}
+      \item{\code{group_index}}{Index of the recorded plot group, which numbers the panel's grobs}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Character vector of grob names
   }
 }
 
@@ -151,6 +187,7 @@ Processes Base R heatmap layers using the heatmap() function
 \if{html}{\out{<a id="method-BaseRHeatmapLayerProcessor-generate_selectors_from_grob"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRHeatmapLayerProcessor-generate_selectors_from_grob}{}}}
 \subsection{\code{BaseRHeatmapLayerProcessor$generate_selectors_from_grob()}}{
+  Build this layer's selector from the grob tree
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRHeatmapLayerProcessor$generate_selectors_from_grob(
@@ -159,16 +196,44 @@ Processes Base R heatmap layers using the heatmap() function
 )}
     \if{html}{\out{</div>}}
   }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{grob}}{The grob tree to search}
+      \item{\code{group_index}}{Index of the recorded plot group, which numbers the panel's grobs}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A selector string, or an empty string when no grob matches
+  }
 }
 
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-BaseRHeatmapLayerProcessor-extract_axis_titles"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRHeatmapLayerProcessor-extract_axis_titles}{}}}
 \subsection{\code{BaseRHeatmapLayerProcessor$extract_axis_titles()}}{
+  Extract the axis titles for this layer
+
+\code{heatmap()} lays the matrix out one way round only -- its columns run
+along x and its rows up y -- so those two words are facts about the
+call. \code{image()} is not the same picture: it draws a coordinate grid,
+and \code{image(x, y, z)} puts the caller's own coordinates on those axes,
+so naming them after a matrix would be a guess. It gets no default.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRHeatmapLayerProcessor$extract_axis_titles(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Canonical axes list
   }
 }
 
@@ -176,10 +241,21 @@ Processes Base R heatmap layers using the heatmap() function
 \if{html}{\out{<a id="method-BaseRHeatmapLayerProcessor-extract_main_title"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRHeatmapLayerProcessor-extract_main_title}{}}}
 \subsection{\code{BaseRHeatmapLayerProcessor$extract_main_title()}}{
+  The main title of the recorded call, or an empty string
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRHeatmapLayerProcessor$extract_main_title(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Character string
   }
 }
 

--- a/man/BaseRHistogramLayerProcessor.Rd
+++ b/man/BaseRHistogramLayerProcessor.Rd
@@ -56,6 +56,8 @@ and selector generation logic.
 \if{html}{\out{<a id="method-BaseRHistogramLayerProcessor-process"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRHistogramLayerProcessor-process}{}}}
 \subsection{\code{BaseRHistogramLayerProcessor$process()}}{
+  Process the layer: read its data, selectors, axis titles and main title from
+the recorded call
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRHistogramLayerProcessor$process(
@@ -70,12 +72,16 @@ and selector generation logic.
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{plot}}{The ggplot2 object}
-      \item{\code{layout}}{Layout information}
-      \item{\code{built}}{Built plot data (optional)}
-      \item{\code{gt}}{Gtable object (optional)}
+      \item{\code{plot}}{Unused; present for the processor interface}
+      \item{\code{layout}}{Unused; present for the processor interface}
+      \item{\code{built}}{Unused; present for the processor interface}
+      \item{\code{gt}}{Gtable of the replayed drawing, searched for selectors (optional)}
+      \item{\code{layer_info}}{Layer information with the recorded call}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List describing the layer for the MAIDR payload
   }
 }
 
@@ -83,10 +89,21 @@ and selector generation logic.
 \if{html}{\out{<a id="method-BaseRHistogramLayerProcessor-extract_data"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRHistogramLayerProcessor-extract_data}{}}}
 \subsection{\code{BaseRHistogramLayerProcessor$extract_data()}}{
+  One point per bin, from the histogram recomputed from the recorded call
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRHistogramLayerProcessor$extract_data(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of points
   }
 }
 
@@ -94,10 +111,21 @@ and selector generation logic.
 \if{html}{\out{<a id="method-BaseRHistogramLayerProcessor-recompute_histogram"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRHistogramLayerProcessor-recompute_histogram}{}}}
 \subsection{\code{BaseRHistogramLayerProcessor$recompute_histogram()}}{
+  Recompute the plotted histogram from the recorded call
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRHistogramLayerProcessor$recompute_histogram(args)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{args}}{Recorded argument list}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A "histogram" object, or NULL when the call recorded no data
   }
 }
 
@@ -105,10 +133,26 @@ and selector generation logic.
 \if{html}{\out{<a id="method-BaseRHistogramLayerProcessor-is_frequency"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRHistogramLayerProcessor-is_frequency}{}}}
 \subsection{\code{BaseRHistogramLayerProcessor$is_frequency()}}{
+  Is this a frequency histogram rather than a density one?
+
+The plotted y-axis shows counts only for frequency histograms; with
+freq = FALSE or probability = TRUE it shows densities. hist()'s own
+default is freq = TRUE only for equidistant breaks.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRHistogramLayerProcessor$is_frequency(args, hist_obj = NULL)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{args}}{Recorded argument list}
+      \item{\code{hist_obj}}{The recomputed histogram, or NULL when there is none}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Logical
   }
 }
 
@@ -116,6 +160,7 @@ and selector generation logic.
 \if{html}{\out{<a id="method-BaseRHistogramLayerProcessor-generate_selectors"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRHistogramLayerProcessor-generate_selectors}{}}}
 \subsection{\code{BaseRHistogramLayerProcessor$generate_selectors()}}{
+  The selector for the bins, scoped to this layer's plot group
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRHistogramLayerProcessor$generate_selectors(layer_info, gt = NULL)}
@@ -124,9 +169,13 @@ and selector generation logic.
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{gt}}{Gtable object (optional)}
+      \item{\code{layer_info}}{Layer information with the recorded call}
+      \item{\code{gt}}{Gtable of the replayed drawing (optional)}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of selectors
   }
 }
 
@@ -134,10 +183,22 @@ and selector generation logic.
 \if{html}{\out{<a id="method-BaseRHistogramLayerProcessor-find_rect_grobs"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRHistogramLayerProcessor-find_rect_grobs}{}}}
 \subsection{\code{BaseRHistogramLayerProcessor$find_rect_grobs()}}{
+  Find the rect grobs drawn by the recorded call at \code{call_index}
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRHistogramLayerProcessor$find_rect_grobs(grob, call_index)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{grob}}{The grob tree to search}
+      \item{\code{call_index}}{Index of the recorded plot group, which numbers the panel's grobs}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Character vector of grob names
   }
 }
 
@@ -145,6 +206,7 @@ and selector generation logic.
 \if{html}{\out{<a id="method-BaseRHistogramLayerProcessor-generate_selectors_from_grob"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRHistogramLayerProcessor-generate_selectors_from_grob}{}}}
 \subsection{\code{BaseRHistogramLayerProcessor$generate_selectors_from_grob()}}{
+  Build this layer's selector from the grob tree
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRHistogramLayerProcessor$generate_selectors_from_grob(
@@ -153,16 +215,47 @@ and selector generation logic.
 )}
     \if{html}{\out{</div>}}
   }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{grob}}{The grob tree to search}
+      \item{\code{call_index}}{Index of the recorded plot group, which numbers the panel's grobs}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A selector string, or an empty string when no grob matches
+  }
 }
 
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-BaseRHistogramLayerProcessor-extract_axis_titles"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRHistogramLayerProcessor-extract_axis_titles}{}}}
 \subsection{\code{BaseRHistogramLayerProcessor$extract_axis_titles()}}{
+  Extract the axis titles for this layer
+
+\code{hist()} derives both titles inside the call and so records neither:
+the x title is \code{deparse(substitute(x))}, which is gone by the time the
+evaluated arguments reach us, and the y title is "Frequency" or
+"Density" depending on what the bars measure. The y default therefore
+repeats hist()'s own choice -- resolved by the same rule that decides
+which values extract_data() emits, so the noun always names the number
+being announced -- while x says only what the axis certainly holds:
+the bins.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRHistogramLayerProcessor$extract_axis_titles(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Canonical axes list
   }
 }
 
@@ -170,10 +263,21 @@ and selector generation logic.
 \if{html}{\out{<a id="method-BaseRHistogramLayerProcessor-frequency_label"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRHistogramLayerProcessor-frequency_label}{}}}
 \subsection{\code{BaseRHistogramLayerProcessor$frequency_label()}}{
+  The title hist() itself would print above the counted axis
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRHistogramLayerProcessor$frequency_label(args)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{args}}{Recorded argument list}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    "Frequency" or "Density"
   }
 }
 
@@ -181,10 +285,21 @@ and selector generation logic.
 \if{html}{\out{<a id="method-BaseRHistogramLayerProcessor-extract_main_title"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRHistogramLayerProcessor-extract_main_title}{}}}
 \subsection{\code{BaseRHistogramLayerProcessor$extract_main_title()}}{
+  The main title of the recorded call, or an empty string
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRHistogramLayerProcessor$extract_main_title(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Character string
   }
 }
 

--- a/man/BaseRInteractionLayerProcessor.Rd
+++ b/man/BaseRInteractionLayerProcessor.Rd
@@ -84,10 +84,21 @@ would lose the trace grouping that makes it an interaction plot.
 \if{html}{\out{<a id="method-BaseRInteractionLayerProcessor-extract_data"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRInteractionLayerProcessor-extract_data}{}}}
 \subsection{\code{BaseRInteractionLayerProcessor$extract_data()}}{
+  One series per trace level, read from the grid of cell means
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRInteractionLayerProcessor$extract_data(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of series
   }
 }
 

--- a/man/BaseRLineLayerProcessor.Rd
+++ b/man/BaseRLineLayerProcessor.Rd
@@ -314,6 +314,9 @@ what \code{abline()} draws its clipped line across.
     }
     \if{html}{\out{</div>}}
   }
+  \subsection{Returns}{
+    Numeric vector of two, or NULL when nothing finite was plotted
+  }
 }
 
 \if{html}{\out{<hr>}}
@@ -408,6 +411,9 @@ BaseRStepLayerProcessor).
       \item{\code{layer_info}}{Layer information with the recorded call}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    "abline" or "lines"
   }
 }
 

--- a/man/BaseRLineLayerProcessor.Rd
+++ b/man/BaseRLineLayerProcessor.Rd
@@ -60,6 +60,8 @@ Processes Base R line plot layers based on recorded plot calls
 \if{html}{\out{<a id="method-BaseRLineLayerProcessor-process"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRLineLayerProcessor-process}{}}}
 \subsection{\code{BaseRLineLayerProcessor$process()}}{
+  Process the layer: read its data, selectors, axis titles and main title from
+the recorded call
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRLineLayerProcessor$process(
@@ -77,14 +79,19 @@ Processes Base R line plot layers based on recorded plot calls
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{plot}}{The ggplot2 object}
-      \item{\code{layout}}{Layout information}
-      \item{\code{built}}{Built plot data (optional)}
-      \item{\code{gt}}{Gtable object (optional)}
-      \item{\code{grob_id}}{Grob ID for faceted plots (optional)}
-      \item{\code{panel_ctx}}{Panel context for panel-scoped selector generation (optional)}
+      \item{\code{plot}}{Unused; present for the processor interface}
+      \item{\code{layout}}{Unused; present for the processor interface}
+      \item{\code{built}}{Unused; present for the processor interface}
+      \item{\code{gt}}{Gtable of the replayed drawing, searched for selectors (optional)}
+      \item{\code{grob_id}}{Unused; present for the processor interface}
+      \item{\code{panel_id}}{Unused; present for the processor interface}
+      \item{\code{panel_ctx}}{Unused; present for the processor interface}
+      \item{\code{layer_info}}{Layer information with the recorded call}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List describing the layer for the MAIDR payload
   }
 }
 
@@ -92,10 +99,15 @@ Processes Base R line plot layers based on recorded plot calls
 \if{html}{\out{<a id="method-BaseRLineLayerProcessor-needs_reordering"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRLineLayerProcessor-needs_reordering}{}}}
 \subsection{\code{BaseRLineLayerProcessor$needs_reordering()}}{
+  Whether the plot data must be reordered before drawing; a Base R layer is read
+from the recorded call and never is
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRLineLayerProcessor$needs_reordering()}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    FALSE
   }
 }
 
@@ -103,10 +115,22 @@ Processes Base R line plot layers based on recorded plot calls
 \if{html}{\out{<a id="method-BaseRLineLayerProcessor-extract_data"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRLineLayerProcessor-extract_data}{}}}
 \subsection{\code{BaseRLineLayerProcessor$extract_data()}}{
+  One series per line: a vector, each column of a matrix, a time series, or the
+endpoints of \code{abline()}
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRLineLayerProcessor$extract_data(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of series
   }
 }
 
@@ -137,10 +161,23 @@ Processes Base R line plot layers based on recorded plot calls
 \if{html}{\out{<a id="method-BaseRLineLayerProcessor-extract_single_line_data"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRLineLayerProcessor-extract_single_line_data}{}}}
 \subsection{\code{BaseRLineLayerProcessor$extract_single_line_data()}}{
+  The points of one line, pairing each x with its y
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRLineLayerProcessor$extract_single_line_data(x, y, x_labels = NULL)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{x}}{x positions}
+      \item{\code{y}}{y values}
+      \item{\code{x_labels}}{Category labels to announce in place of the x positions (optional)}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List holding one series
   }
 }
 
@@ -148,10 +185,23 @@ Processes Base R line plot layers based on recorded plot calls
 \if{html}{\out{<a id="method-BaseRLineLayerProcessor-extract_multiline_data"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRLineLayerProcessor-extract_multiline_data}{}}}
 \subsection{\code{BaseRLineLayerProcessor$extract_multiline_data()}}{
+  One series per column of \code{y_matrix}, named after the columns
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRLineLayerProcessor$extract_multiline_data(x, y_matrix, x_labels = NULL)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{x}}{x positions}
+      \item{\code{y_matrix}}{One column of y values per series}
+      \item{\code{x_labels}}{Category labels to announce in place of the x positions (optional)}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of series
   }
 }
 
@@ -159,10 +209,22 @@ Processes Base R line plot layers based on recorded plot calls
 \if{html}{\out{<a id="method-BaseRLineLayerProcessor-extract_axis_titles"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRLineLayerProcessor-extract_axis_titles}{}}}
 \subsection{\code{BaseRLineLayerProcessor$extract_axis_titles()}}{
+  The axis titles, taken from the HIGH-level call for an overlay such as
+\code{abline()}
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRLineLayerProcessor$extract_axis_titles(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Canonical axes list
   }
 }
 
@@ -170,10 +232,21 @@ Processes Base R line plot layers based on recorded plot calls
 \if{html}{\out{<a id="method-BaseRLineLayerProcessor-extract_abline_data"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRLineLayerProcessor-extract_abline_data}{}}}
 \subsection{\code{BaseRLineLayerProcessor$extract_abline_data()}}{
+  The endpoints of an \code{abline()} call across the axis the HIGH-level call set up
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRLineLayerProcessor$extract_abline_data(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List holding one two-point series, or empty
   }
 }
 
@@ -181,10 +254,21 @@ Processes Base R line plot layers based on recorded plot calls
 \if{html}{\out{<a id="method-BaseRLineLayerProcessor-get_x_range_from_group"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRLineLayerProcessor-get_x_range_from_group}{}}}
 \subsection{\code{BaseRLineLayerProcessor$get_x_range_from_group()}}{
+  The x extent of the group's HIGH-level call, as the axis was drawn
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRLineLayerProcessor$get_x_range_from_group(group)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{group}}{The recorded plot group holding the HIGH-level call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Numeric vector of two, or NULL
   }
 }
 
@@ -192,10 +276,21 @@ Processes Base R line plot layers based on recorded plot calls
 \if{html}{\out{<a id="method-BaseRLineLayerProcessor-get_y_range_from_group"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRLineLayerProcessor-get_y_range_from_group}{}}}
 \subsection{\code{BaseRLineLayerProcessor$get_y_range_from_group()}}{
+  The y extent of the group's HIGH-level call, as the axis was drawn
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRLineLayerProcessor$get_y_range_from_group(group)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{group}}{The recorded plot group holding the HIGH-level call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Numeric vector of two, or NULL
   }
 }
 
@@ -203,9 +298,20 @@ Processes Base R line plot layers based on recorded plot calls
 \if{html}{\out{<a id="method-BaseRLineLayerProcessor-axis_extent"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRLineLayerProcessor-axis_extent}{}}}
 \subsection{\code{BaseRLineLayerProcessor$axis_extent()}}{
+  The extent of an axis the way \code{plot.default()} sets it: an explicit
+\code{xlim}/\code{ylim}, or the finite data extended by 4 \% each way, which is
+what \code{abline()} draws its clipped line across.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRLineLayerProcessor$axis_extent(limits, data)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{limits}}{An explicit \code{xlim}/\code{ylim}, or NULL}
+      \item{\code{data}}{The plotted values on that axis}
+    }
     \if{html}{\out{</div>}}
   }
 }
@@ -214,10 +320,21 @@ Processes Base R line plot layers based on recorded plot calls
 \if{html}{\out{<a id="method-BaseRLineLayerProcessor-extract_main_title"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRLineLayerProcessor-extract_main_title}{}}}
 \subsection{\code{BaseRLineLayerProcessor$extract_main_title()}}{
+  The main title, taken from the HIGH-level call for \code{abline()}
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRLineLayerProcessor$extract_main_title(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Character string
   }
 }
 
@@ -225,6 +342,7 @@ Processes Base R line plot layers based on recorded plot calls
 \if{html}{\out{<a id="method-BaseRLineLayerProcessor-generate_selectors"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRLineLayerProcessor-generate_selectors}{}}}
 \subsection{\code{BaseRLineLayerProcessor$generate_selectors()}}{
+  One selector per polyline, in series order
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRLineLayerProcessor$generate_selectors(layer_info, gt = NULL)}
@@ -233,9 +351,13 @@ Processes Base R line plot layers based on recorded plot calls
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{gt}}{Gtable object (optional)}
+      \item{\code{layer_info}}{Layer information with the recorded call}
+      \item{\code{gt}}{Gtable of the replayed drawing (optional)}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of selectors
   }
 }
 
@@ -243,6 +365,7 @@ Processes Base R line plot layers based on recorded plot calls
 \if{html}{\out{<a id="method-BaseRLineLayerProcessor-find_lines_grobs"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRLineLayerProcessor-find_lines_grobs}{}}}
 \subsection{\code{BaseRLineLayerProcessor$find_lines_grobs()}}{
+  Find every grob of the given family drawn by the plot group at \code{group_index}
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRLineLayerProcessor$find_lines_grobs(
@@ -252,15 +375,38 @@ Processes Base R line plot layers based on recorded plot calls
 )}
     \if{html}{\out{</div>}}
   }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{grob}}{The grob tree to search}
+      \item{\code{group_index}}{Index of the recorded plot group, which numbers the panel's grobs}
+      \item{\code{grob_type}}{The grob family to match: "lines", "abline", "segments", "spike" or "step"}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Character vector of grob names
+  }
 }
 
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-BaseRLineLayerProcessor-selector_grob_type"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRLineLayerProcessor-selector_grob_type}{}}}
 \subsection{\code{BaseRLineLayerProcessor$selector_grob_type()}}{
+  Which family of grob names this layer's selectors are drawn from:
+"abline", "lines", "segments", "spike" or "step". Overridden by
+subclasses whose geometry lands under a different grob name (see
+BaseRStepLayerProcessor).
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRLineLayerProcessor$selector_grob_type(layer_info)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
     \if{html}{\out{</div>}}
   }
 }
@@ -269,6 +415,7 @@ Processes Base R line plot layers based on recorded plot calls
 \if{html}{\out{<a id="method-BaseRLineLayerProcessor-generate_selectors_from_grob"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRLineLayerProcessor-generate_selectors_from_grob}{}}}
 \subsection{\code{BaseRLineLayerProcessor$generate_selectors_from_grob()}}{
+  One selector per matching polyline, sorted by the grob number
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRLineLayerProcessor$generate_selectors_from_grob(
@@ -277,6 +424,18 @@ Processes Base R line plot layers based on recorded plot calls
   layer_info
 )}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{grob}}{The grob tree to search}
+      \item{\code{group_index}}{Index of the recorded plot group, which numbers the panel's grobs}
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of selectors
   }
 }
 

--- a/man/BaseRMosaicLayerProcessor.Rd
+++ b/man/BaseRMosaicLayerProcessor.Rd
@@ -102,10 +102,15 @@ the counts, the margins they imply, and the level names from \code{dimnames()}.
 \if{html}{\out{<a id="method-BaseRMosaicLayerProcessor-needs_reordering"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRMosaicLayerProcessor-needs_reordering}{}}}
 \subsection{\code{BaseRMosaicLayerProcessor$needs_reordering()}}{
+  Whether the plot data must be reordered before drawing; a Base R layer is read
+from the recorded call and never is
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRMosaicLayerProcessor$needs_reordering()}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    FALSE
   }
 }
 

--- a/man/BaseRPatcher.Rd
+++ b/man/BaseRPatcher.Rd
@@ -20,10 +20,22 @@ Modular system for patching Base R plotting functions with chain of responsibili
 \if{html}{\out{<a id="method-BaseRPatcher-can_patch"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRPatcher-can_patch}{}}}
 \subsection{\code{BaseRPatcher$can_patch()}}{
+  Abstract: whether this patcher applies to the call
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRPatcher$can_patch(function_name, args)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{function_name}}{Name of the plotting function}
+      \item{\code{args}}{Recorded argument list}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Logical
   }
 }
 
@@ -31,10 +43,22 @@ Modular system for patching Base R plotting functions with chain of responsibili
 \if{html}{\out{<a id="method-BaseRPatcher-apply_patch"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRPatcher-apply_patch}{}}}
 \subsection{\code{BaseRPatcher$apply_patch()}}{
+  Abstract: the argument list with this patcher's change applied
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRPatcher$apply_patch(function_name, args)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{function_name}}{Name of the plotting function}
+      \item{\code{args}}{Recorded argument list}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Argument list
   }
 }
 
@@ -42,6 +66,7 @@ Modular system for patching Base R plotting functions with chain of responsibili
 \if{html}{\out{<a id="method-BaseRPatcher-get_name"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRPatcher-get_name}{}}}
 \subsection{\code{BaseRPatcher$get_name()}}{
+  Get the patcher name for debugging
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRPatcher$get_name()}

--- a/man/BaseRPlotOrchestrator.Rd
+++ b/man/BaseRPlotOrchestrator.Rd
@@ -44,9 +44,17 @@ the results into a comprehensive interactive plot.
 \if{html}{\out{<a id="method-BaseRPlotOrchestrator-initialize"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRPlotOrchestrator-initialize}{}}}
 \subsection{\code{BaseRPlotOrchestrator$new()}}{
+  Create an orchestrator for the calls recorded on a device
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRPlotOrchestrator$new(device_id = grDevices::dev.cur())}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{device_id}}{Graphics device ID}
+    }
     \if{html}{\out{</div>}}
   }
 }
@@ -55,6 +63,8 @@ the results into a comprehensive interactive plot.
 \if{html}{\out{<a id="method-BaseRPlotOrchestrator-detect_layers"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRPlotOrchestrator-detect_layers}{}}}
 \subsection{\code{BaseRPlotOrchestrator$detect_layers()}}{
+  Turn each recorded plot group into layer entries: one for its HIGH-level call
+and one per LOW-level overlay
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRPlotOrchestrator$detect_layers()}
@@ -66,6 +76,7 @@ the results into a comprehensive interactive plot.
 \if{html}{\out{<a id="method-BaseRPlotOrchestrator-analyze_single_layer"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRPlotOrchestrator-analyze_single_layer}{}}}
 \subsection{\code{BaseRPlotOrchestrator$analyze_single_layer()}}{
+  Describe one recorded call as a layer entry with its detected type
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRPlotOrchestrator$analyze_single_layer(
@@ -75,12 +86,25 @@ the results into a comprehensive interactive plot.
 )}
     \if{html}{\out{</div>}}
   }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{plot_call}}{The recorded call}
+      \item{\code{layer_index}}{Index of the layer}
+      \item{\code{group}}{The recorded plot group holding the HIGH-level call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Layer information list
+  }
 }
 
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-BaseRPlotOrchestrator-create_layer_processors"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRPlotOrchestrator-create_layer_processors}{}}}
 \subsection{\code{BaseRPlotOrchestrator$create_layer_processors()}}{
+  Create a processor for every layer of a known type
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRPlotOrchestrator$create_layer_processors()}
@@ -92,10 +116,21 @@ the results into a comprehensive interactive plot.
 \if{html}{\out{<a id="method-BaseRPlotOrchestrator-create_layer_processor"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRPlotOrchestrator-create_layer_processor}{}}}
 \subsection{\code{BaseRPlotOrchestrator$create_layer_processor()}}{
+  Create the processor for one layer
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRPlotOrchestrator$create_layer_processor(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A layer processor, or NULL for an unknown type
   }
 }
 
@@ -125,6 +160,7 @@ the results into a comprehensive interactive plot.
 \if{html}{\out{<a id="method-BaseRPlotOrchestrator-process_layers"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRPlotOrchestrator-process_layers}{}}}
 \subsection{\code{BaseRPlotOrchestrator$process_layers()}}{
+  Run every layer processor and combine the results
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRPlotOrchestrator$process_layers()}
@@ -154,10 +190,15 @@ The wrapper stores .maidr_format_config when labels is a scales:: function.
 \if{html}{\out{<a id="method-BaseRPlotOrchestrator-extract_layout"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRPlotOrchestrator-extract_layout}{}}}
 \subsection{\code{BaseRPlotOrchestrator$extract_layout()}}{
+  Read the figure-level title, subtitle and axis labels from the recorded
+HIGH-level calls
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRPlotOrchestrator$extract_layout()}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List
   }
 }
 
@@ -165,9 +206,17 @@ The wrapper stores .maidr_format_config when labels is a scales:: function.
 \if{html}{\out{<a id="method-BaseRPlotOrchestrator-combine_layer_results"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRPlotOrchestrator-combine_layer_results}{}}}
 \subsection{\code{BaseRPlotOrchestrator$combine_layer_results()}}{
+  Combine the per-layer results into the subplot grid
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRPlotOrchestrator$combine_layer_results(layer_results)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_results}}{List of per-layer results, one per processor}
+    }
     \if{html}{\out{</div>}}
   }
 }
@@ -176,10 +225,14 @@ The wrapper stores .maidr_format_config when labels is a scales:: function.
 \if{html}{\out{<a id="method-BaseRPlotOrchestrator-generate_maidr_data"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRPlotOrchestrator-generate_maidr_data}{}}}
 \subsection{\code{BaseRPlotOrchestrator$generate_maidr_data()}}{
+  Assemble the MAIDR data object for the figure
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRPlotOrchestrator$generate_maidr_data()}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List with an id and the subplots
   }
 }
 
@@ -187,10 +240,14 @@ The wrapper stores .maidr_format_config when labels is a scales:: function.
 \if{html}{\out{<a id="method-BaseRPlotOrchestrator-get_layout"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRPlotOrchestrator-get_layout}{}}}
 \subsection{\code{BaseRPlotOrchestrator$get_layout()}}{
+  The figure-level layout read by \code{extract_layout()}
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRPlotOrchestrator$get_layout()}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List
   }
 }
 
@@ -198,10 +255,14 @@ The wrapper stores .maidr_format_config when labels is a scales:: function.
 \if{html}{\out{<a id="method-BaseRPlotOrchestrator-get_combined_data"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRPlotOrchestrator-get_combined_data}{}}}
 \subsection{\code{BaseRPlotOrchestrator$get_combined_data()}}{
+  The combined per-layer data
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRPlotOrchestrator$get_combined_data()}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List
   }
 }
 
@@ -209,10 +270,14 @@ The wrapper stores .maidr_format_config when labels is a scales:: function.
 \if{html}{\out{<a id="method-BaseRPlotOrchestrator-get_layer_processors"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRPlotOrchestrator-get_layer_processors}{}}}
 \subsection{\code{BaseRPlotOrchestrator$get_layer_processors()}}{
+  The processors created for the layers
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRPlotOrchestrator$get_layer_processors()}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List
   }
 }
 
@@ -220,10 +285,14 @@ The wrapper stores .maidr_format_config when labels is a scales:: function.
 \if{html}{\out{<a id="method-BaseRPlotOrchestrator-get_layers"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRPlotOrchestrator-get_layers}{}}}
 \subsection{\code{BaseRPlotOrchestrator$get_layers()}}{
+  The detected layer entries
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRPlotOrchestrator$get_layers()}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List
   }
 }
 
@@ -231,10 +300,14 @@ The wrapper stores .maidr_format_config when labels is a scales:: function.
 \if{html}{\out{<a id="method-BaseRPlotOrchestrator-get_plot_calls"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRPlotOrchestrator-get_plot_calls}{}}}
 \subsection{\code{BaseRPlotOrchestrator$get_plot_calls()}}{
+  The recorded plot calls
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRPlotOrchestrator$get_plot_calls()}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List
   }
 }
 
@@ -242,10 +315,14 @@ The wrapper stores .maidr_format_config when labels is a scales:: function.
 \if{html}{\out{<a id="method-BaseRPlotOrchestrator-get_gtable"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRPlotOrchestrator-get_gtable}{}}}
 \subsection{\code{BaseRPlotOrchestrator$get_gtable()}}{
+  The gtable of the replayed drawing, built once and cached
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRPlotOrchestrator$get_gtable()}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A gtable, or NULL when nothing was recorded
   }
 }
 
@@ -253,10 +330,21 @@ The wrapper stores .maidr_format_config when labels is a scales:: function.
 \if{html}{\out{<a id="method-BaseRPlotOrchestrator-get_grob_for_layer"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRPlotOrchestrator-get_grob_for_layer}{}}}
 \subsection{\code{BaseRPlotOrchestrator$get_grob_for_layer()}}{
+  The grob a layer's processor searches for its selectors
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRPlotOrchestrator$get_grob_for_layer(layer_index)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_index}}{Index of the layer}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A grob, or NULL
   }
 }
 

--- a/man/BaseRPointLayerProcessor.Rd
+++ b/man/BaseRPointLayerProcessor.Rd
@@ -53,6 +53,8 @@ Processes Base R scatter plot layers based on recorded plot calls
 \if{html}{\out{<a id="method-BaseRPointLayerProcessor-process"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRPointLayerProcessor-process}{}}}
 \subsection{\code{BaseRPointLayerProcessor$process()}}{
+  Process the layer: read its data, selectors, axis titles and main title from
+the recorded call
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRPointLayerProcessor$process(
@@ -70,14 +72,19 @@ Processes Base R scatter plot layers based on recorded plot calls
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{plot}}{The ggplot2 object}
-      \item{\code{layout}}{Layout information}
-      \item{\code{built}}{Built plot data (optional)}
-      \item{\code{gt}}{Gtable object (optional)}
-      \item{\code{grob_id}}{Grob ID for faceted plots (optional)}
-      \item{\code{panel_ctx}}{Panel context for panel-scoped selector generation (optional)}
+      \item{\code{plot}}{Unused; present for the processor interface}
+      \item{\code{layout}}{Unused; present for the processor interface}
+      \item{\code{built}}{Unused; present for the processor interface}
+      \item{\code{gt}}{Gtable of the replayed drawing, searched for selectors (optional)}
+      \item{\code{grob_id}}{Unused; present for the processor interface}
+      \item{\code{panel_id}}{Unused; present for the processor interface}
+      \item{\code{panel_ctx}}{Unused; present for the processor interface}
+      \item{\code{layer_info}}{Layer information with the recorded call}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List describing the layer for the MAIDR payload
   }
 }
 
@@ -85,10 +92,15 @@ Processes Base R scatter plot layers based on recorded plot calls
 \if{html}{\out{<a id="method-BaseRPointLayerProcessor-needs_reordering"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRPointLayerProcessor-needs_reordering}{}}}
 \subsection{\code{BaseRPointLayerProcessor$needs_reordering()}}{
+  Whether the plot data must be reordered before drawing; a Base R layer is read
+from the recorded call and never is
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRPointLayerProcessor$needs_reordering()}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    FALSE
   }
 }
 
@@ -96,10 +108,22 @@ Processes Base R scatter plot layers based on recorded plot calls
 \if{html}{\out{<a id="method-BaseRPointLayerProcessor-extract_data"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRPointLayerProcessor-extract_data}{}}}
 \subsection{\code{BaseRPointLayerProcessor$extract_data()}}{
+  One point per observation, from the recorded x and y or from the formula's
+model frame
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRPointLayerProcessor$extract_data(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of points
   }
 }
 
@@ -107,10 +131,27 @@ Processes Base R scatter plot layers based on recorded plot calls
 \if{html}{\out{<a id="method-BaseRPointLayerProcessor-resolve_coordinates"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRPointLayerProcessor-resolve_coordinates}{}}}
 \subsection{\code{BaseRPointLayerProcessor$resolve_coordinates()}}{
+  The x and y a recorded call plots, resolved as plot() resolves them.
+
+\code{plot(y ~ x, data = d)} carries a formula rather than two vectors, and
+its coordinates are the two columns of the model frame the recording
+kept (#254). Read from \code{resolve_xy_args()} alone, the formula is a
+language object and the layer came out with no points at all -- an
+interactive chart with nothing in it.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRPointLayerProcessor$resolve_coordinates(plot_call)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{plot_call}}{The recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A list with \code{x} and \code{y}, either of which may be NULL
   }
 }
 
@@ -118,10 +159,25 @@ Processes Base R scatter plot layers based on recorded plot calls
 \if{html}{\out{<a id="method-BaseRPointLayerProcessor-formula_variables"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRPointLayerProcessor-formula_variables}{}}}
 \subsection{\code{BaseRPointLayerProcessor$formula_variables()}}{
+  The two numeric variables of a recorded formula call, or NULL.
+
+Only a numeric pair is a scatter: \code{plot(y ~ f)} on a factor draws a
+box plot through \code{plot.factor()}, and a frame with more than one
+predictor draws something else again. Both are left as they were.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRPointLayerProcessor$formula_variables(plot_call)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{plot_call}}{The recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A list with \code{x}, \code{y}, \code{x_name}, \code{y_name}, or NULL
   }
 }
 
@@ -129,10 +185,27 @@ Processes Base R scatter plot layers based on recorded plot calls
 \if{html}{\out{<a id="method-BaseRPointLayerProcessor-extract_axis_titles"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRPointLayerProcessor-extract_axis_titles}{}}}
 \subsection{\code{BaseRPointLayerProcessor$extract_axis_titles()}}{
+  Extract axis information from Base R plot call
+
+Returns per-axis objects with an optional label and optional grid
+navigation fields (min, max, tickStep). Grid fields are derived from
+xlim/ylim args or data range, and tick intervals via pretty(). Every
+field is included only when extraction succeeds, and an axis that ends
+up with none of them is left out of the payload entirely.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRPointLayerProcessor$extract_axis_titles(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with recorded plot call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Canonical axes list
   }
 }
 
@@ -140,10 +213,25 @@ Processes Base R scatter plot layers based on recorded plot calls
 \if{html}{\out{<a id="method-BaseRPointLayerProcessor-extract_base_r_axis_grid_info"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRPointLayerProcessor-extract_base_r_axis_grid_info}{}}}
 \subsection{\code{BaseRPointLayerProcessor$extract_base_r_axis_grid_info()}}{
+  Extract grid navigation info for a Base R axis
+
+Computes min, max from xlim/ylim or data range, and tickStep from
+pretty() tick positions. Returns NULL if extraction fails.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRPointLayerProcessor$extract_base_r_axis_grid_info(data, lim = NULL)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{data}}{Numeric vector of data values}
+      \item{\code{lim}}{Optional axis limits (xlim or ylim)}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List with min, max, tickStep or NULL
   }
 }
 
@@ -151,10 +239,21 @@ Processes Base R scatter plot layers based on recorded plot calls
 \if{html}{\out{<a id="method-BaseRPointLayerProcessor-extract_main_title"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRPointLayerProcessor-extract_main_title}{}}}
 \subsection{\code{BaseRPointLayerProcessor$extract_main_title()}}{
+  The main title of the recorded call, or an empty string
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRPointLayerProcessor$extract_main_title(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Character string
   }
 }
 
@@ -162,6 +261,7 @@ Processes Base R scatter plot layers based on recorded plot calls
 \if{html}{\out{<a id="method-BaseRPointLayerProcessor-generate_selectors"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRPointLayerProcessor-generate_selectors}{}}}
 \subsection{\code{BaseRPointLayerProcessor$generate_selectors()}}{
+  The selector for the points, scoped to this layer's plot group
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRPointLayerProcessor$generate_selectors(layer_info, gt = NULL)}
@@ -170,9 +270,13 @@ Processes Base R scatter plot layers based on recorded plot calls
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{gt}}{Gtable object (optional)}
+      \item{\code{layer_info}}{Layer information with the recorded call}
+      \item{\code{gt}}{Gtable of the replayed drawing (optional)}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of selectors
   }
 }
 

--- a/man/BaseRSmoothLayerProcessor.Rd
+++ b/man/BaseRSmoothLayerProcessor.Rd
@@ -57,6 +57,8 @@ Processes Base R smooth curves including:
 \if{html}{\out{<a id="method-BaseRSmoothLayerProcessor-process"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRSmoothLayerProcessor-process}{}}}
 \subsection{\code{BaseRSmoothLayerProcessor$process()}}{
+  Process the layer: read its data, selectors, axis titles and main title from
+the recorded call
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRSmoothLayerProcessor$process(
@@ -74,14 +76,19 @@ Processes Base R smooth curves including:
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{plot}}{The ggplot2 object}
-      \item{\code{layout}}{Layout information}
-      \item{\code{built}}{Built plot data (optional)}
-      \item{\code{gt}}{Gtable object (optional)}
-      \item{\code{grob_id}}{Grob ID for faceted plots (optional)}
-      \item{\code{panel_ctx}}{Panel context for panel-scoped selector generation (optional)}
+      \item{\code{plot}}{Unused; present for the processor interface}
+      \item{\code{layout}}{Unused; present for the processor interface}
+      \item{\code{built}}{Unused; present for the processor interface}
+      \item{\code{gt}}{Gtable of the replayed drawing, searched for selectors (optional)}
+      \item{\code{grob_id}}{Unused; present for the processor interface}
+      \item{\code{panel_id}}{Unused; present for the processor interface}
+      \item{\code{panel_ctx}}{Unused; present for the processor interface}
+      \item{\code{layer_info}}{Layer information with the recorded call}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List describing the layer for the MAIDR payload
   }
 }
 
@@ -89,10 +96,21 @@ Processes Base R smooth curves including:
 \if{html}{\out{<a id="method-BaseRSmoothLayerProcessor-extract_data"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRSmoothLayerProcessor-extract_data}{}}}
 \subsection{\code{BaseRSmoothLayerProcessor$extract_data()}}{
+  One point per fitted value of the smooth, density or curve
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRSmoothLayerProcessor$extract_data(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of points
   }
 }
 
@@ -100,6 +118,7 @@ Processes Base R smooth curves including:
 \if{html}{\out{<a id="method-BaseRSmoothLayerProcessor-generate_selectors"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRSmoothLayerProcessor-generate_selectors}{}}}
 \subsection{\code{BaseRSmoothLayerProcessor$generate_selectors()}}{
+  The selector for the curve's polyline
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRSmoothLayerProcessor$generate_selectors(layer_info, gt = NULL)}
@@ -108,9 +127,13 @@ Processes Base R smooth curves including:
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{gt}}{Gtable object (optional)}
+      \item{\code{layer_info}}{Layer information with the recorded call}
+      \item{\code{gt}}{Gtable of the replayed drawing (optional)}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of selectors
   }
 }
 
@@ -118,10 +141,22 @@ Processes Base R smooth curves including:
 \if{html}{\out{<a id="method-BaseRSmoothLayerProcessor-find_polyline_grobs"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRSmoothLayerProcessor-find_polyline_grobs}{}}}
 \subsection{\code{BaseRSmoothLayerProcessor$find_polyline_grobs()}}{
+  Find the lines container grob for this layer
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRSmoothLayerProcessor$find_polyline_grobs(grob, call_index = NULL)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{grob}}{The grob tree to search}
+      \item{\code{call_index}}{Index of the recorded plot group, which numbers the panel's grobs}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Grob name, or NULL
   }
 }
 
@@ -129,10 +164,22 @@ Processes Base R smooth curves including:
 \if{html}{\out{<a id="method-BaseRSmoothLayerProcessor-generate_selectors_from_grob"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRSmoothLayerProcessor-generate_selectors_from_grob}{}}}
 \subsection{\code{BaseRSmoothLayerProcessor$generate_selectors_from_grob()}}{
+  Build this layer's selector from the grob tree
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRSmoothLayerProcessor$generate_selectors_from_grob(grob, call_index = NULL)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{grob}}{The grob tree to search}
+      \item{\code{call_index}}{Index of the recorded plot group, which numbers the panel's grobs}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A selector string, or an empty string when no grob matches
   }
 }
 
@@ -140,10 +187,26 @@ Processes Base R smooth curves including:
 \if{html}{\out{<a id="method-BaseRSmoothLayerProcessor-extract_axis_titles"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRSmoothLayerProcessor-extract_axis_titles}{}}}
 \subsection{\code{BaseRSmoothLayerProcessor$extract_axis_titles()}}{
+  Extract the axis titles for this layer
+
+The x axis holds whatever variable was smoothed, which the recorded
+arguments no longer name, so it carries no default. The y axis does
+when the curve came from \code{density()}: that estimate is a density, and
+plot.density() prints exactly that word.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRSmoothLayerProcessor$extract_axis_titles(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Canonical axes list
   }
 }
 
@@ -151,10 +214,21 @@ Processes Base R smooth curves including:
 \if{html}{\out{<a id="method-BaseRSmoothLayerProcessor-extract_main_title"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRSmoothLayerProcessor-extract_main_title}{}}}
 \subsection{\code{BaseRSmoothLayerProcessor$extract_main_title()}}{
+  The main title of the recorded call, or an empty string
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRSmoothLayerProcessor$extract_main_title(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Character string
   }
 }
 

--- a/man/BaseRStackedBarLayerProcessor.Rd
+++ b/man/BaseRStackedBarLayerProcessor.Rd
@@ -53,6 +53,8 @@ applied by the \code{SortingPatcher}.
 \if{html}{\out{<a id="method-BaseRStackedBarLayerProcessor-process"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRStackedBarLayerProcessor-process}{}}}
 \subsection{\code{BaseRStackedBarLayerProcessor$process()}}{
+  Process the layer: read its data, selectors, axis titles and main title from
+the recorded call
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRStackedBarLayerProcessor$process(
@@ -70,14 +72,19 @@ applied by the \code{SortingPatcher}.
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{plot}}{The ggplot2 object}
-      \item{\code{layout}}{Layout information}
-      \item{\code{built}}{Built plot data (optional)}
-      \item{\code{gt}}{Gtable object (optional)}
-      \item{\code{grob_id}}{Grob ID for faceted plots (optional)}
-      \item{\code{panel_ctx}}{Panel context for panel-scoped selector generation (optional)}
+      \item{\code{plot}}{Unused; present for the processor interface}
+      \item{\code{layout}}{Unused; present for the processor interface}
+      \item{\code{built}}{Unused; present for the processor interface}
+      \item{\code{gt}}{Gtable of the replayed drawing, searched for selectors (optional)}
+      \item{\code{grob_id}}{Unused; present for the processor interface}
+      \item{\code{panel_id}}{Unused; present for the processor interface}
+      \item{\code{panel_ctx}}{Unused; present for the processor interface}
+      \item{\code{layer_info}}{Layer information with the recorded call}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List describing the layer for the MAIDR payload
   }
 }
 
@@ -85,10 +92,15 @@ applied by the \code{SortingPatcher}.
 \if{html}{\out{<a id="method-BaseRStackedBarLayerProcessor-needs_reordering"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRStackedBarLayerProcessor-needs_reordering}{}}}
 \subsection{\code{BaseRStackedBarLayerProcessor$needs_reordering()}}{
+  Whether the plot data must be reordered before drawing; a Base R layer is read
+from the recorded call and never is
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRStackedBarLayerProcessor$needs_reordering()}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    FALSE
   }
 }
 
@@ -96,10 +108,21 @@ applied by the \code{SortingPatcher}.
 \if{html}{\out{<a id="method-BaseRStackedBarLayerProcessor-extract_data"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRStackedBarLayerProcessor-extract_data}{}}}
 \subsection{\code{BaseRStackedBarLayerProcessor$extract_data()}}{
+  One series per row of the recorded height matrix
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRStackedBarLayerProcessor$extract_data(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of series
   }
 }
 
@@ -107,10 +130,27 @@ applied by the \code{SortingPatcher}.
 \if{html}{\out{<a id="method-BaseRStackedBarLayerProcessor-extract_axis_titles"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRStackedBarLayerProcessor-extract_axis_titles}{}}}
 \subsection{\code{BaseRStackedBarLayerProcessor$extract_axis_titles()}}{
+  Extract the axis titles for this layer
+
+A stacked \code{barplot()} records no title unless the author wrote one, and
+its points always carry the column category on x and the segment height
+on y, so the defaults name those two. The stack's own dimension is
+already announced per point as z; nothing in the call names the
+variable those groups came from, so no z title is claimed.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRStackedBarLayerProcessor$extract_axis_titles(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Canonical axes list
   }
 }
 
@@ -118,10 +158,21 @@ applied by the \code{SortingPatcher}.
 \if{html}{\out{<a id="method-BaseRStackedBarLayerProcessor-extract_main_title"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRStackedBarLayerProcessor-extract_main_title}{}}}
 \subsection{\code{BaseRStackedBarLayerProcessor$extract_main_title()}}{
+  The main title of the recorded call, or an empty string
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRStackedBarLayerProcessor$extract_main_title(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Character string
   }
 }
 
@@ -129,6 +180,7 @@ applied by the \code{SortingPatcher}.
 \if{html}{\out{<a id="method-BaseRStackedBarLayerProcessor-generate_selectors"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRStackedBarLayerProcessor-generate_selectors}{}}}
 \subsection{\code{BaseRStackedBarLayerProcessor$generate_selectors()}}{
+  The selector for the segments, scoped to this layer's plot group
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRStackedBarLayerProcessor$generate_selectors(
@@ -141,9 +193,14 @@ applied by the \code{SortingPatcher}.
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{gt}}{Gtable object (optional)}
+      \item{\code{layer_info}}{Layer information with the recorded call}
+      \item{\code{gt}}{Gtable of the replayed drawing (optional)}
+      \item{\code{extracted_data}}{The data already extracted for this layer (optional)}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of selectors
   }
 }
 
@@ -151,10 +208,22 @@ applied by the \code{SortingPatcher}.
 \if{html}{\out{<a id="method-BaseRStackedBarLayerProcessor-find_rect_groups"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRStackedBarLayerProcessor-find_rect_groups}{}}}
 \subsection{\code{BaseRStackedBarLayerProcessor$find_rect_groups()}}{
+  Find every rect group drawn by the plot group at \code{call_index}
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRStackedBarLayerProcessor$find_rect_groups(grob, call_index)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{grob}}{The grob tree to search}
+      \item{\code{call_index}}{Index of the recorded plot group, which numbers the panel's grobs}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Character vector of grob names
   }
 }
 

--- a/man/BaseRUnknownLayerProcessor.Rd
+++ b/man/BaseRUnknownLayerProcessor.Rd
@@ -48,6 +48,7 @@ Processes unknown Base R layer types as a fallback
 \if{html}{\out{<a id="method-BaseRUnknownLayerProcessor-process"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRUnknownLayerProcessor-process}{}}}
 \subsection{\code{BaseRUnknownLayerProcessor$process()}}{
+  Describe a layer nothing is known about
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRUnknownLayerProcessor$process(
@@ -65,14 +66,19 @@ Processes unknown Base R layer types as a fallback
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{plot}}{The ggplot2 object}
-      \item{\code{layout}}{Layout information}
-      \item{\code{built}}{Built plot data (optional)}
-      \item{\code{gt}}{Gtable object (optional)}
-      \item{\code{grob_id}}{Grob ID for faceted plots (optional)}
-      \item{\code{panel_ctx}}{Panel context for panel-scoped selector generation (optional)}
+      \item{\code{plot}}{Unused; present for the processor interface}
+      \item{\code{layout}}{Unused; present for the processor interface}
+      \item{\code{built}}{Unused; present for the processor interface}
+      \item{\code{gt}}{Gtable of the replayed drawing, searched for selectors (optional)}
+      \item{\code{grob_id}}{Unused; present for the processor interface}
+      \item{\code{panel_id}}{Unused; present for the processor interface}
+      \item{\code{panel_ctx}}{Unused; present for the processor interface}
+      \item{\code{layer_info}}{Layer information with the recorded call}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List with no data and no selectors
   }
 }
 
@@ -80,10 +86,15 @@ Processes unknown Base R layer types as a fallback
 \if{html}{\out{<a id="method-BaseRUnknownLayerProcessor-needs_reordering"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRUnknownLayerProcessor-needs_reordering}{}}}
 \subsection{\code{BaseRUnknownLayerProcessor$needs_reordering()}}{
+  Whether the plot data must be reordered before drawing; a Base R layer is read
+from the recorded call and never is
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRUnknownLayerProcessor$needs_reordering()}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    FALSE
   }
 }
 
@@ -91,10 +102,21 @@ Processes unknown Base R layer types as a fallback
 \if{html}{\out{<a id="method-BaseRUnknownLayerProcessor-extract_data"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRUnknownLayerProcessor-extract_data}{}}}
 \subsection{\code{BaseRUnknownLayerProcessor$extract_data()}}{
+  Nothing: an unknown layer has no data to announce
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRUnknownLayerProcessor$extract_data(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Empty list
   }
 }
 
@@ -102,10 +124,21 @@ Processes unknown Base R layer types as a fallback
 \if{html}{\out{<a id="method-BaseRUnknownLayerProcessor-generate_selectors"></a>}}
 \if{latex}{\out{\hypertarget{method-BaseRUnknownLayerProcessor-generate_selectors}{}}}
 \subsection{\code{BaseRUnknownLayerProcessor$generate_selectors()}}{
+  Nothing: an unknown layer has no elements to address
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{BaseRUnknownLayerProcessor$generate_selectors(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information with the recorded call}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Empty list
   }
 }
 

--- a/man/Ggplot2BarLayerProcessor.Rd
+++ b/man/Ggplot2BarLayerProcessor.Rd
@@ -54,6 +54,7 @@ Processes bar plot layers with complete logic included
 \if{html}{\out{<a id="method-Ggplot2BarLayerProcessor-process"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2BarLayerProcessor-process}{}}}
 \subsection{\code{Ggplot2BarLayerProcessor$process()}}{
+  Process the layer: read its bars, selectors and orientation from the built plot
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2BarLayerProcessor$process(
@@ -75,9 +76,13 @@ Processes bar plot layers with complete logic included
       \item{\code{built}}{Built plot data (optional)}
       \item{\code{gt}}{Gtable object (optional)}
       \item{\code{grob_id}}{Grob ID for faceted plots (optional)}
+      \item{\code{panel_id}}{Panel ID for faceted plots (optional)}
       \item{\code{panel_ctx}}{Panel context for panel-scoped selector generation (optional)}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List describing the layer for the MAIDR payload
   }
 }
 
@@ -162,10 +167,15 @@ never written.
 \if{html}{\out{<a id="method-Ggplot2BarLayerProcessor-needs_reordering"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2BarLayerProcessor-needs_reordering}{}}}
 \subsection{\code{Ggplot2BarLayerProcessor$needs_reordering()}}{
+  Whether the plot data must be reordered before drawing, so the emitted order
+matches the drawn rects
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2BarLayerProcessor$needs_reordering()}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    TRUE
   }
 }
 
@@ -173,6 +183,7 @@ never written.
 \if{html}{\out{<a id="method-Ggplot2BarLayerProcessor-reorder_layer_data"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2BarLayerProcessor-reorder_layer_data}{}}}
 \subsection{\code{Ggplot2BarLayerProcessor$reorder_layer_data()}}{
+  Reorder the plot data by category so the emitted rows match the drawn rects
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2BarLayerProcessor$reorder_layer_data(data, plot)}
@@ -181,10 +192,13 @@ never written.
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{data}}{data.frame effective for this layer}
-      \item{\code{plot}}{full ggplot object (for mappings)}
+      \item{\code{data}}{The data frame ggplot2 will draw from}
+      \item{\code{plot}}{The ggplot2 object}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    The reordered data frame
   }
 }
 
@@ -192,6 +206,7 @@ never written.
 \if{html}{\out{<a id="method-Ggplot2BarLayerProcessor-extract_data"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2BarLayerProcessor-extract_data}{}}}
 \subsection{\code{Ggplot2BarLayerProcessor$extract_data()}}{
+  One point per bar, read from the built plot
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2BarLayerProcessor$extract_data(plot, built = NULL, panel_id = NULL)}
@@ -202,8 +217,12 @@ never written.
     \describe{
       \item{\code{plot}}{The ggplot2 object}
       \item{\code{built}}{Built plot data (optional)}
+      \item{\code{panel_id}}{Panel ID for faceted plots (optional)}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of points
   }
 }
 
@@ -221,6 +240,13 @@ so candle and bar layers from the same Date column align string-wise.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2BarLayerProcessor$format_x_value(x)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{x}}{The value to format}
+    }
     \if{html}{\out{</div>}}
   }
 }
@@ -309,6 +335,7 @@ in \code{Ggplot2LineLayerProcessor}.
 \if{html}{\out{<a id="method-Ggplot2BarLayerProcessor-generate_selectors"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2BarLayerProcessor-generate_selectors}{}}}
 \subsection{\code{Ggplot2BarLayerProcessor$generate_selectors()}}{
+  Selectors for the layer's rects
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2BarLayerProcessor$generate_selectors(
@@ -328,6 +355,9 @@ in \code{Ggplot2LineLayerProcessor}.
       \item{\code{panel_ctx}}{Panel context for panel-scoped selector generation (optional)}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of selectors
   }
 }
 

--- a/man/Ggplot2BarLayerProcessor.Rd
+++ b/man/Ggplot2BarLayerProcessor.Rd
@@ -249,6 +249,9 @@ so candle and bar layers from the same Date column align string-wise.
     }
     \if{html}{\out{</div>}}
   }
+  \subsection{Returns}{
+    Character vector
+  }
 }
 
 \if{html}{\out{<hr>}}

--- a/man/Ggplot2CandlestickProcessor.Rd
+++ b/man/Ggplot2CandlestickProcessor.Rd
@@ -213,6 +213,9 @@ Here we additionally fall back to \code{plot$mapping$x} and synthesize a
     }
     \if{html}{\out{</div>}}
   }
+  \subsection{Returns}{
+    The column name, or NULL when the mapping names no column of \code{data}
+  }
 }
 
 \if{html}{\out{<hr>}}
@@ -231,6 +234,9 @@ Here we additionally fall back to \code{plot$mapping$x} and synthesize a
       \item{\code{x}}{The value to format}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Character vector
   }
 }
 
@@ -289,6 +295,9 @@ Here we additionally fall back to \code{plot$mapping$x} and synthesize a
     }
     \if{html}{\out{</div>}}
   }
+  \subsection{Returns}{
+    Integer, 0 when there is no data
+  }
 }
 
 \if{html}{\out{<hr>}}
@@ -332,6 +341,9 @@ for a single plot, where the panel is the cell literally named "panel"}
       \item{\code{pattern}}{Regular expression the grob name must match}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    The matching grob name, or NULL
   }
 }
 

--- a/man/Ggplot2CandlestickProcessor.Rd
+++ b/man/Ggplot2CandlestickProcessor.Rd
@@ -205,6 +205,14 @@ Here we additionally fall back to \code{plot$mapping$x} and synthesize a
     \preformatted{Ggplot2CandlestickProcessor$resolve_col(mapping_expr, data)}
     \if{html}{\out{</div>}}
   }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{mapping_expr}}{A mapping quosure}
+      \item{\code{data}}{The data frame to resolve the column in}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
 \if{html}{\out{<hr>}}
@@ -215,6 +223,13 @@ Here we additionally fall back to \code{plot$mapping$x} and synthesize a
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2CandlestickProcessor$format_x_value(x)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{x}}{The value to format}
+    }
     \if{html}{\out{</div>}}
   }
 }
@@ -229,6 +244,13 @@ Here we additionally fall back to \code{plot$mapping$x} and synthesize a
     \preformatted{Ggplot2CandlestickProcessor$get_effective_mapping(plot)}
     \if{html}{\out{</div>}}
   }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{plot}}{The ggplot2 object}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
 \if{html}{\out{<hr>}}
@@ -241,6 +263,13 @@ Here we additionally fall back to \code{plot$mapping$x} and synthesize a
     \preformatted{Ggplot2CandlestickProcessor$get_original_data(plot)}
     \if{html}{\out{</div>}}
   }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{plot}}{The ggplot2 object}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
 \if{html}{\out{<hr>}}
@@ -251,6 +280,13 @@ Here we additionally fall back to \code{plot$mapping$x} and synthesize a
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2CandlestickProcessor$count_candles(plot)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{plot}}{The ggplot2 object}
+    }
     \if{html}{\out{</div>}}
   }
 }
@@ -287,6 +323,14 @@ for a single plot, where the panel is the cell literally named "panel"}
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2CandlestickProcessor$find_first_child_name(grob, pattern)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{grob}}{The grob tree to search}
+      \item{\code{pattern}}{Regular expression the grob name must match}
+    }
     \if{html}{\out{</div>}}
   }
 }

--- a/man/Ggplot2DodgedBarLayerProcessor.Rd
+++ b/man/Ggplot2DodgedBarLayerProcessor.Rd
@@ -49,6 +49,8 @@ Processes dodged bar plot layers with complete logic included
 \if{html}{\out{<a id="method-Ggplot2DodgedBarLayerProcessor-process"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2DodgedBarLayerProcessor-process}{}}}
 \subsection{\code{Ggplot2DodgedBarLayerProcessor$process()}}{
+  Process the layer: read its series, selectors and DOM mapping from the built
+plot
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2DodgedBarLayerProcessor$process(
@@ -70,9 +72,13 @@ Processes dodged bar plot layers with complete logic included
       \item{\code{built}}{Built plot data (optional)}
       \item{\code{gt}}{Gtable object (optional)}
       \item{\code{grob_id}}{Grob ID for faceted plots (optional)}
+      \item{\code{panel_id}}{Panel ID for faceted plots (optional)}
       \item{\code{panel_ctx}}{Panel context for panel-scoped selector generation (optional)}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List describing the layer for the MAIDR payload
   }
 }
 
@@ -80,10 +86,15 @@ Processes dodged bar plot layers with complete logic included
 \if{html}{\out{<a id="method-Ggplot2DodgedBarLayerProcessor-needs_reordering"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2DodgedBarLayerProcessor-needs_reordering}{}}}
 \subsection{\code{Ggplot2DodgedBarLayerProcessor$needs_reordering()}}{
+  Whether the plot data must be reordered before drawing, so the emitted order
+matches the drawn rects
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2DodgedBarLayerProcessor$needs_reordering()}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    TRUE
   }
 }
 
@@ -120,6 +131,8 @@ i.e. NULL.
 \if{html}{\out{<a id="method-Ggplot2DodgedBarLayerProcessor-reorder_layer_data"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2DodgedBarLayerProcessor-reorder_layer_data}{}}}
 \subsection{\code{Ggplot2DodgedBarLayerProcessor$reorder_layer_data()}}{
+  Reorder the plot data by x and fill so each column's rects are drawn in the
+order the frontend walks them
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2DodgedBarLayerProcessor$reorder_layer_data(data, plot)}
@@ -128,10 +141,13 @@ i.e. NULL.
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{data}}{data.frame effective for this layer}
-      \item{\code{plot}}{full ggplot object (for mappings)}
+      \item{\code{data}}{The data frame ggplot2 will draw from}
+      \item{\code{plot}}{The ggplot2 object}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    The reordered data frame
   }
 }
 
@@ -139,6 +155,8 @@ i.e. NULL.
 \if{html}{\out{<a id="method-Ggplot2DodgedBarLayerProcessor-extract_data"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2DodgedBarLayerProcessor-extract_data}{}}}
 \subsection{\code{Ggplot2DodgedBarLayerProcessor$extract_data()}}{
+  One series per fill level, as a rectangular grid with a \code{0} for every missing
+bar
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2DodgedBarLayerProcessor$extract_data(
@@ -153,8 +171,12 @@ i.e. NULL.
     \describe{
       \item{\code{plot}}{The ggplot2 object}
       \item{\code{built}}{Built plot data (optional)}
+      \item{\code{panel_ctx}}{Panel context for panel-scoped selector generation (optional)}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of series
   }
 }
 
@@ -162,6 +184,8 @@ i.e. NULL.
 \if{html}{\out{<a id="method-Ggplot2DodgedBarLayerProcessor-generate_selectors"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2DodgedBarLayerProcessor-generate_selectors}{}}}
 \subsection{\code{Ggplot2DodgedBarLayerProcessor$generate_selectors()}}{
+  One flat selector matching every rect in the layer, which is the contract the
+frontend expects (see the note above)
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2DodgedBarLayerProcessor$generate_selectors(
@@ -179,6 +203,9 @@ i.e. NULL.
       \item{\code{panel_ctx}}{Panel context for panel-scoped selector generation (optional)}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List holding one selector
   }
 }
 

--- a/man/Ggplot2HeatmapLayerProcessor.Rd
+++ b/man/Ggplot2HeatmapLayerProcessor.Rd
@@ -52,6 +52,7 @@ Processes heatmap layers (geom_tile) with generic data and grob reordering
 \if{html}{\out{<a id="method-Ggplot2HeatmapLayerProcessor-process"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2HeatmapLayerProcessor-process}{}}}
 \subsection{\code{Ggplot2HeatmapLayerProcessor$process()}}{
+  Process the layer: read its tiles, selectors and axis names from the built plot
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2HeatmapLayerProcessor$process(
@@ -73,9 +74,13 @@ Processes heatmap layers (geom_tile) with generic data and grob reordering
       \item{\code{built}}{Built plot data (optional)}
       \item{\code{gt}}{Gtable object (optional)}
       \item{\code{grob_id}}{Grob ID for faceted plots (optional)}
+      \item{\code{panel_id}}{Panel ID for faceted plots (optional)}
       \item{\code{panel_ctx}}{Panel context for panel-scoped selector generation (optional)}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List describing the layer for the MAIDR payload
   }
 }
 
@@ -83,10 +88,15 @@ Processes heatmap layers (geom_tile) with generic data and grob reordering
 \if{html}{\out{<a id="method-Ggplot2HeatmapLayerProcessor-needs_reordering"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2HeatmapLayerProcessor-needs_reordering}{}}}
 \subsection{\code{Ggplot2HeatmapLayerProcessor$needs_reordering()}}{
+  Whether the plot data must be reordered before drawing, so the emitted order
+matches the drawn tiles
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2HeatmapLayerProcessor$needs_reordering()}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    TRUE
   }
 }
 
@@ -94,6 +104,7 @@ Processes heatmap layers (geom_tile) with generic data and grob reordering
 \if{html}{\out{<a id="method-Ggplot2HeatmapLayerProcessor-reorder_layer_data"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2HeatmapLayerProcessor-reorder_layer_data}{}}}
 \subsection{\code{Ggplot2HeatmapLayerProcessor$reorder_layer_data()}}{
+  Reorder the plot data row-wise so the emitted cells match the drawn tiles
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2HeatmapLayerProcessor$reorder_layer_data(data, plot)}
@@ -102,10 +113,13 @@ Processes heatmap layers (geom_tile) with generic data and grob reordering
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{data}}{data.frame effective for this layer}
-      \item{\code{plot}}{full ggplot object (for mappings)}
+      \item{\code{data}}{The data frame ggplot2 will draw from}
+      \item{\code{plot}}{The ggplot2 object}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    The reordered data frame
   }
 }
 
@@ -239,6 +253,7 @@ which is still a coordinate rather than an index.
 \if{html}{\out{<a id="method-Ggplot2HeatmapLayerProcessor-extract_data"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2HeatmapLayerProcessor-extract_data}{}}}
 \subsection{\code{Ggplot2HeatmapLayerProcessor$extract_data()}}{
+  One row per tile plus the fill label, read from the built plot
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2HeatmapLayerProcessor$extract_data(plot, built = NULL, panel_id = NULL)}
@@ -249,8 +264,12 @@ which is still a coordinate rather than an index.
     \describe{
       \item{\code{plot}}{The ggplot2 object}
       \item{\code{built}}{Built plot data (optional)}
+      \item{\code{panel_id}}{Panel ID for faceted plots (optional)}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List
   }
 }
 
@@ -258,6 +277,7 @@ which is still a coordinate rather than an index.
 \if{html}{\out{<a id="method-Ggplot2HeatmapLayerProcessor-generate_selectors"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2HeatmapLayerProcessor-generate_selectors}{}}}
 \subsection{\code{Ggplot2HeatmapLayerProcessor$generate_selectors()}}{
+  Selectors for the tiles, scoped to the panel
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2HeatmapLayerProcessor$generate_selectors(
@@ -275,6 +295,9 @@ which is still a coordinate rather than an index.
       \item{\code{panel_ctx}}{Panel context for panel-scoped selector generation (optional)}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of selectors
   }
 }
 

--- a/man/Ggplot2HistogramLayerProcessor.Rd
+++ b/man/Ggplot2HistogramLayerProcessor.Rd
@@ -49,6 +49,7 @@ Processes histogram plot layers with complete logic included
 \if{html}{\out{<a id="method-Ggplot2HistogramLayerProcessor-process"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2HistogramLayerProcessor-process}{}}}
 \subsection{\code{Ggplot2HistogramLayerProcessor$process()}}{
+  Process the layer: read its bins, selectors and orientation from the built plot
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2HistogramLayerProcessor$process(
@@ -70,9 +71,13 @@ Processes histogram plot layers with complete logic included
       \item{\code{built}}{Built plot data (optional)}
       \item{\code{gt}}{Gtable object (optional)}
       \item{\code{grob_id}}{Grob ID for faceted plots (optional)}
+      \item{\code{panel_id}}{Panel ID for faceted plots (optional)}
       \item{\code{panel_ctx}}{Panel context for panel-scoped selector generation (optional)}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List describing the layer for the MAIDR payload
   }
 }
 
@@ -122,6 +127,7 @@ horizontal would swap a pair that is already the right way round.
 \if{html}{\out{<a id="method-Ggplot2HistogramLayerProcessor-extract_data"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2HistogramLayerProcessor-extract_data}{}}}
 \subsection{\code{Ggplot2HistogramLayerProcessor$extract_data()}}{
+  One point per bin, read from this layer's own built data
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2HistogramLayerProcessor$extract_data(
@@ -136,8 +142,12 @@ horizontal would swap a pair that is already the right way round.
     \describe{
       \item{\code{plot}}{The ggplot2 object}
       \item{\code{built}}{Built plot data (optional)}
+      \item{\code{panel_id}}{Panel ID for faceted plots (optional)}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of points
   }
 }
 
@@ -145,6 +155,7 @@ horizontal would swap a pair that is already the right way round.
 \if{html}{\out{<a id="method-Ggplot2HistogramLayerProcessor-generate_selectors"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2HistogramLayerProcessor-generate_selectors}{}}}
 \subsection{\code{Ggplot2HistogramLayerProcessor$generate_selectors()}}{
+  Selectors for the bins, scoped to the panel
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2HistogramLayerProcessor$generate_selectors(
@@ -162,6 +173,9 @@ horizontal would swap a pair that is already the right way round.
       \item{\code{panel_ctx}}{Panel context for panel-scoped selector generation (optional)}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of selectors
   }
 }
 

--- a/man/Ggplot2LineLayerProcessor.Rd
+++ b/man/Ggplot2LineLayerProcessor.Rd
@@ -524,6 +524,13 @@ from the same Date column align string-wise.
     \preformatted{Ggplot2LineLayerProcessor$format_x_value(x)}
     \if{html}{\out{</div>}}
   }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{x}}{The value to format}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
 \if{html}{\out{<hr>}}

--- a/man/Ggplot2LineLayerProcessor.Rd
+++ b/man/Ggplot2LineLayerProcessor.Rd
@@ -531,6 +531,9 @@ from the same Date column align string-wise.
     }
     \if{html}{\out{</div>}}
   }
+  \subsection{Returns}{
+    Character vector
+  }
 }
 
 \if{html}{\out{<hr>}}

--- a/man/Ggplot2PlotOrchestrator.Rd
+++ b/man/Ggplot2PlotOrchestrator.Rd
@@ -42,9 +42,17 @@ the results into a comprehensive interactive plot.
 \if{html}{\out{<a id="method-Ggplot2PlotOrchestrator-initialize"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2PlotOrchestrator-initialize}{}}}
 \subsection{\code{Ggplot2PlotOrchestrator$new()}}{
+  Create an orchestrator for a ggplot2 object
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2PlotOrchestrator$new(plot)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{plot}}{The ggplot2 object}
+    }
     \if{html}{\out{</div>}}
   }
 }
@@ -53,6 +61,7 @@ the results into a comprehensive interactive plot.
 \if{html}{\out{<a id="method-Ggplot2PlotOrchestrator-detect_layers"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2PlotOrchestrator-detect_layers}{}}}
 \subsection{\code{Ggplot2PlotOrchestrator$detect_layers()}}{
+  Turn each layer of the plot into a layer entry with its detected type
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2PlotOrchestrator$detect_layers()}
@@ -107,10 +116,22 @@ needs the build.
 \if{html}{\out{<a id="method-Ggplot2PlotOrchestrator-analyze_single_layer"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2PlotOrchestrator-analyze_single_layer}{}}}
 \subsection{\code{Ggplot2PlotOrchestrator$analyze_single_layer()}}{
+  Describe one ggplot2 layer as a layer entry with its detected type
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2PlotOrchestrator$analyze_single_layer(layer, layer_index)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer}}{A ggplot2 layer object}
+      \item{\code{layer_index}}{Index of the layer}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Layer information list
   }
 }
 
@@ -118,10 +139,22 @@ needs the build.
 \if{html}{\out{<a id="method-Ggplot2PlotOrchestrator-determine_layer_type"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2PlotOrchestrator-determine_layer_type}{}}}
 \subsection{\code{Ggplot2PlotOrchestrator$determine_layer_type()}}{
+  The layer type the adapter detects for one layer of the plot
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2PlotOrchestrator$determine_layer_type(plot, layer_index)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{plot}}{The ggplot2 object}
+      \item{\code{layer_index}}{Index of the layer}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Character string
   }
 }
 
@@ -129,6 +162,7 @@ needs the build.
 \if{html}{\out{<a id="method-Ggplot2PlotOrchestrator-create_layer_processors"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2PlotOrchestrator-create_layer_processors}{}}}
 \subsection{\code{Ggplot2PlotOrchestrator$create_layer_processors()}}{
+  Create a processor for every layer of a known type
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2PlotOrchestrator$create_layer_processors()}
@@ -140,10 +174,21 @@ needs the build.
 \if{html}{\out{<a id="method-Ggplot2PlotOrchestrator-create_layer_processor"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2PlotOrchestrator-create_layer_processor}{}}}
 \subsection{\code{Ggplot2PlotOrchestrator$create_layer_processor()}}{
+  Create the processor for one layer
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2PlotOrchestrator$create_layer_processor(layer_info)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_info}}{Layer information}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A layer processor, or NULL for an unknown type
   }
 }
 
@@ -173,6 +218,7 @@ needs the build.
 \if{html}{\out{<a id="method-Ggplot2PlotOrchestrator-process_layers"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2PlotOrchestrator-process_layers}{}}}
 \subsection{\code{Ggplot2PlotOrchestrator$process_layers()}}{
+  Run every layer processor and combine the results
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2PlotOrchestrator$process_layers()}
@@ -184,10 +230,22 @@ needs the build.
 \if{html}{\out{<a id="method-Ggplot2PlotOrchestrator-extract_layout"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2PlotOrchestrator-extract_layout}{}}}
 \subsection{\code{Ggplot2PlotOrchestrator$extract_layout()}}{
+  Read the figure-level title, subtitle, caption and axis labels from the built
+plot
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2PlotOrchestrator$extract_layout(built = NULL)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{built}}{Built plot data (optional)}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List
   }
 }
 
@@ -195,9 +253,17 @@ needs the build.
 \if{html}{\out{<a id="method-Ggplot2PlotOrchestrator-combine_layer_results"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2PlotOrchestrator-combine_layer_results}{}}}
 \subsection{\code{Ggplot2PlotOrchestrator$combine_layer_results()}}{
+  Combine the per-layer results into the subplot grid
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2PlotOrchestrator$combine_layer_results(layer_results)}
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{layer_results}}{List of per-layer results, one per processor}
+    }
     \if{html}{\out{</div>}}
   }
 }
@@ -206,10 +272,14 @@ needs the build.
 \if{html}{\out{<a id="method-Ggplot2PlotOrchestrator-generate_maidr_data"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2PlotOrchestrator-generate_maidr_data}{}}}
 \subsection{\code{Ggplot2PlotOrchestrator$generate_maidr_data()}}{
+  Assemble the MAIDR data object for the figure
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2PlotOrchestrator$generate_maidr_data()}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List with an id and the subplots
   }
 }
 
@@ -217,10 +287,14 @@ needs the build.
 \if{html}{\out{<a id="method-Ggplot2PlotOrchestrator-get_gtable"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2PlotOrchestrator-get_gtable}{}}}
 \subsection{\code{Ggplot2PlotOrchestrator$get_gtable()}}{
+  The gtable the plot was drawn to
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2PlotOrchestrator$get_gtable()}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    A gtable, or NULL before the layers are processed
   }
 }
 
@@ -228,10 +302,14 @@ needs the build.
 \if{html}{\out{<a id="method-Ggplot2PlotOrchestrator-get_layout"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2PlotOrchestrator-get_layout}{}}}
 \subsection{\code{Ggplot2PlotOrchestrator$get_layout()}}{
+  The figure-level layout read by \code{extract_layout()}
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2PlotOrchestrator$get_layout()}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List
   }
 }
 
@@ -239,10 +317,14 @@ needs the build.
 \if{html}{\out{<a id="method-Ggplot2PlotOrchestrator-get_combined_data"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2PlotOrchestrator-get_combined_data}{}}}
 \subsection{\code{Ggplot2PlotOrchestrator$get_combined_data()}}{
+  The combined per-layer data
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2PlotOrchestrator$get_combined_data()}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List
   }
 }
 
@@ -250,10 +332,14 @@ needs the build.
 \if{html}{\out{<a id="method-Ggplot2PlotOrchestrator-get_layer_processors"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2PlotOrchestrator-get_layer_processors}{}}}
 \subsection{\code{Ggplot2PlotOrchestrator$get_layer_processors()}}{
+  The processors created for the layers
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2PlotOrchestrator$get_layer_processors()}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List
   }
 }
 
@@ -261,10 +347,14 @@ needs the build.
 \if{html}{\out{<a id="method-Ggplot2PlotOrchestrator-get_layers"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2PlotOrchestrator-get_layers}{}}}
 \subsection{\code{Ggplot2PlotOrchestrator$get_layers()}}{
+  The detected layer entries
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2PlotOrchestrator$get_layers()}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List
   }
 }
 

--- a/man/Ggplot2SmoothLayerProcessor.Rd
+++ b/man/Ggplot2SmoothLayerProcessor.Rd
@@ -60,6 +60,7 @@ Processes smooth plot layers with complete logic included
 \if{html}{\out{<a id="method-Ggplot2SmoothLayerProcessor-process"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2SmoothLayerProcessor-process}{}}}
 \subsection{\code{Ggplot2SmoothLayerProcessor$process()}}{
+  Process the layer: read its curves, selectors and axes from the built plot
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2SmoothLayerProcessor$process(
@@ -81,9 +82,13 @@ Processes smooth plot layers with complete logic included
       \item{\code{built}}{Built plot data (optional)}
       \item{\code{gt}}{Gtable object (optional)}
       \item{\code{grob_id}}{Grob ID for faceted plots (optional)}
+      \item{\code{panel_id}}{Panel ID for faceted plots (optional)}
       \item{\code{panel_ctx}}{Panel context for panel-scoped selector generation (optional)}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List describing the layer for the MAIDR payload
   }
 }
 
@@ -346,6 +351,8 @@ can key on their presence instead of re-asking the stat per sample.
 \if{html}{\out{<a id="method-Ggplot2SmoothLayerProcessor-generate_selectors"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2SmoothLayerProcessor-generate_selectors}{}}}
 \subsection{\code{Ggplot2SmoothLayerProcessor$generate_selectors()}}{
+  The selector for the polyline this layer drew, or none when it cannot be found
+(see the note above)
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2SmoothLayerProcessor$generate_selectors(
@@ -363,8 +370,13 @@ can key on their presence instead of re-asking the stat per sample.
       \item{\code{plot}}{The ggplot2 object}
       \item{\code{gt}}{Gtable object (optional)}
       \item{\code{panel_ctx}}{Panel context for panel-scoped selector generation (optional)}
+      \item{\code{built}}{Built plot data (optional)}
+      \item{\code{panel_id}}{Panel ID for faceted plots (optional)}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of selectors
   }
 }
 

--- a/man/Ggplot2StackedBarProcessor.Rd
+++ b/man/Ggplot2StackedBarProcessor.Rd
@@ -49,6 +49,8 @@ Processes stacked bar plot layers with complete logic included
 \if{html}{\out{<a id="method-Ggplot2StackedBarProcessor-process"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2StackedBarProcessor-process}{}}}
 \subsection{\code{Ggplot2StackedBarProcessor$process()}}{
+  Process the layer: read its series, selectors and the fill legend title from
+the built plot
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2StackedBarProcessor$process(
@@ -70,9 +72,13 @@ Processes stacked bar plot layers with complete logic included
       \item{\code{built}}{Built plot data (optional)}
       \item{\code{gt}}{Gtable object (optional)}
       \item{\code{grob_id}}{Grob ID for faceted plots (optional)}
+      \item{\code{panel_id}}{Panel ID for faceted plots (optional)}
       \item{\code{panel_ctx}}{Panel context for panel-scoped selector generation (optional)}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List describing the layer for the MAIDR payload
   }
 }
 
@@ -80,10 +86,15 @@ Processes stacked bar plot layers with complete logic included
 \if{html}{\out{<a id="method-Ggplot2StackedBarProcessor-needs_reordering"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2StackedBarProcessor-needs_reordering}{}}}
 \subsection{\code{Ggplot2StackedBarProcessor$needs_reordering()}}{
+  Whether the plot data must be reordered before drawing, so the emitted order
+matches the drawn rects
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2StackedBarProcessor$needs_reordering()}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    TRUE
   }
 }
 
@@ -91,6 +102,8 @@ Processes stacked bar plot layers with complete logic included
 \if{html}{\out{<a id="method-Ggplot2StackedBarProcessor-reorder_layer_data"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2StackedBarProcessor-reorder_layer_data}{}}}
 \subsection{\code{Ggplot2StackedBarProcessor$reorder_layer_data()}}{
+  Reorder the plot data by category and fill so the emitted rows match the drawn
+rects
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2StackedBarProcessor$reorder_layer_data(data, plot)}
@@ -99,10 +112,13 @@ Processes stacked bar plot layers with complete logic included
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{data}}{data.frame effective for this layer}
-      \item{\code{plot}}{full ggplot object (for mappings)}
+      \item{\code{data}}{The data frame ggplot2 will draw from}
+      \item{\code{plot}}{The ggplot2 object}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    The reordered data frame
   }
 }
 
@@ -110,10 +126,21 @@ Processes stacked bar plot layers with complete logic included
 \if{html}{\out{<a id="method-Ggplot2StackedBarProcessor-extract_plot_columns"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2StackedBarProcessor-extract_plot_columns}{}}}
 \subsection{\code{Ggplot2StackedBarProcessor$extract_plot_columns()}}{
+  The column names the plot maps to x, y and fill
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2StackedBarProcessor$extract_plot_columns(plot)}
     \if{html}{\out{</div>}}
+  }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{plot}}{The ggplot2 object}
+    }
+    \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List with \code{category_col}, \code{value_col} and \code{fill_col}
   }
 }
 
@@ -121,6 +148,7 @@ Processes stacked bar plot layers with complete logic included
 \if{html}{\out{<a id="method-Ggplot2StackedBarProcessor-extract_data"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2StackedBarProcessor-extract_data}{}}}
 \subsection{\code{Ggplot2StackedBarProcessor$extract_data()}}{
+  One series per fill level, restricted to the panel's rows under faceting
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2StackedBarProcessor$extract_data(
@@ -136,8 +164,13 @@ Processes stacked bar plot layers with complete logic included
     \describe{
       \item{\code{plot}}{The ggplot2 object}
       \item{\code{built}}{Built plot data (optional)}
+      \item{\code{panel_id}}{Panel ID for faceted plots (optional)}
+      \item{\code{panel_ctx}}{Panel context for panel-scoped selector generation (optional)}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List of series
   }
 }
 
@@ -145,6 +178,8 @@ Processes stacked bar plot layers with complete logic included
 \if{html}{\out{<a id="method-Ggplot2StackedBarProcessor-generate_selectors"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2StackedBarProcessor-generate_selectors}{}}}
 \subsection{\code{Ggplot2StackedBarProcessor$generate_selectors()}}{
+  One flat selector matching every rect in the layer, which is the contract the
+frontend expects (see the note above)
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2StackedBarProcessor$generate_selectors(
@@ -162,6 +197,9 @@ Processes stacked bar plot layers with complete logic included
       \item{\code{panel_ctx}}{Panel context for panel-scoped selector generation (optional)}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List holding one selector
   }
 }
 

--- a/man/Ggplot2UnknownLayerProcessor.Rd
+++ b/man/Ggplot2UnknownLayerProcessor.Rd
@@ -48,6 +48,7 @@ Handles unsupported layer types gracefully by returning empty data
 \if{html}{\out{<a id="method-Ggplot2UnknownLayerProcessor-process"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2UnknownLayerProcessor-process}{}}}
 \subsection{\code{Ggplot2UnknownLayerProcessor$process()}}{
+  Describe a layer nothing is known about
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2UnknownLayerProcessor$process(
@@ -69,9 +70,13 @@ Handles unsupported layer types gracefully by returning empty data
       \item{\code{built}}{Built plot data (optional)}
       \item{\code{gt}}{Gtable object (optional)}
       \item{\code{grob_id}}{Grob ID for faceted plots (optional)}
+      \item{\code{panel_id}}{Panel ID for faceted plots (optional)}
       \item{\code{panel_ctx}}{Panel context for panel-scoped selector generation (optional)}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    List with no data and no selectors
   }
 }
 
@@ -79,6 +84,7 @@ Handles unsupported layer types gracefully by returning empty data
 \if{html}{\out{<a id="method-Ggplot2UnknownLayerProcessor-extract_data"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2UnknownLayerProcessor-extract_data}{}}}
 \subsection{\code{Ggplot2UnknownLayerProcessor$extract_data()}}{
+  Nothing: an unknown layer has no data to announce
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2UnknownLayerProcessor$extract_data(plot, built = NULL)}
@@ -92,12 +98,16 @@ Handles unsupported layer types gracefully by returning empty data
     }
     \if{html}{\out{</div>}}
   }
+  \subsection{Returns}{
+    Empty list
+  }
 }
 
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Ggplot2UnknownLayerProcessor-generate_selectors"></a>}}
 \if{latex}{\out{\hypertarget{method-Ggplot2UnknownLayerProcessor-generate_selectors}{}}}
 \subsection{\code{Ggplot2UnknownLayerProcessor$generate_selectors()}}{
+  Nothing: an unknown layer has no elements to address
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Ggplot2UnknownLayerProcessor$generate_selectors(
@@ -117,6 +127,9 @@ Handles unsupported layer types gracefully by returning empty data
       \item{\code{panel_ctx}}{Panel context for panel-scoped selector generation (optional)}
     }
     \if{html}{\out{</div>}}
+  }
+  \subsection{Returns}{
+    Empty list
   }
 }
 

--- a/man/Ggplot2ViolinLayerProcessor.Rd
+++ b/man/Ggplot2ViolinLayerProcessor.Rd
@@ -323,6 +323,13 @@ iq, q2, max, lowerOutliers, upperOutliers.
     \preformatted{Ggplot2ViolinLayerProcessor$determine_orientation(built)}
     \if{html}{\out{</div>}}
   }
+  \subsection{Arguments}{
+    \if{html}{\out{<div class="arguments">}}
+    \describe{
+      \item{\code{built}}{Built plot data (optional)}
+    }
+    \if{html}{\out{</div>}}
+  }
 }
 
 \if{html}{\out{<hr>}}

--- a/tests/testthat/test-roxygen-orphans.R
+++ b/tests/testthat/test-roxygen-orphans.R
@@ -15,24 +15,18 @@
 #    `@name` documents whatever object comes next (#116).
 #
 # `tools::checkRd()` and `R CMD check` cannot see any of it -- the Rd is
-# valid, it just describes the wrong thing -- and `docs-drift` only asks
-# whether `man/` matches the sources, not whether the sources say what
-# their author meant. The checks here are on the SOURCE, because `man/` is
-# regenerated; the one on `man/` catches the scattered keywords whatever
-# their cause.
+# valid, it just describes the wrong thing. roxygen2 itself warns on some
+# of it ("@keywords must be only 1 line long" when the merged block ends in
+# a keyword, "Skipping; no name and/or title" for the class), and
+# `tools/document.R` and the `docs-drift` CI job fail on any such warning.
+# The rest is silent: a block merged into one ending in `@return` or
+# `@param`, and the method prose glued onto the previous section. The
+# checks here are on the SOURCE, because `man/` is regenerated.
 
 r_sources <- function() {
   list.files(
     testthat::test_path("..", "..", "R"),
     pattern = "\\.R$",
-    full.names = TRUE
-  )
-}
-
-rd_sources <- function() {
-  list.files(
-    testthat::test_path("..", "..", "man"),
-    pattern = "\\.Rd$",
     full.names = TRUE
   )
 }
@@ -126,17 +120,6 @@ untitled_method_blocks <- function(path) {
   starts[nzchar(first_words) & !grepl("^@", first_words)]
 }
 
-# The keywords roxygen is expected to write. Anything else is a title that
-# was scattered, one word per entry, and `R CMD check` NOTEs each of them.
-known_keywords <- c("internal", "datasets", "hplot", "utilities", "misc")
-
-stray_keywords <- function(path) {
-  lines <- readLines(path, warn = FALSE)
-  found <- regmatches(lines, regexpr("^\\\\keyword\\{([^}]*)\\}", lines))
-  words <- sub("^\\\\keyword\\{([^}]*)\\}$", "\\1", found)
-  setdiff(words, known_keywords)
-}
-
 report <- function(paths, finder) {
   reported <- character(0)
   for (path in paths) {
@@ -172,12 +155,6 @@ test_that("every R6 method block opens with a tag", {
   testthat::expect_equal(
     report(r_sources(), untitled_method_blocks), character(0)
   )
-})
-
-test_that("no generated page carries a keyword that is a scattered title", {
-  testthat::skip_if(length(rd_sources()) == 0L, "man/ is not shipped")
-
-  testthat::expect_equal(report(rd_sources(), stray_keywords), character(0))
 })
 
 # The detectors, each against a temporary file rather than a real source, so
@@ -277,20 +254,4 @@ test_that("a method block opening with prose is reported", {
   on.exit(unlink(path), add = TRUE)
 
   testthat::expect_identical(untitled_method_blocks(path), 1L)
-})
-
-test_that("a scattered title shows up as stray keywords", {
-  path <- tempfile(fileext = ".Rd")
-  writeLines(
-    c(
-      "\\name{second}",
-      "\\keyword{Second}",
-      "\\keyword{helper}",
-      "\\keyword{internal}"
-    ),
-    path
-  )
-  on.exit(unlink(path), add = TRUE)
-
-  testthat::expect_identical(stray_keywords(path), c("Second", "helper"))
 })

--- a/tools/document.R
+++ b/tools/document.R
@@ -50,7 +50,10 @@ if (installed != pinned) {
 }
 
 # roxygen2 reports through cli, whose alerts are `message` conditions; with
-# unicode off the ones that matter start with "x ".
+# unicode off the ones that matter start with "x ". That prefix is cli's
+# rendering, not an API: if a cli release changes its alert glyph, this
+# pattern is the line to update, and the throwaway-package check in #297
+# (a block merged into the next one must exit 1) is how to tell.
 options(cli.unicode = FALSE, cli.num_colors = 1)
 faults <- character(0)
 withCallingHandlers(

--- a/tools/document.R
+++ b/tools/document.R
@@ -1,6 +1,6 @@
 #!/usr/bin/env Rscript
 # Regenerate man/ and NAMESPACE with the roxygen2 release that generated
-# what is committed.
+# what is committed, and fail on any roxygen2 warning.
 #
 # roxygen2 changes its output between minors, and `man/` is checked against
 # the sources in CI with the version recorded in DESCRIPTION
@@ -8,6 +8,16 @@
 # with another version rewrites pages that nothing in the branch touched --
 # 47 of them the last time it happened (#143) -- so this refuses to run
 # with any other version and says which one to install.
+#
+# roxygen2's warnings are how it reports a block it could not attach the
+# way the author meant: a block merged into the next one ("@keywords must
+# be only 1 line long"), a class left without a page ("Skipping; no name
+# and/or title"), a method with no block or a missing @param. The pages
+# it writes in those cases are valid Rd describing the wrong thing, which
+# nothing downstream can see, so the warnings are the check -- and there
+# were 391 of them before #296, which is why none stood out. The count is
+# now zero and this keeps it there: the `docs-drift` CI job runs this
+# script, and one warning fails it.
 #
 #     Rscript tools/document.R
 
@@ -39,4 +49,27 @@ if (installed != pinned) {
   )
 }
 
-roxygen2::roxygenise()
+# roxygen2 reports through cli, whose alerts are `message` conditions; with
+# unicode off the ones that matter start with "x ".
+options(cli.unicode = FALSE, cli.num_colors = 1)
+faults <- character(0)
+withCallingHandlers(
+  roxygen2::roxygenise(),
+  message = function(m) {
+    text <- conditionMessage(m)
+    if (grepl("^x ", text)) {
+      faults <<- c(faults, trimws(text))
+    }
+  }
+)
+
+if (length(faults) > 0) {
+  cat(
+    "\n", length(faults), " roxygen2 warning(s) above. Each one is a page that",
+    " describes something other than what its author meant, or a method",
+    " left out of its class's page. Fix the comment it names; see",
+    " tests/testthat/test-roxygen-orphans.R for the layouts that cause them.\n",
+    sep = ""
+  )
+  quit(status = 1)
+}


### PR DESCRIPTION
## What this is

The follow-up #296 left open. That PR fixed the pages roxygen had attached to the wrong object and added source-level detectors for the layouts that cause it. Reviewing it afterwards showed that roxygen2 itself already warns on two of the three layouts (a merged block ending in `@keywords`: "@keywords must be only 1 line long"; a class left without a page: "Skipping; no name and/or title") and on the deleted-page case that bit #294 and #295. Those warnings were useless as a check only because every regeneration printed 391 of them, 369 of which were undocumented methods. This PR takes the count to zero and makes any new warning fail.

## Changes

**Documentation** (`R/` comments only; `man/` regenerated, `NAMESPACE` unchanged)

- 150 public R6 methods across 25 classes had no roxygen block; each now has a `@description`, a `@param` per argument and a `@return`. The interface methods (`process`, `extract_data`, `generate_selectors`, `extract_axis_titles`, `extract_main_title`, `needs_reordering`, the orchestrator getters) are described per class in one line; the others from their bodies.
- 26 documented methods were missing a `@param` for one of their arguments.
- 21 plain-comment blocks that were already roxygen-shaped (`# @param` / `# @return`) are roxygen now. The three long engineering notes above `generate_selectors()` on the dodged, stacked and smooth processors stay as plain comments, with a short roxygen block after them.
- The regenerated pages: 28 changed, +1468 lines, all the new method sections. `roxygenise()` now prints no warning.

**Gate**

- `tools/document.R` captures roxygen2's alerts (cli `message` conditions starting with `x `) and exits 1 when there are any, after the version check it already did. Verified on a throwaway package with a merged block (exit 1, the warning printed) and on this tree (exit 0).
- The `docs-drift` job runs that script instead of calling `roxygenise()` directly, so a PR that introduces a warning fails there, before the drift diff.
- `test-roxygen-orphans.R` drops the `stray_keywords` detector: the merge that scatters a title is one of the warnings now. The two silent layouts (a block merged into one ending in `@return`/`@param`; method prose glued onto the previous section) keep their detectors.

## Verification

- Full `testthat` suite locally (R 4.3.3): 8460 pass, 0 fail, 0 error, 4 skip; `test-roxygen-orphans.R` 12 pass.
- `Rscript tools/document.R`: exit 0, 0 warnings (391 on `main` before #296, 369 after).
- `tools::checkRd()` on every page: the same three notes as on `main` (non-ASCII example bytes in `escape_for_attribute.Rd`, two pre-existing), nothing new.
- `lintr` on the changed files: no new lint; every generated line is wrapped under the 100-character limit.
- No behaviour change: the diff under `R/` is roxygen comments only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018txuh4mV45nGJY69qBAt9q

---
_Generated by [Claude Code](https://claude.ai/code/session_018txuh4mV45nGJY69qBAt9q)_