### PR TITLE
docs: add the CRAN status and downloads badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # maidr <img src="man/figures/logo.svg" align="right" height="139" alt="maidr logo" />
 
 <!-- badges: start -->
+[![CRAN status](https://www.r-pkg.org/badges/version/maidr)](https://CRAN.R-project.org/package=maidr)
+[![CRAN downloads](https://cranlogs.r-pkg.org/badges/grand-total/maidr)](https://CRAN.R-project.org/package=maidr)
 [![R-CMD-check](https://github.com/xability/r-maidr/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/xability/r-maidr/actions/workflows/R-CMD-check.yaml)
 [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 <!-- badges: end -->


### PR DESCRIPTION
## Description

`maidr` is on CRAN, and the README never said so. The badge block had R-CMD-check and a lifecycle stage — both describing development state — and nothing telling a reader the package is installable with `install.packages()` today. That fact lives in the Installation section two screens down, after the reader has already decided whether to keep reading.

```diff
  <!-- badges: start -->
+ [![CRAN status](https://www.r-pkg.org/badges/version/maidr)](https://CRAN.R-project.org/package=maidr)
+ [![CRAN downloads](https://cranlogs.r-pkg.org/badges/grand-total/maidr)](https://CRAN.R-project.org/package=maidr)
  [![R-CMD-check](...)](...)
  [![Lifecycle: experimental](...)](...)
  <!-- badges: end -->
```

Both render real values as of opening this PR — parsed out of the returned SVGs rather than eyeballed:

| badge | renders |
|---|---|
| `r-pkg.org/badges/version/maidr` | `CRAN \| 0.4.0` |
| `cranlogs.r-pkg.org/badges/grand-total/maidr` | `downloads \| 2866` |

Grand-total rather than `/badges/maidr` (which gives `283/month`): a lifetime count does not visually regress on a quiet month, and it matches the downloads badge on the py-maidr README.

## Deliberately not added

A codecov badge, even though `test-coverage.yaml` uploads there. `https://codecov.io/gh/xability/r-maidr/graph/badge.svg` currently renders **`codecov | unknown`**. A badge reading "unknown" looks like neglect rather than like a missing integration, so it is worth adding once coverage actually reports — not before.

## Type of Change

- [x] Documentation update

## Checklist

- [x] Self-reviewed
- [x] No new warnings
- [x] Badge URLs verified to return real values, not placeholders or errors

No `README.Rmd` in this repo, so `README.md` is the source and there is nothing to re-knit. `docs-drift` only regenerates `man/` and `NAMESPACE` from roxygen, which this does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
